### PR TITLE
chore: add more ts type definitions

### DIFF
--- a/packages/apify/src/autoscaling/autoscaled_pool.ts
+++ b/packages/apify/src/autoscaling/autoscaled_pool.ts
@@ -424,8 +424,6 @@ export class AutoscaledPool {
      * and this.isTaskReadyFunction() returns true.
      *
      * It doesn't allow multiple concurrent runs of this method.
-     *
-     * @internal
      */
     protected async _maybeRunTask(intervalCallback): Promise<void> {
         this.log.perf('Attempting to run a task.');
@@ -521,8 +519,6 @@ export class AutoscaledPool {
      * Gets called every autoScaleIntervalSecs and evaluates the current system status.
      * If the system IS NOT overloaded and the settings allow it, it scales up.
      * If the system IS overloaded and the settings allow it, it scales down.
-     *
-     * @internal
      */
     protected _autoscale(intervalCallback) {
         // Don't scale if paused.
@@ -570,9 +566,8 @@ export class AutoscaledPool {
      * the desired concurrency by the scaleUpStepRatio.
      *
      * @param systemStatus for logging
-     * @internal
      */
-    protected _scaleUp(systemStatus: SystemInfo) {
+    protected _scaleUp(systemStatus: SystemInfo): void {
         const step = Math.ceil(this._desiredConcurrency * this.scaleUpStepRatio);
         this._desiredConcurrency = Math.min(this._maxConcurrency, this._desiredConcurrency + step);
         this.log.debug('scaling up', {
@@ -587,9 +582,8 @@ export class AutoscaledPool {
      * the desired concurrency by the scaleDownStepRatio.
      *
      * @param systemStatus for logging
-     * @internal
      */
-    protected _scaleDown(systemStatus: SystemInfo) {
+    protected _scaleDown(systemStatus: SystemInfo): void {
         const step = Math.ceil(this._desiredConcurrency * this.scaleUpStepRatio);
         this._desiredConcurrency = Math.max(this._minConcurrency, this._desiredConcurrency - step);
         this.log.debug('scaling down', {
@@ -604,7 +598,6 @@ export class AutoscaledPool {
      * the pool and resolves the pool's promise returned by the run() method.
      *
      * It doesn't allow multiple concurrent runs of this method.
-     * @internal
      */
     protected async _maybeFinish(): Promise<void> {
         if (this.queryingIsFinished) return;
@@ -627,7 +620,6 @@ export class AutoscaledPool {
 
     /**
      * Cleans up resources.
-     * @internal
      */
     protected async _destroy(): Promise<void> {
         this.resolve = null;

--- a/packages/apify/src/autoscaling/snapshotter.ts
+++ b/packages/apify/src/autoscaling/snapshotter.ts
@@ -276,7 +276,6 @@ export class Snapshotter {
     /**
      * Creates a snapshot of current memory usage
      * using the Apify platform `systemInfo` event.
-     * @internal
      */
     protected _snapshotMemoryOnPlatform(systemInfo: SystemInfo) {
         const now = new Date();
@@ -294,7 +293,6 @@ export class Snapshotter {
 
     /**
      * Creates a snapshot of current memory usage using the Apify platform `systemInfo` event.
-     * @internal
      */
     protected async _snapshotMemoryOnLocal(intervalCallback: () => unknown): Promise<void> {
         try {
@@ -320,7 +318,6 @@ export class Snapshotter {
 
     /**
      * Checks for critical memory overload and logs it to the console.
-     * @internal
      */
     protected _memoryOverloadWarning({ memCurrentBytes }: SystemInfo) {
         const now = new Date();
@@ -342,7 +339,6 @@ export class Snapshotter {
 
     /**
      * Creates a snapshot of current event loop delay.
-     * @internal
      */
     protected _snapshotEventLoop(intervalCallback: () => unknown) {
         const now = new Date();
@@ -368,9 +364,7 @@ export class Snapshotter {
     }
 
     /**
-     * Creates a snapshot of current CPU usage
-     * using the Apify platform `systemInfo` event.
-     * @internal
+     * Creates a snapshot of current CPU usage using the Apify platform `systemInfo` event.
      */
     protected _snapshotCpuOnPlatform(systemInfo: SystemInfo) {
         const { cpuCurrentUsage, isCpuOverloaded } = systemInfo;
@@ -386,7 +380,6 @@ export class Snapshotter {
 
     /**
      * Creates a snapshot of current CPU usage using OS provided metrics.
-     * @internal
      */
     protected _snapshotCpuOnLocal(intervalCallback: () => unknown): void {
         const now = new Date();
@@ -416,9 +409,6 @@ export class Snapshotter {
         intervalCallback();
     }
 
-    /**
-     * @internal
-     */
     protected _getCurrentCpuTicks() {
         const cpus = os.cpus();
         return cpus.reduce((acc, cpu) => {
@@ -437,7 +427,6 @@ export class Snapshotter {
      * earlier errors may just be caused by a random spike in
      * number of requests and do not necessarily signify API
      * overloading.
-     * @internal
      */
     protected _snapshotClient(intervalCallback: () => unknown) {
         const now = new Date();
@@ -466,7 +455,6 @@ export class Snapshotter {
     /**
      * Removes snapshots that are older than the snapshotHistorySecs option
      * from the array (destructively - in place).
-     * @internal
      */
     protected _pruneSnapshots(snapshots: MemorySnapshot[] | CpuSnapshot[] | EventLoopSnapshot[] | ClientSnapshot[], now: Date) {
         let oldCount = 0;
@@ -480,7 +468,6 @@ export class Snapshotter {
 
     /**
      * Calculate max memory for platform or local usage.
-     * @internal
      */
     protected async _ensureCorrectMaxMemory() {
         if (this.maxMemoryBytes) return;

--- a/packages/apify/src/browser_launchers/browser_launcher.ts
+++ b/packages/apify/src/browser_launchers/browser_launcher.ts
@@ -127,7 +127,7 @@ export abstract class BrowserLauncher<
 
     /**
      * Launches a browser instance based on the plugin.
-     * @returns {Promise<unknown>} Browser instance.
+     * @returns Browser instance.
      */
     async launch(): Promise<unknown> {
         const plugin = this.createBrowserPlugin();

--- a/packages/apify/src/browser_launchers/playwright_launcher.ts
+++ b/packages/apify/src/browser_launchers/playwright_launcher.ts
@@ -142,7 +142,7 @@ function getDefaultExecutablePath(launchContext: PlaywrightLaunchContext): strin
  *   Optional settings passed to `browserType.launch()`. In addition to
  *   [Playwright's options](https://playwright.dev/docs/api/class-browsertype?_highlight=launch#browsertypelaunchoptions)
  *   the object may contain our own  {@link PlaywrightLaunchContext} that enable additional features.
- * @returns {Promise<unknown>}
+ * @returns
  *   Promise that resolves to Playwright's `Browser` instance.
  */
 export async function launchPlaywright(launchContext?: PlaywrightLaunchContext): Promise<unknown> {

--- a/packages/apify/src/browser_launchers/puppeteer_launcher.ts
+++ b/packages/apify/src/browser_launchers/puppeteer_launcher.ts
@@ -208,7 +208,7 @@ export class PuppeteerLauncher extends BrowserLauncher<PuppeteerPlugin> {
  * @param [launchContext]
  *   All `PuppeteerLauncher` parameters are passed via an launchContext object.
  *   If you want to pass custom `puppeteer.launch(options)` options you can use the `PuppeteerLaunchContext.launchOptions` property.
- * @returns {Promise<Browser>}
+ * @returns
  *   Promise that resolves to Puppeteer's `Browser` instance.
  */
 export async function launchPuppeteer(launchContext?: PuppeteerLaunchContext): Promise<Browser> {

--- a/packages/apify/src/enqueue_links/click_elements.ts
+++ b/packages/apify/src/enqueue_links/click_elements.ts
@@ -134,7 +134,7 @@ export interface EnqueueLinksByClickingElementsOptions {
  * });
  * ```
  *
- * @return {Promise<Array<QueueOperationInfo>>}
+ * @returns
  *   Promise that resolves to an array of {@link QueueOperationInfo} objects.
  */
 export async function enqueueLinksByClickingElements(options: EnqueueLinksByClickingElementsOptions): Promise<QueueOperationInfo[]> {

--- a/packages/apify/src/enqueue_links/enqueue_links.ts
+++ b/packages/apify/src/enqueue_links/enqueue_links.ts
@@ -108,7 +108,7 @@ export interface EnqueueLinksOptions {
  *
  * @param {object} options
  *   All `enqueueLinks()` parameters are passed via an options object.
- * @return {Promise<QueueOperationInfo[]>}
+ * @returns
  *   Promise that resolves to an array of {@link QueueOperationInfo} objects.
  */
 export async function enqueueLinks(options: EnqueueLinksOptions): Promise<QueueOperationInfo[]> {

--- a/packages/apify/src/enqueue_links/shared.ts
+++ b/packages/apify/src/enqueue_links/shared.ts
@@ -109,7 +109,7 @@ export async function addRequestsToQueueInBatches(requests: Request[], requestQu
 export interface RequestTransform {
     /**
      * @param original Request options to be modified.
-     * @return {RequestOptions} The modified request options to enqueue.
+     * @returns The modified request options to enqueue.
      */
     (original: RequestOptions): RequestOptions;
 }

--- a/packages/apify/src/session_pool/session.ts
+++ b/packages/apify/src/session_pool/session.ts
@@ -271,11 +271,11 @@ export class Session {
      * that the target website is blocking us. This function helps to do this conveniently
      * by retiring the session when such code is received. Optionally the default status
      * codes can be extended in the second parameter.
-     * @param statusCode {number} - HTTP status code
-     * @param [blockedStatusCodes] {number[]} - Custom HTTP status codes that means blocking on particular website.
+     * @param statusCode HTTP status code.
+     * @param [blockedStatusCodes] Custom HTTP status codes that means blocking on particular website.
      * @return {boolean} whether the session was retired.
      */
-    retireOnBlockedStatusCodes(statusCode, blockedStatusCodes = []) {
+    retireOnBlockedStatusCodes(statusCode: number, blockedStatusCodes: number[] = []): boolean {
         const isBlocked = STATUS_CODES_BLOCKED.concat(blockedStatusCodes).includes(statusCode);
         if (isBlocked) {
             this.retire();
@@ -340,7 +340,7 @@ export class Session {
 
     /**
      * Transforms puppeteer cookie to tough-cookie.
-     * @param puppeteerCookie Cookie from puppeteer `page.cookies method.
+     * @param puppeteerCookie Cookie from puppeteer `page.cookies` method.
      * @internal
      */
     protected _puppeteerCookieToTough(puppeteerCookie: PuppeteerCookie): Cookie {

--- a/packages/apify/src/session_pool/session.ts
+++ b/packages/apify/src/session_pool/session.ts
@@ -170,11 +170,10 @@ export class Session {
     }
 
     /**
-     * indicates whether the session is blocked.
+     * Indicates whether the session is blocked.
      * Session is blocked once it reaches the `maxErrorScore`.
-     * @return {boolean}
      */
-    isBlocked() {
+    isBlocked(): boolean {
         return this.errorScore >= this.maxErrorScore;
     }
 
@@ -182,27 +181,24 @@ export class Session {
      * Indicates whether the session is expired.
      * Session expiration is determined by the `maxAgeSecs`.
      * Once the session is older than `createdAt + maxAgeSecs` the session is considered expired.
-     * @return {boolean}
      */
-    isExpired() {
+    isExpired(): boolean {
         return this.expiresAt <= new Date();
     }
 
     /**
      * Indicates whether the session is used maximum number of times.
      * Session maximum usage count can be changed by `maxUsageCount` parameter.
-     * @return {boolean}
      */
-    isMaxUsageCountReached() {
+    isMaxUsageCountReached(): boolean {
         return this.usageCount >= this.maxUsageCount;
     }
 
     /**
      * Indicates whether the session can be used for next requests.
      * Session is usable when it is not expired, not blocked and the maximum usage count has not be reached.
-     * @return {boolean}
      */
-    isUsable() {
+    isUsable(): boolean {
         return !this.isBlocked() && !this.isExpired() && !this.isMaxUsageCountReached();
     }
 
@@ -222,11 +218,13 @@ export class Session {
 
     /**
      * Gets session state for persistence in KeyValueStore.
-     * @return {SessionState} represents session internal state.
+     * @returns Represents session internal state.
      */
-    getState() {
+    getState(): SessionState {
         return {
             id: this.id,
+            // @ts-expect-error Type 'Serialized' is missing the following properties from type 'CookieJar':
+            // setCookie, setCookieSync, getCookies, getCookiesSync, and 11 more.
             cookieJar: this.cookieJar.toJSON(),
             userData: this.userData,
             maxErrorScore: this.maxErrorScore,
@@ -273,7 +271,7 @@ export class Session {
      * codes can be extended in the second parameter.
      * @param statusCode HTTP status code.
      * @param [blockedStatusCodes] Custom HTTP status codes that means blocking on particular website.
-     * @return {boolean} whether the session was retired.
+     * @returns Whether the session was retired.
      */
     retireOnBlockedStatusCodes(statusCode: number, blockedStatusCodes: number[] = []): boolean {
         const isBlocked = STATUS_CODES_BLOCKED.concat(blockedStatusCodes).includes(statusCode);
@@ -332,7 +330,7 @@ export class Session {
      * Returns cookies saved with the session in the typical
      * key1=value1; key2=value2 format, ready to be used in
      * a cookie header or elsewhere.
-     * @return {string} represents `Cookie` header.
+     * @returns Represents `Cookie` header.
      */
     getCookieString(url: string): string {
         return this.cookieJar.getCookieStringSync(url, {});
@@ -341,7 +339,6 @@ export class Session {
     /**
      * Transforms puppeteer cookie to tough-cookie.
      * @param puppeteerCookie Cookie from puppeteer `page.cookies` method.
-     * @internal
      */
     protected _puppeteerCookieToTough(puppeteerCookie: PuppeteerCookie): Cookie {
         const isExpiresValid = puppeteerCookie.expires && typeof puppeteerCookie.expires === 'number' && puppeteerCookie.expires > 0;
@@ -364,8 +361,7 @@ export class Session {
     /**
      * Transforms tough-cookie to puppeteer cookie.
      * @param toughCookie Cookie from CookieJar
-     * @return {PuppeteerCookie} Cookie from Puppeteer
-     * @internal
+     * @return Cookie from Puppeteer
      */
     protected _toughCookieToPuppeteer(toughCookie: Cookie): PuppeteerCookie {
         return {
@@ -382,7 +378,6 @@ export class Session {
 
     /**
      * Sets cookies.
-     * @internal
      */
     protected _setCookies(cookies: Cookie[], url: string): void {
         const errorMessages: string[] = [];
@@ -404,8 +399,7 @@ export class Session {
     /**
      * Calculate cookie expiration date
      * @param maxAgeSecs
-     * @return {Date} calculated date by session max age seconds.
-     * @internal
+     * @returns Calculated date by session max age seconds.
      */
     protected _getDefaultCookieExpirationDate(maxAgeSecs: number): Date {
         return new Date(Date.now() + (maxAgeSecs * 1000));
@@ -413,7 +407,6 @@ export class Session {
 
     /**
      * Checks if session is not usable. if it is not retires the session.
-     * @internal
      */
     protected _maybeSelfRetire(): void {
         if (!this.isUsable()) {

--- a/packages/apify/src/session_pool/session_pool.ts
+++ b/packages/apify/src/session_pool/session_pool.ts
@@ -221,9 +221,9 @@ export class SessionPool extends EventEmitter {
      * Adds a new session to the session pool. The pool automatically creates sessions up to the maximum size of the pool,
      * but this allows you to add more sessions once the max pool size is reached.
      * This also allows you to add session with overridden session options (e.g. with specific session id).
-     * @param [options] - The configuration options for the session being added to the session pool.
+     * @param [options] The configuration options for the session being added to the session pool.
      */
-    async addSession(options: Session | SessionOptions = {}) {
+    async addSession(options: Session | SessionOptions = {}): Promise<void> {
         this._throwIfNotInitialized();
         const { id } = options;
         if (id) {
@@ -364,7 +364,7 @@ export class SessionPool extends EventEmitter {
      * Creates new session without any extra behavior.
      * @param sessionPool
      * @param [options]
-     * @param [options.sessionOptions] The configuration options for the session being created
+     * @param [options.sessionOptions] The configuration options for the session being created.
      * @return {Session} New session.
      * @internal
      */

--- a/packages/apify/src/session_pool/session_pool.ts
+++ b/packages/apify/src/session_pool/session_pool.ts
@@ -183,17 +183,15 @@ export class SessionPool extends EventEmitter {
 
     /**
      * Gets count of usable sessions in the pool.
-     * @return {number}
      */
-    get usableSessionsCount() {
+    get usableSessionsCount(): number {
         return this.sessions.filter((session) => session.isUsable()).length;
     }
 
     /**
      * Gets count of retired sessions in the pool.
-     * @return {number}
      */
-    get retiredSessionsCount() {
+    get retiredSessionsCount(): number {
         return this.sessions.filter((session) => !session.isUsable()).length;
     }
 
@@ -321,7 +319,6 @@ export class SessionPool extends EventEmitter {
 
     /**
      * SessionPool should not work before initialization.
-     * @internal
      */
     protected _throwIfNotInitialized() {
         if (!this._listener) throw new Error('SessionPool is not initialized.');
@@ -329,7 +326,6 @@ export class SessionPool extends EventEmitter {
 
     /**
      * Removes retired `Session` instances from `SessionPool`.
-     * @internal
      */
     protected _removeRetiredSessions() {
         this.sessions = this.sessions.filter((storedSession) => {
@@ -345,7 +341,6 @@ export class SessionPool extends EventEmitter {
     /**
      * Adds `Session` instance to `SessionPool`.
      * @param newSession `Session` instance to be added.
-     * @internal
      */
     protected _addSession(newSession: Session) {
         this.sessions.push(newSession);
@@ -354,7 +349,6 @@ export class SessionPool extends EventEmitter {
 
     /**
      * Gets random index.
-     * @internal
      */
     protected _getRandomIndex(): number {
         return Math.floor(Math.random() * this.sessions.length);
@@ -365,8 +359,7 @@ export class SessionPool extends EventEmitter {
      * @param sessionPool
      * @param [options]
      * @param [options.sessionOptions] The configuration options for the session being created.
-     * @return {Session} New session.
-     * @internal
+     * @returns New session.
      */
     protected _defaultCreateSessionFunction(sessionPool: SessionPool, options: { sessionOptions?: SessionOptions } = {}): Session {
         ow(options, ow.object.exactShape({ sessionOptions: ow.optional.object }));
@@ -380,8 +373,7 @@ export class SessionPool extends EventEmitter {
 
     /**
      * Creates new session and adds it to the pool.
-     * @return {Promise<Session>} Newly created `Session` instance.
-     * @internal
+     * @returns Newly created `Session` instance.
      */
     protected async _createSession(): Promise<Session> {
         const newSession = await this.createSessionFunction(this);
@@ -393,7 +385,6 @@ export class SessionPool extends EventEmitter {
 
     /**
      * Decides whether there is enough space for creating new session.
-     * @internal
      */
     protected _hasSpaceForSession(): boolean {
         return this.sessions.length < this.maxPoolSize;
@@ -401,8 +392,7 @@ export class SessionPool extends EventEmitter {
 
     /**
      * Picks random session from the `SessionPool`.
-     * @return {Session} Picked `Session`
-     * @internal
+     * @returns Picked `Session`.
      */
     protected _pickSession(): Session {
         return this.sessions[this._getRandomIndex()]; // Or maybe we should let the developer to customize the picking algorithm
@@ -411,7 +401,6 @@ export class SessionPool extends EventEmitter {
     /**
      * Potentially loads `SessionPool`.
      * If the state was persisted it loads the `SessionPool` from the persisted state.
-     * @internal
      */
     protected async _maybeLoadSessionPool(): Promise<void> {
         const loadedSessionPool = await this.keyValueStore.getValue(this.persistStateKey);

--- a/packages/apify/src/stealth/stealth.ts
+++ b/packages/apify/src/stealth/stealth.ts
@@ -53,7 +53,7 @@ const alreadyWrapped = Symbol('alreadyWrapped');
  *  The main purpose of this function is to override newPage function and attach selected tricks.
  * @param browser puppeteer browser instance
  * @param options
- * @returns {Browser} Instance of Browser from puppeteer package
+ * @returns Instance of Browser from puppeteer package
  */
 export function applyStealthToBrowser(browser: Browser, options: StealthOptions): Browser {
     const modifiedBrowser = browser;

--- a/packages/apify/src/stealth/stealth.ts
+++ b/packages/apify/src/stealth/stealth.ts
@@ -90,10 +90,10 @@ function generateEvaluationDebugMessage() {
 }
 /**
  * Logs the stealth errors in browser to the node stdout.
- * @param {Page} page - puppeteer page instance
- * @param {string} evaluationDebugMessage - debug message
+ * @param page puppeteer page instance
+ * @param evaluationDebugMessage debug message
  */
-function addStealthDebugToPage(page, evaluationDebugMessage) {
+function addStealthDebugToPage(page: Page, evaluationDebugMessage: string): void {
     let warningLogged = false;
     let counter = 1;
     page.on('console', (msg) => {

--- a/packages/apify/src/storages/dataset.ts
+++ b/packages/apify/src/storages/dataset.ts
@@ -137,7 +137,7 @@ export interface DatasetDataOptions {
     skipEmpty?: boolean;
 }
 
-interface DatasetIteratorOptions extends DatasetDataOptions {
+export interface DatasetIteratorOptions extends Omit<DatasetDataOptions, 'offset' | 'limit' | 'clean' | 'skipHidden' | 'skipEmpty'> {
     /** @internal */
     offset?: number;
 

--- a/packages/apify/src/storages/key_value_store.ts
+++ b/packages/apify/src/storages/key_value_store.ts
@@ -364,7 +364,7 @@ export async function openKeyValueStore(storeIdOrName?: string | null, options: 
  *
  * @param key
  *   Unique record key.
- * @returns {Promise<Object<string, *>|string|Buffer|null>}
+ * @returns
  *   Returns a promise that resolves to an object, string
  *   or [`Buffer`](https://nodejs.org/api/buffer.html), depending
  *   on the MIME content type of the record, or `null`
@@ -434,7 +434,7 @@ export async function setValue<T>(key: string, value: T, options: RecordOptions 
  * For more information, see  {@link Apify.openKeyValueStore}
  * and {@link KeyValueStore.getValue}.
  *
- * @returns {T}
+ * @returns
  *   Returns a promise that resolves to an object, string
  *   or [`Buffer`](https://nodejs.org/api/buffer.html), depending
  *   on the MIME content type of the record, or `null`

--- a/packages/apify/src/storages/key_value_store.ts
+++ b/packages/apify/src/storages/key_value_store.ts
@@ -213,7 +213,7 @@ export class KeyValueStore {
             validator: ow.isValid(k, ow.string.matches(KEY_VALUE_STORE_KEY_REGEX)),
             message: 'The "key" argument must be at most 256 characters long and only contain the following characters: a-zA-Z0-9!-_.\'()',
         })));
-        if (options!.contentType && !ow.isValid(value, ow.any(ow.string, ow.buffer))) {
+        if (options.contentType && !ow.isValid(value, ow.any(ow.string, ow.buffer))) {
             throw new ArgumentError('The "value" parameter must be a String or Buffer when "options.contentType" is specified.', this.setValue);
         }
         ow(options, ow.object.exactShape({
@@ -280,9 +280,8 @@ export class KeyValueStore {
         return this._forEachKey(iteratee, options);
     }
 
-    /** @private */
     private async _forEachKey(iteratee: KeyConsumer, options: KeyValueStoreIteratorOptions = {}, index = 0): Promise<void> {
-        const { exclusiveStartKey } = options!;
+        const { exclusiveStartKey } = options;
         ow(iteratee, ow.function);
         ow(options, ow.object.exactShape({
             exclusiveStartKey: ow.optional.string,
@@ -410,7 +409,6 @@ export async function getValue<T extends Dictionary | string | Buffer>(key: stri
 export async function setValue<T>(key: string, value: T, options: RecordOptions = {}): Promise<void> {
     const store = await openKeyValueStore();
 
-    // @ts-ignore options need to be typed
     return store.setValue(key, value, options);
 }
 
@@ -466,14 +464,14 @@ export interface KeyValueStoreOptions {
     isLocal?: boolean;
 }
 
-interface RecordOptions {
+export interface RecordOptions {
     /**
      * Specifies a custom MIME content type of the record.
      */
     contentType?: string;
 }
 
-interface KeyValueStoreIteratorOptions {
+export interface KeyValueStoreIteratorOptions {
     /**
      * All keys up to this one (including) are skipped from the result.
      */

--- a/packages/apify/src/storages/request_queue.ts
+++ b/packages/apify/src/storages/request_queue.ts
@@ -285,7 +285,7 @@ export class RequestQueue {
      * Gets the request from the queue specified by ID.
      *
      * @param id ID of the request.
-     * @return {Promise<Request | null>} Returns the request object, or `null` if it was not found.
+     * @returns Returns the request object, or `null` if it was not found.
      */
     async getRequest(id: string): Promise<Request | null> {
         ow(id, ow.string);
@@ -510,7 +510,7 @@ export class RequestQueue {
      * @default false
      * @param [limit] How many queue head items will be fetched.
      * @param [iteration] Used when this function is called recursively to limit the recursion.
-     * @return {Promise<boolean>} Indicates if queue head is consistent (true) or inconsistent (false).
+     * @returns Indicates if queue head is consistent (true) or inconsistent (false).
      */
     protected async _ensureHeadIsNonEmpty(
         ensureConsistency = false,

--- a/packages/apify/src/storages/request_queue.ts
+++ b/packages/apify/src/storages/request_queue.ts
@@ -673,7 +673,6 @@ export class RequestQueue {
      *   ID or name of the request queue to be opened. If `null` or `undefined`,
      *   the function returns the default request queue associated with the actor run.
      * @param [options] Open Request Queue options.
-     * @default false
      */
     static async open(queueIdOrName?: string | null, options: OpenRequestQueueOptions = {}): Promise<RequestQueue> {
         ow(queueIdOrName, ow.optional.string);

--- a/packages/apify/src/storages/request_queue.ts
+++ b/packages/apify/src/storages/request_queue.ts
@@ -88,7 +88,7 @@ export interface QueueOperationInfo {
 
 }
 
-interface RequestQueueOperationOptions {
+export interface RequestQueueOperationOptions {
     /**
      * If set to `true`:
      *   - while adding the request to the queue: the request will be added to the foremost position in the queue.
@@ -98,6 +98,15 @@ interface RequestQueueOperationOptions {
      * @default false
      */
     forefront?: boolean;
+}
+
+export interface OpenRequestQueueOptions {
+    /**
+     * If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
+     * environment variable is set. This way it is possible to combine local and cloud storage.
+     * @default false
+     */
+    forceCloud?: boolean;
 }
 
 /**
@@ -484,8 +493,6 @@ export class RequestQueue {
 
     /**
      * Caches information about request to beware of unneeded addRequest() calls.
-     * @ignore
-     * @internal
      */
     protected _cacheRequest(cacheKey: string, queueOperationInfo: QueueOperationInfoOptions): void {
         this.requestsCache.add(cacheKey, {
@@ -504,8 +511,6 @@ export class RequestQueue {
      * @param [limit] How many queue head items will be fetched.
      * @param [iteration] Used when this function is called recursively to limit the recursion.
      * @return {Promise<boolean>} Indicates if queue head is consistent (true) or inconsistent (false).
-     * @ignore
-     * @internal
      */
     protected async _ensureHeadIsNonEmpty(
         ensureConsistency = false,
@@ -591,9 +596,8 @@ export class RequestQueue {
 
     /**
      * Adds a request straight to the queueHeadDict, to improve performance.
-     * @private
      */
-    _maybeAddRequestToQueueHead(requestId: string, forefront: boolean): void {
+    private _maybeAddRequestToQueueHead(requestId: string, forefront: boolean): void {
         if (forefront) {
             this.queueHeadDict.add(requestId, requestId, true);
         } else if (this.assumedTotalCount < QUERY_HEAD_MIN_LENGTH) {
@@ -668,13 +672,10 @@ export class RequestQueue {
      * @param [queueIdOrName]
      *   ID or name of the request queue to be opened. If `null` or `undefined`,
      *   the function returns the default request queue associated with the actor run.
-     * @param [options]
-     * @param [options.forceCloud]
-     *   If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
-     *   environment variable is set. This way it is possible to combine local and cloud storage.
+     * @param [options] Open Request Queue options.
      * @default false
      */
-    static async open(queueIdOrName?: string | null, options: { forceCloud?: boolean } = {}): Promise<RequestQueue> {
+    static async open(queueIdOrName?: string | null, options: OpenRequestQueueOptions = {}): Promise<RequestQueue> {
         ow(queueIdOrName, ow.optional.string);
         ow(options, ow.object.exactShape({
             forceCloud: ow.optional.boolean,
@@ -698,14 +699,10 @@ export class RequestQueue {
  * @param [queueIdOrName]
  *   ID or name of the request queue to be opened. If `null` or `undefined`,
  *   the function returns the default request queue associated with the actor run.
- * @param [options]
- * @param [options.forceCloud]
- *   If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
- *   environment variable is set. This way it is possible to combine local and cloud storage.
- * @default false
+ * @param [options] Open Request Queue options.
  * @deprecated use `RequestQueue.open()` instead
  */
-export async function openRequestQueue(queueIdOrName?: string | null, options: { forceCloud?: boolean } = {}): Promise<RequestQueue> {
+export async function openRequestQueue(queueIdOrName?: string | null, options: OpenRequestQueueOptions = {}): Promise<RequestQueue> {
     return RequestQueue.open(queueIdOrName, options);
 }
 

--- a/packages/apify/src/storages/storage_manager.ts
+++ b/packages/apify/src/storages/storage_manager.ts
@@ -76,9 +76,6 @@ export class StorageManager<T> {
         }
     }
 
-    /**
-     * @internal
-     */
     protected _createCacheKey(idOrName: string, isLocal?: boolean): string {
         return isLocal
             ? `LOCAL:${idOrName}`
@@ -87,7 +84,6 @@ export class StorageManager<T> {
 
     /**
      * Helper function that first requests storage by ID and if storage doesn't exist then gets it by name.
-     * @internal
      */
     protected async _getOrCreateStorage(storageIdOrName: string, storageConstructorName: string, apiClient: ApifyClient | ApifyStorageLocal) {
         const {
@@ -103,9 +99,6 @@ export class StorageManager<T> {
         return storageCollectionClient.getOrCreate(storageIdOrName);
     }
 
-    /**
-     * @internal
-     */
     protected _getStorageClientFactories(client: ApifyClient | ApifyStorageLocal, storageConstructorName: string) {
         // Dataset => dataset
         const clientName = storageConstructorName[0].toLowerCase() + storageConstructorName.slice(1);
@@ -118,9 +111,6 @@ export class StorageManager<T> {
         };
     }
 
-    /**
-     * @internal
-     */
     protected _addStorageToCache(storage: { id: string; name?: string; isLocal?: boolean }): void {
         const idKey = this._createCacheKey(storage.id, storage.isLocal);
         this.cache.add(idKey, storage);

--- a/packages/apify/src/storages/storage_manager.ts
+++ b/packages/apify/src/storages/storage_manager.ts
@@ -131,3 +131,17 @@ export class StorageManager<T> {
         }
     }
 }
+
+export interface StorageManagerOptions {
+    /**
+     * If set to `true` then the cloud storage is used even if the `APIFY_LOCAL_STORAGE_DIR`
+     * environment variable is set. This way it is possible to combine local and cloud storage.
+     * @default false
+     */
+    forceCloud?: boolean;
+
+    /**
+     * SDK configuration instance, defaults to the static register.
+     */
+    config?: Configuration;
+}

--- a/test/storages/key_value_store.test.ts
+++ b/test/storages/key_value_store.test.ts
@@ -165,13 +165,17 @@ describe('KeyValueStore remote', () => {
             await expect(store.setValue('key', null, { contentType: 'image/png' }))
                 .rejects.toThrow('The "value" parameter must be a String or Buffer when "options.contentType" is specified.');
             await expect(store.setValue('key', null, { contentType: '' })).rejects.toThrow(contTypeRedundantErrMsg);
+            // @ts-expect-error Type '{}' is not assignable to type 'string'.
             await expect(store.setValue('key', null, { contentType: {} }))
                 .rejects.toThrow('The "value" parameter must be a String or Buffer when "options.contentType" is specified.');
 
+            // @ts-expect-error Type 'number' is not assignable to type 'string'.
             await expect(store.setValue('key', 'value', { contentType: 123 }))
                 .rejects.toThrow('Expected property `contentType` to be of type `string` but received type `number` in object');
+            // @ts-expect-error Type '{}' is not assignable to type 'string'.
             await expect(store.setValue('key', 'value', { contentType: {} }))
                 .rejects.toThrow('Expected property `contentType` to be of type `string` but received type `Object` in object');
+            // @ts-expect-error Type 'Date' is not assignable to type 'string'.
             await expect(store.setValue('key', 'value', { contentType: new Date() }))
                 .rejects.toThrow('Expected property `contentType` to be of type `string` but received type `Date` in object');
             await expect(store.setValue('key', 'value', { contentType: '' }))

--- a/test/storages/request_queue.test.ts
+++ b/test/storages/request_queue.test.ts
@@ -1,5 +1,6 @@
 import Apify from 'apify';
 import { apifyClient } from 'apify/src/utils';
+import { Request as ApifyRequest } from 'apify/src/request';
 import {
     RequestQueue,
     QUERY_HEAD_MIN_LENGTH,
@@ -512,13 +513,13 @@ describe('RequestQueue remote', () => {
         const updateRequestMock = jest.spyOn(queue.client, 'updateRequest');
         updateRequestMock.mockResolvedValueOnce({ requestId: 'b', wasAlreadyHandled: false, wasAlreadyPresent: true });
 
-        await queue.markRequestHandled(requestBWithId);
+        await queue.markRequestHandled(requestBWithId as ApifyRequest);
         expect(updateRequestMock).toHaveBeenCalledTimes(1);
         expect(updateRequestMock).toHaveBeenLastCalledWith(requestBWithId);
 
         updateRequestMock.mockResolvedValueOnce({ requestId: 'a', wasAlreadyHandled: false, wasAlreadyPresent: true });
 
-        await queue.reclaimRequest(requestAWithId, { forefront: true });
+        await queue.reclaimRequest(requestAWithId as ApifyRequest, { forefront: true });
         expect(updateRequestMock).toHaveBeenCalledTimes(2);
         expect(updateRequestMock).toHaveBeenLastCalledWith(requestAWithId, { forefront: true });
         // @ts-expect-error Accessing private property
@@ -558,7 +559,7 @@ describe('RequestQueue remote', () => {
         // Mark handled.
         updateRequestMock.mockResolvedValueOnce({ requestId: 'a', wasAlreadyHandled: false, wasAlreadyPresent: true });
 
-        await queue.markRequestHandled(requestAWithId);
+        await queue.markRequestHandled(requestAWithId as ApifyRequest);
         expect(updateRequestMock).toHaveBeenCalledTimes(3);
         expect(updateRequestMock).toHaveBeenLastCalledWith(requestAWithId);
 

--- a/test/storages/request_queue.test.ts
+++ b/test/storages/request_queue.test.ts
@@ -1,6 +1,5 @@
 import Apify from 'apify';
 import { apifyClient } from 'apify/src/utils';
-import { Request as ApifyRequest } from 'apify/src/request';
 import {
     RequestQueue,
     QUERY_HEAD_MIN_LENGTH,
@@ -459,9 +458,9 @@ describe('RequestQueue remote', () => {
 
         // Add some requests.
         const requestA = new Apify.Request({ url: 'http://example.com/a' });
-        const requestAWithId = { ...requestA, id: 'a' };
+        const requestAWithId = { ...requestA, id: 'a' } as Apify.Request;
         const requestB = new Apify.Request({ url: 'http://example.com/b' });
-        const requestBWithId = { ...requestB, id: 'b' };
+        const requestBWithId = { ...requestB, id: 'b' } as Apify.Request;
         const addRequestMock = jest.spyOn(queue.client, 'addRequest');
         addRequestMock.mockResolvedValueOnce({ requestId: 'a', wasAlreadyHandled: false, wasAlreadyPresent: false });
         addRequestMock.mockResolvedValueOnce({ requestId: 'b', wasAlreadyHandled: false, wasAlreadyPresent: false });
@@ -513,13 +512,13 @@ describe('RequestQueue remote', () => {
         const updateRequestMock = jest.spyOn(queue.client, 'updateRequest');
         updateRequestMock.mockResolvedValueOnce({ requestId: 'b', wasAlreadyHandled: false, wasAlreadyPresent: true });
 
-        await queue.markRequestHandled(requestBWithId as ApifyRequest);
+        await queue.markRequestHandled(requestBWithId);
         expect(updateRequestMock).toHaveBeenCalledTimes(1);
         expect(updateRequestMock).toHaveBeenLastCalledWith(requestBWithId);
 
         updateRequestMock.mockResolvedValueOnce({ requestId: 'a', wasAlreadyHandled: false, wasAlreadyPresent: true });
 
-        await queue.reclaimRequest(requestAWithId as ApifyRequest, { forefront: true });
+        await queue.reclaimRequest(requestAWithId, { forefront: true });
         expect(updateRequestMock).toHaveBeenCalledTimes(2);
         expect(updateRequestMock).toHaveBeenLastCalledWith(requestAWithId, { forefront: true });
         // @ts-expect-error Accessing private property
@@ -539,6 +538,8 @@ describe('RequestQueue remote', () => {
         expect(listHeadMock).not.toHaveBeenCalled();
 
         // Fetch again.
+        // @ts-expect-error Argument of type 'Request' is not assignable to parameter of type
+        // 'RequestQueueClientGetRequestResult | Promise<RequestQueueClientGetRequestResult>'.
         getRequestMock.mockResolvedValueOnce(requestAWithId);
 
         const requestAFromQueue2 = await queue.fetchNextRequest();
@@ -559,7 +560,7 @@ describe('RequestQueue remote', () => {
         // Mark handled.
         updateRequestMock.mockResolvedValueOnce({ requestId: 'a', wasAlreadyHandled: false, wasAlreadyPresent: true });
 
-        await queue.markRequestHandled(requestAWithId as ApifyRequest);
+        await queue.markRequestHandled(requestAWithId);
         expect(updateRequestMock).toHaveBeenCalledTimes(3);
         expect(updateRequestMock).toHaveBeenLastCalledWith(requestAWithId);
 


### PR DESCRIPTION
Second portion of TS type definitions, jsdoc cleaned up + updated the tests where necessary.

Main question I have here is related to the dataset. There's `DatasetDataOptions` interface, which has all params like `limit`, `skipHidden`, `fields` and so on. And there are methods such as `forEach` and some others. `forEach` has 3 options exposed (desc, fields, unwind). While inside of the method there are checks for `format`, `limit`, maybe some others. So I could basically use the `DatasetDataOptions` interface there, but in order to hide some params, I am using `DatasetIteratorOptions extends DatasetDataOptions` with some params overridden with `@internal`. Is it the correct way to do it or what's the proper way in such cases?

P.S.: sry for the delay, will start with the remaining part right away.