### PR TITLE
chore: add more TS types (last batch)

### DIFF
--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -365,7 +365,7 @@ export async function call(actId: string, input?: Dictionary | string, options: 
     callActorOpts.timeout = timeoutSecs;
 
     if (input) {
-        callActorOpts.contentType = addCharsetToContentType(callActorOpts.contentType);
+        callActorOpts.contentType = addCharsetToContentType(callActorOpts.contentType!);
         input = maybeStringify(input, callActorOpts);
     }
 
@@ -600,7 +600,7 @@ export async function metamorph(targetActorId: string, input: Dictionary | strin
     if (!runId) throw new Error(`Environment variable ${ENV_VARS.ACTOR_RUN_ID} must be provided!`);
 
     if (input) {
-        metamorphOpts.contentType = addCharsetToContentType(metamorphOpts.contentType);
+        metamorphOpts.contentType = addCharsetToContentType(metamorphOpts.contentType!);
         input = maybeStringify(input, metamorphOpts);
     }
 
@@ -667,7 +667,7 @@ export interface WebhookOptions {
  * In local environment, the function will print a warning and have no effect.
  *
  * @param options
- * @return {Promise<WebhookRun | undefined>} The return value is the Webhook object.
+ * @return The return value is the Webhook object.
  * For more information, see the [Get webhook](https://apify.com/docs/api/v2#/reference/webhooks/webhook-object/get-webhook) API endpoint.
  */
 export async function addWebhook(options: WebhookOptions): Promise<WebhookRun | undefined> {

--- a/packages/apify/src/apify.ts
+++ b/packages/apify/src/apify.ts
@@ -1,11 +1,11 @@
 import ow from 'ow';
 import { ACT_JOB_STATUSES, ENV_VARS } from '@apify/consts';
-import { ApifyClient } from 'apify-client';
+import { ApifyClient, ApifyClientOptions } from 'apify-client';
 import { WebhookOptions, CallOptions, CallTaskOptions, getEnv, UserFunc, WebhookRun, ApifyEnv } from './actor';
 import { initializeEvents, stopEvents } from './events';
-import { StorageManager } from './storages/storage_manager';
+import { StorageManager, StorageManagerOptions } from './storages/storage_manager';
 import { Dataset } from './storages/dataset';
-import { KeyValueStore, maybeStringify } from './storages/key_value_store';
+import { KeyValueStore, RecordOptions, maybeStringify } from './storages/key_value_store';
 import { RequestList, RequestListOptions, REQUESTS_PERSISTENCE_KEY, STATE_PERSISTENCE_KEY } from './request_list';
 import { RequestQueue } from './storages/request_queue';
 import { SessionPool, SessionPoolOptions } from './session_pool/session_pool';
@@ -238,7 +238,7 @@ export class Apify {
         callActorOpts.token = token;
 
         if (input) {
-            callActorOpts.contentType = addCharsetToContentType(callActorOpts.contentType);
+            callActorOpts.contentType = addCharsetToContentType(callActorOpts.contentType!);
             input = maybeStringify(input, callActorOpts);
         }
 
@@ -305,7 +305,7 @@ export class Apify {
      *  Input overrides for the actor task. If it is an object, it will be stringified to
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Provided input will be merged with actor task input.
-     * @param {object} [options]
+     * @param [options]
      * @throws {ApifyCallError} If the run did not succeed, e.g. if it failed or timed out.
      */
     async callTask(taskId: string, input?: Dictionary | string, options: CallTaskOptions = {}): Promise<ActorRun> {
@@ -379,8 +379,8 @@ export class Apify {
      * @param [input]
      *  Input for the actor. If it is an object, it will be stringified to
      *  JSON and its content type set to `application/json; charset=utf-8`.
-     *  Otherwise the `options.contentType` parameter must be provided.
-     * @param {object} [options]
+     *  Otherwise, the `options.contentType` parameter must be provided.
+     * @param [options]
      */
     async metamorph(targetActorId: string, input?: Dictionary | string, options: MetamorphOptions = {}): Promise<void> {
         ow(targetActorId, ow.string);
@@ -402,7 +402,7 @@ export class Apify {
         if (!runId) throw new Error(`Environment variable ${ENV_VARS.ACTOR_RUN_ID} must be provided!`);
 
         if (input) {
-            metamorphOpts.contentType = addCharsetToContentType(metamorphOpts.contentType);
+            metamorphOpts.contentType = addCharsetToContentType(metamorphOpts.contentType!);
             input = maybeStringify(input, metamorphOpts);
         }
 
@@ -422,7 +422,7 @@ export class Apify {
      * In local environment, the function will print a warning and have no effect.
      *
      * @param options
-     * @return {Promise<WebhookRun | undefined>} The return value is the Webhook object.
+     * @returns The return value is the Webhook object.
      * For more information, see the [Get webhook](https://apify.com/docs/api/v2#/reference/webhooks/webhook-object/get-webhook) API endpoint.
      */
     async addWebhook(options: WebhookOptions): Promise<WebhookRun | undefined> {
@@ -499,11 +499,8 @@ export class Apify {
      *   ID or name of the dataset to be opened. If `null` or `undefined`,
      *   the function returns the default dataset associated with the actor run.
      * @param [options]
-     * @param [options.forceCloud=false]
-     *   If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
-     *   environment variable is set. This way it is possible to combine local and cloud storage.
      */
-    async openDataset(datasetIdOrName?: string | null, options: { forceCloud?: boolean } = {}): Promise<Dataset> {
+    async openDataset(datasetIdOrName?: string | null, options: Omit<StorageManagerOptions, 'config'> = {}): Promise<Dataset> {
         ow(datasetIdOrName, ow.optional.string);
         ow(options, ow.object.exactShape({
             forceCloud: ow.optional.boolean,
@@ -532,15 +529,14 @@ export class Apify {
      * For more information, see  {@link Apify.openKeyValueStore}
      * and  {@link KeyValueStore.getValue}.
      *
-     * @param {string} key
-     *   Unique record key.
-     * @returns {Promise<Object<string, *>|string|Buffer|null>}
+     * @param key Unique record key.
+     * @returns
      *   Returns a promise that resolves to an object, string
      *   or [`Buffer`](https://nodejs.org/api/buffer.html), depending
      *   on the MIME content type of the record, or `null`
      *   if the record is missing.
      */
-    async getValue(key) {
+    async getValue(key: string): Promise<Record<string, unknown> | string | Buffer | null> {
         const store = await this.openKeyValueStore();
         return store.getValue(key);
     }
@@ -565,19 +561,17 @@ export class Apify {
      * For more information, see  {@link Apify.openKeyValueStore}
      * and  {@link KeyValueStore.getValue}.
      *
-     * @param {string} key
+     * @param key
      *   Unique record key.
-     * @param {*} value
+     * @param value
      *   Record data, which can be one of the following values:
      *    - If `null`, the record in the key-value store is deleted.
-     *    - If no `options.contentType` is specified, `value` can be any JavaScript object and it will be stringified to JSON.
-     *    - If `options.contentType` is set, `value` is taken as is and it must be a `String` or [`Buffer`](https://nodejs.org/api/buffer.html).
+     *    - If no `options.contentType` is specified, `value` can be any JavaScript object, and it will be stringified to JSON.
+     *    - If `options.contentType` is set, `value` is taken as is, and it must be a `String` or [`Buffer`](https://nodejs.org/api/buffer.html).
      *   For any other value an error will be thrown.
-     * @param {object} [options]
-     * @param {string} [options.contentType]
-     *   Specifies a custom MIME content type of the record.
+     * @param [options]
      */
-    async setValue(key, value, options): Promise<void> {
+    async setValue(key: string, value: string | Record<string, unknown> | Buffer | null, options: RecordOptions): Promise<void> {
         const store = await this.openKeyValueStore();
         return store.setValue(key, value, options);
     }
@@ -604,13 +598,13 @@ export class Apify {
      * For more information, see  {@link Apify.openKeyValueStore}
      * and {@link KeyValueStore.getValue}.
      *
-     * @returns {Promise<Object<string, *>|string|Buffer|null>}
+     * @returns
      *   Returns a promise that resolves to an object, string
      *   or [`Buffer`](https://nodejs.org/api/buffer.html), depending
      *   on the MIME content type of the record, or `null`
      *   if the record is missing.
      */
-    async getInput() {
+    async getInput(): Promise<Record<string, unknown> | string | Buffer | null> {
         return this.getValue(this.config.get('inputKey'));
     }
 
@@ -627,11 +621,8 @@ export class Apify {
      *   ID or name of the key-value store to be opened. If `null` or `undefined`,
      *   the function returns the default key-value store associated with the actor run.
      * @param [options]
-     * @param [options.forceCloud=false]
-     *   If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
-     *   environment variable is set. This way it is possible to combine local and cloud storage.
      */
-    async openKeyValueStore(storeIdOrName?: string | null, options: { forceCloud?: boolean } = {}): Promise<KeyValueStore> {
+    async openKeyValueStore(storeIdOrName?: string | null, options: Omit<StorageManagerOptions, 'config'> = {}): Promise<KeyValueStore> {
         ow(storeIdOrName, ow.optional.string);
         ow(options, ow.object.exactShape({
             forceCloud: ow.optional.boolean,
@@ -728,11 +719,8 @@ export class Apify {
      *   ID or name of the request queue to be opened. If `null` or `undefined`,
      *   the function returns the default request queue associated with the actor run.
      * @param [options]
-     * @param {boolean} [options.forceCloud=false]
-     *   If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
-     *   environment variable is set. This way it is possible to combine local and cloud storage.
      */
-    async openRequestQueue(queueIdOrName?: string | null, options: { forceCloud?: boolean } = {}): Promise<RequestQueue> {
+    async openRequestQueue(queueIdOrName?: string | null, options: Omit<StorageManagerOptions, 'config'> = {}): Promise<RequestQueue> {
         ow(queueIdOrName, ow.optional.string);
         ow(options, ow.object.exactShape({
             forceCloud: ow.optional.boolean,
@@ -823,26 +811,19 @@ export class Apify {
      * NPM package, and it is automatically configured using the `APIFY_API_BASE_URL`, and `APIFY_TOKEN`
      * environment variables. You can override the token via the available options. That's useful
      * if you want to use the client as a different Apify user than the SDK internals are using.
-     *
-     * @param {object} [options]
-     * @param {string} [options.token]
-     * @param {string} [options.maxRetries]
-     * @param {string} [options.minDelayBetweenRetriesMillis]
      */
-    newClient(options = {}): ApifyClient {
+    newClient(options: Omit<ApifyClientOptions, 'baseUrl' | 'requestInterceptors' | 'timeoutSecs'> = {}): ApifyClient {
         return this.config.createClient(options);
     }
 
     /**
      * Returns `true` when code is running on Apify platform and `false` otherwise (for example locally).
-     *
-     * @returns {boolean}
      */
-    isAtHome() {
+    isAtHome(): boolean {
         return !!this.config.get('isAtHome');
     }
 
-    get utils() {
+    get utils(): Record<string, unknown> {
         return {
             ...publicUtils,
             puppeteer: puppeteerUtils,

--- a/packages/apify/src/apify.ts
+++ b/packages/apify/src/apify.ts
@@ -812,7 +812,7 @@ export class Apify {
      * environment variables. You can override the token via the available options. That's useful
      * if you want to use the client as a different Apify user than the SDK internals are using.
      */
-    newClient(options: Omit<ApifyClientOptions, 'baseUrl' | 'requestInterceptors' | 'timeoutSecs'> = {}): ApifyClient {
+    newClient(options: ApifyClientOptions = {}): ApifyClient {
         return this.config.createClient(options);
     }
 

--- a/packages/apify/src/apify.ts
+++ b/packages/apify/src/apify.ts
@@ -536,9 +536,9 @@ export class Apify {
      *   on the MIME content type of the record, or `null`
      *   if the record is missing.
      */
-    async getValue(key: string): Promise<Record<string, unknown> | string | Buffer | null> {
+    async getValue<T>(key: string): Promise<T | null> {
         const store = await this.openKeyValueStore();
-        return store.getValue(key);
+        return store.getValue<T>(key);
     }
 
     /**
@@ -571,7 +571,7 @@ export class Apify {
      *   For any other value an error will be thrown.
      * @param [options]
      */
-    async setValue(key: string, value: string | Record<string, unknown> | Buffer | null, options: RecordOptions): Promise<void> {
+    async setValue<T>(key: string, value: T, options: RecordOptions = {}): Promise<void> {
         const store = await this.openKeyValueStore();
         return store.setValue(key, value, options);
     }
@@ -604,8 +604,8 @@ export class Apify {
      *   on the MIME content type of the record, or `null`
      *   if the record is missing.
      */
-    async getInput(): Promise<Record<string, unknown> | string | Buffer | null> {
-        return this.getValue(this.config.get('inputKey'));
+    async getInput<T extends Dictionary | string | Buffer>(): Promise<T | null> {
+        return this.getValue<T>(this.config.get('inputKey'));
     }
 
     /**

--- a/packages/apify/src/configuration.ts
+++ b/packages/apify/src/configuration.ts
@@ -192,7 +192,7 @@ export class Configuration {
 
     private _castEnvValue(key: keyof ConfigurationOptions, value: number | string | boolean) {
         if (Configuration.INTEGER_VARS.includes(key)) {
-            return +value as U;
+            return +value;
         }
 
         if (Configuration.BOOLEAN_VARS.includes(key)) {

--- a/packages/apify/src/configuration.ts
+++ b/packages/apify/src/configuration.ts
@@ -220,7 +220,7 @@ export class Configuration {
      * multiple instances, one for each variant of the options.
      * @internal
      */
-    getClient(options: CreateClientOptions = {}): ApifyClient {
+    getClient(options: ApifyClientOptions = {}): ApifyClient {
         const baseUrl = options.baseUrl ?? this.get('apiBaseUrl');
         const token = options.token ?? this.get('token');
         const cacheKey = `${baseUrl}~${token}`;
@@ -260,7 +260,7 @@ export class Configuration {
      * Creates an instance of ApifyClient using options as defined in the environment variables or in this `Configuration` instance.
      * @internal
      */
-    createClient(options: CreateClientOptions = {}): ApifyClient {
+    createClient(options: ApifyClientOptions = {}): ApifyClient {
         return new ApifyClient({
             baseUrl: this.get('apiBaseUrl'),
             token: this.get('token'),
@@ -297,11 +297,4 @@ export class Configuration {
 
         return Configuration.globalConfig;
     }
-}
-
-export interface CreateClientOptions {
-    token?: string;
-    maxRetries?: number;
-    minDelayBetweenRetriesMillis?: number;
-    baseUrl?: string;
 }

--- a/packages/apify/src/proxy_configuration.ts
+++ b/packages/apify/src/proxy_configuration.ts
@@ -279,7 +279,7 @@ export class ProxyConfiguration {
      *  All the HTTP requests going through the proxy with the same session identifier
      *  will use the same target proxy server (i.e. the same IP address).
      *  The identifier must not be longer than 50 characters and include only the following: `0-9`, `a-z`, `A-Z`, `"."`, `"_"` and `"~"`.
-     * @return {ProxyInfo} represents information about used proxy and its configuration.
+     * @return Represents information about used proxy and its configuration.
      */
     newProxyInfo(sessionId?: string | number): ProxyInfo {
         if (typeof sessionId === 'number') sessionId = `${sessionId}`;
@@ -310,7 +310,7 @@ export class ProxyConfiguration {
      *  All the HTTP requests going through the proxy with the same session identifier
      *  will use the same target proxy server (i.e. the same IP address).
      *  The identifier must not be longer than 50 characters and include only the following: `0-9`, `a-z`, `A-Z`, `"."`, `"_"` and `"~"`.
-     * @return {string} A string with a proxy URL, including authentication credentials and port number.
+     * @return A string with a proxy URL, including authentication credentials and port number.
      *  For example, `http://bob:password123@proxy.example.com:8000`
      */
     newUrl(sessionId?: string | number): string {

--- a/packages/apify/src/pseudo_url.ts
+++ b/packages/apify/src/pseudo_url.ts
@@ -127,7 +127,7 @@ export class PseudoUrl {
      * Determines whether a URL matches this pseudo-URL pattern.
      *
      * @param url URL to be matched.
-     * @return {boolean} Returns `true` if given URL matches pseudo-URL.
+     * @return Returns `true` if given URL matches pseudo-URL.
      */
     matches(url: string): boolean {
         return _.isString(url) && url.match(this.regex) !== null;

--- a/packages/apify/src/puppeteer_request_interception.ts
+++ b/packages/apify/src/puppeteer_request_interception.ts
@@ -60,7 +60,7 @@ function browserifyHeaders(headers: Record<string, string>): Record<string, stri
  * @param interceptRequestHandlers An array of intercept request handlers.
  * @ignore
  */
-async function handleRequest(request: PuppeteerRequest, interceptRequestHandlers: InterceptHandler[]) {
+async function handleRequest(request: PuppeteerRequest, interceptRequestHandlers: InterceptHandler[]): Promise<void> {
     // If there are no intercept handlers, it means that request interception is not enabled (anymore)
     // and therefore .abort() .respond() and .continue() would throw and crash the process.
     if (!interceptRequestHandlers.length) return;
@@ -155,8 +155,7 @@ async function handleRequest(request: PuppeteerRequest, interceptRequestHandlers
  * await page.goto('http://example.com');
  * ```
  *
- * @param page
- *   Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
+ * @param page Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
  * @param handler Request interception handler.
  */
 export async function addInterceptRequestHandler(page: Page, handler: InterceptHandler): Promise<void> {
@@ -199,12 +198,10 @@ export async function addInterceptRequestHandler(page: Page, handler: InterceptH
 /**
  * Removes request interception handler for given page.
  *
- * @param {Page} page
- *   Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
- * @param {InterceptHandler} handler Request interception handler.
- * @return {Promise<void>}
+ * @param page Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
+ * @param handler Request interception handler.
  */
-export const removeInterceptRequestHandler = async (page, handler) => {
+export const removeInterceptRequestHandler = async (page: Page, handler: InterceptHandler): Promise<void> => {
     ow(page, ow.object.hasKeys('goto', 'evaluate'));
     ow(handler, ow.function);
 
@@ -237,7 +234,7 @@ export const removeInterceptRequestHandler = async (page, handler) => {
     }
 };
 
-async function disableRequestInterception(page) {
+async function disableRequestInterception(page: Page): Promise<void> {
     await page.setRequestInterception(false);
     const requestHandler = pageInterceptRequestMasterHandlerMap.get(page);
     page.removeListener('request', requestHandler);

--- a/packages/apify/src/puppeteer_utils.ts
+++ b/packages/apify/src/puppeteer_utils.ts
@@ -65,6 +65,30 @@ export interface DirectNavigationOptions {
     referer?: string;
 }
 
+export interface InjectFileOptions {
+    /**
+     * Enables the injected script to survive page navigations and reloads without need to be re-injected manually.
+     * This does not mean, however, that internal state will be preserved. Just that it will be automatically
+     * re-injected on each navigation before any other scripts get the chance to execute.
+     */
+    surviveNavigations?: boolean;
+}
+
+export interface BlockRequestsOptions {
+    /**
+     * The patterns of URLs to block from being loaded by the browser.
+     * Only `*` can be used as a wildcard. It is also automatically added to the beginning
+     * and end of the pattern. This limitation is enforced by the DevTools protocol.
+     * `.png` is the same as `*.png*`.
+     */
+    urlPatterns?: string[];
+
+    /**
+     * If you just want to append to the default blocked patterns, use this property.
+     */
+    extraUrlPatterns?: string[];
+}
+
 export interface CompiledScriptParams {
     page: Page;
     request: Request;
@@ -84,16 +108,11 @@ const injectedFilesCache = new LruCache({ maxLength: MAX_INJECT_FILE_CACHE_SIZE 
  *
  * File contents are cached for up to 10 files to limit file system access.
  *
- * @param page
- *   Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
+ * @param page Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
  * @param filePath File path
  * @param [options]
- * @param [options.surviveNavigations]
- *   Enables the injected script to survive page navigations and reloads without need to be re-injected manually.
- *   This does not mean, however, that internal state will be preserved. Just that it will be automatically
- *   re-injected on each navigation before any other scripts get the chance to execute.
  */
-export async function injectFile(page: Page, filePath: string, options: { surviveNavigations?: boolean } = {}): Promise<unknown> {
+export async function injectFile(page: Page, filePath: string, options: InjectFileOptions = {}): Promise<unknown> {
     ow(page, ow.object.validate(validators.browserPage));
     ow(filePath, ow.string);
     ow(options, ow.object.exactShape({
@@ -134,8 +153,7 @@ export async function injectFile(page: Page, filePath: string, options: { surviv
  * [`page.$()`](https://pptr.dev/#?product=Puppeteer&show=api-pageselector)
  * function in any way.
  *
- * @param page
- *   Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
+ * @param page Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
  */
 export function injectJQuery(page: Page): Promise<unknown> {
     ow(page, ow.object.validate(validators.browserPage));
@@ -205,18 +223,10 @@ export function injectUnderscore(page: Page): Promise<unknown> {
  * await page.goto('https://cnn.com');
  * ```
  *
- * @param page
- *   Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
+ * @param page Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
  * @param [options]
- * @param [options.urlPatterns]
- *   The patterns of URLs to block from being loaded by the browser.
- *   Only `*` can be used as a wildcard. It is also automatically added to the beginning
- *   and end of the pattern. This limitation is enforced by the DevTools protocol.
- *   `.png` is the same as `*.png*`.
- * @param [options.extraUrlPatterns]
- *   If you just want to append to the default blocked patterns, use this property.
  */
-export async function blockRequests(page: Page, options: { urlPatterns?: string[]; extraUrlPatterns?: string[] } = {}): Promise<void> {
+export async function blockRequests(page: Page, options: BlockRequestsOptions = {}): Promise<void> {
     ow(page, ow.object.validate(validators.browserPage));
     ow(options, ow.object.exactShape({
         urlPatterns: ow.optional.array.ofType(ow.string),
@@ -362,8 +372,7 @@ export function compileScript(scriptString: string, context: Dictionary = Object
  * *NOTE:* In recent versions of Puppeteer using requests other than GET, overriding headers and adding payloads disables
  * browser cache which degrades performance.
  *
- * @param page
- *   Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
+ * @param page Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
  * @param request
  * @param [gotoOptions] Custom options for `page.goto()`.
  */
@@ -440,8 +449,7 @@ export interface InfiniteScrollOptions {
 /**
  * Scrolls to the bottom of a page, or until it times out.
  * Loads dynamic content when it hits the bottom of a page, and then continues scrolling.
- * @param page
- *   Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
+ * @param page Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
  * @param [options]
  */
 export async function infiniteScroll(page: Page, options: InfiniteScrollOptions = {}): Promise<void> {
@@ -569,8 +577,7 @@ export interface SaveSnapshotOptions {
 
 /**
  * Saves a full screenshot and HTML of the current page into a Key-Value store.
- * @param page
- *   Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
+ * @param page Puppeteer [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) object.
  * @param [options]
  */
 export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}): Promise<void> {

--- a/packages/apify/src/request.ts
+++ b/packages/apify/src/request.ts
@@ -186,12 +186,10 @@ export class Request {
      * inspection of the passed argument and attempts to extract as much information
      * as possible, since just throwing a bad type error makes any debugging rather difficult.
      *
-     * @param {(Error|string)} errorOrMessage Error object or error message to be stored in the request.
-     * @param {object} [options]
-     * @param {boolean} [options.omitStack=false] Only push the error message without stack trace when true.
+     * @param errorOrMessage Error object or error message to be stored in the request.
+     * @param [options]
      */
-    pushErrorMessage(errorOrMessage, options = {}) {
-        // @ts-ignore
+    pushErrorMessage(errorOrMessage: Error | Record<string, string> | string, options: PushErrorMessageOptions = {}): void {
         const { omitStack } = options;
         let message;
         const type = typeof errorOrMessage;
@@ -203,8 +201,8 @@ export class Request {
                     ? errorOrMessage.message
                     // .stack includes the message
                     : errorOrMessage.stack;
-            } else if (errorOrMessage.message) {
-                message = errorOrMessage.message; // eslint-disable-line prefer-destructuring
+            } else if ((errorOrMessage as Record<string, string>).message) {
+                message = (errorOrMessage as Record<string, string>).message;
             } else if (errorOrMessage.toString() !== '[object Object]') {
                 message = errorOrMessage.toString();
             } else {
@@ -223,9 +221,6 @@ export class Request {
         this.errorMessages.push(message);
     }
 
-    /**
-     * @internal
-     */
     protected _computeUniqueKey({ url, method, payload, keepUrlFragment, useExtendedUniqueKey }) {
         const normalizedMethod = method.toUpperCase();
         const normalizedUrl = normalizeUrl(url, keepUrlFragment) || url; // It returns null when url is invalid, causing weird errors.
@@ -313,4 +308,12 @@ export interface RequestOptions {
     // TODO: do we want to document this
     id?: string;
 
+}
+
+export interface PushErrorMessageOptions {
+    /**
+     * Only push the error message without stack trace when true.
+     * @default false
+     */
+    omitStack?: boolean;
 }

--- a/packages/apify/src/request.ts
+++ b/packages/apify/src/request.ts
@@ -190,7 +190,7 @@ export class Request {
      * @param errorOrMessage Error object or error message to be stored in the request.
      * @param [options]
      */
-    pushErrorMessage(errorOrMessage: Error | string, options: PushErrorMessageOptions = {}): void {
+    pushErrorMessage(errorOrMessage: unknown, options: PushErrorMessageOptions = {}): void {
         const { omitStack } = options;
         let message;
         const type = typeof errorOrMessage;
@@ -204,8 +204,8 @@ export class Request {
                     : errorOrMessage.stack;
             } else if (Reflect.has(Object(errorOrMessage), 'message')) {
                 message = Reflect.get(Object(errorOrMessage), 'message');
-            } else if (errorOrMessage.toString() !== '[object Object]') {
-                message = errorOrMessage.toString();
+            } else if ((errorOrMessage as string).toString() !== '[object Object]') {
+                message = (errorOrMessage as string).toString();
             } else {
                 try {
                     message = util.inspect(errorOrMessage);
@@ -216,7 +216,7 @@ export class Request {
         } else if (type === 'undefined') {
             message = 'undefined';
         } else {
-            message = errorOrMessage.toString();
+            message = (errorOrMessage as string).toString();
         }
 
         this.errorMessages.push(message);

--- a/packages/apify/src/storages/request_queue.ts
+++ b/packages/apify/src/storages/request_queue.ts
@@ -5,11 +5,10 @@ import { cryptoRandomObjectId } from '@apify/utilities';
 import { ApifyStorageLocal } from '@apify/storage-local';
 import { ApifyClient, RequestQueueClient, RequestQueue as RequestQueueInfo } from 'apify-client';
 import ow from 'ow';
-import { StorageManager } from './storage_manager';
+import { StorageManager, StorageManagerOptions } from './storage_manager';
 import { sleep } from '../utils';
 import log from '../utils_log';
 import { Request, RequestOptions } from '../request';
-import { Dictionary } from '../typedefs';
 
 const MAX_CACHED_REQUESTS = 1_000_000;
 
@@ -98,15 +97,6 @@ export interface RequestQueueOperationOptions {
      * @default false
      */
     forefront?: boolean;
-}
-
-export interface OpenRequestQueueOptions {
-    /**
-     * If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
-     * environment variable is set. This way it is possible to combine local and cloud storage.
-     * @default false
-     */
-    forceCloud?: boolean;
 }
 
 /**
@@ -674,7 +664,7 @@ export class RequestQueue {
      *   the function returns the default request queue associated with the actor run.
      * @param [options] Open Request Queue options.
      */
-    static async open(queueIdOrName?: string | null, options: OpenRequestQueueOptions = {}): Promise<RequestQueue> {
+    static async open(queueIdOrName?: string | null, options: Omit<StorageManagerOptions, 'config'> = {}): Promise<RequestQueue> {
         ow(queueIdOrName, ow.optional.string);
         ow(options, ow.object.exactShape({
             forceCloud: ow.optional.boolean,
@@ -701,7 +691,7 @@ export class RequestQueue {
  * @param [options] Open Request Queue options.
  * @deprecated use `RequestQueue.open()` instead
  */
-export async function openRequestQueue(queueIdOrName?: string | null, options: OpenRequestQueueOptions = {}): Promise<RequestQueue> {
+export async function openRequestQueue(queueIdOrName?: string | null, options: Omit<StorageManagerOptions, 'config'> = {}): Promise<RequestQueue> {
     return RequestQueue.open(queueIdOrName, options);
 }
 

--- a/packages/apify/src/utils.ts
+++ b/packages/apify/src/utils.ts
@@ -647,32 +647,6 @@ export function parseContentTypeFromResponse(response: IncomingMessage): { type:
     };
 }
 
-export interface WaitForRunToFinishOptions {
-    /**
-     * ID of the actor that started the run.
-     */
-    actorId: string;
-
-    /**
-     * ID of the run itself.
-     */
-    runId: string;
-
-    /**
-     * Maximum time to wait for the run to finish, in seconds.
-     * If the limit is reached, the returned promise is resolved to a run object that will have
-     * status `READY` or `RUNNING`. If `waitSecs` omitted, the function waits indefinitely.
-     */
-    waitSecs?: string;
-
-    /**
-     * You can supply an Apify token to override the default one
-     * that's used by the default ApifyClient instance.
-     * E.g. you can track other users' runs.
-     */
-    token?: string;
-}
-
 /**
  * Returns a promise that resolves with the finished Run object when the provided actor run finishes
  * or with the unfinished Run object when the `waitSecs` timeout lapses. The promise is NOT rejected

--- a/packages/apify/src/utils.ts
+++ b/packages/apify/src/utils.ts
@@ -81,7 +81,7 @@ const psTreePromised = util.promisify(psTree);
  * environment variables. You can override the token via the available options. That's useful
  * if you want to use the client as a different Apify user than the SDK internals are using.
  */
-export function newClient(options: Omit<ApifyClientOptions, 'baseUrl' | 'requestInterceptors' | 'timeoutSecs'> = {}): ApifyClient {
+export function newClient(options: ApifyClientOptions = {}): ApifyClient {
     ow(options, ow.object.exactShape({
         baseUrl: ow.optional.string.url,
         token: ow.optional.string,

--- a/packages/apify/src/utils_request.ts
+++ b/packages/apify/src/utils_request.ts
@@ -243,8 +243,7 @@ export async function requestAsBrowser<T = string>(options: RequestAsBrowserOpti
                     return reject(e);
                 }
 
-                // TODO: stream vs response interface?
-                addResponsePropertiesToStream(duplexStream as any, res);
+                addResponsePropertiesToStream(duplexStream, res);
 
                 return resolve(duplexStream as unknown as RequestAsBrowserResult<T>);
             });

--- a/packages/apify/src/utils_request.ts
+++ b/packages/apify/src/utils_request.ts
@@ -2,7 +2,6 @@ import { AfterResponseHook, GotOptionsInit, gotScraping, Method, Response, GotSt
 import { IncomingMessage } from 'http';
 import { Duplex } from 'stream';
 import ow from 'ow';
-import { Duplex } from 'stream';
 import { Dictionary, keys } from './typedefs';
 import log from './utils_log';
 

--- a/packages/apify/src/utils_request.ts
+++ b/packages/apify/src/utils_request.ts
@@ -257,7 +257,6 @@ export async function requestAsBrowser<T = string>(options: RequestAsBrowserOpti
  * Those options are mutually exclusive. `requestAsBrowser` also supports `payload` as
  * an alias of `body`. It must be exclusive as well.
  * @internal
- * @ignore
  */
 function areBodyOptionsCompatible(requestAsBrowserOptions: RequestAsBrowserOptions): boolean {
     // @ts-expect-error Property does not exist on type 'RequestAsBrowserOptions' // TODO
@@ -277,7 +276,6 @@ function areBodyOptionsCompatible(requestAsBrowserOptions: RequestAsBrowserOptio
  * got-scraping uses 'body', but we also support 'payload' from {@link Request}.
  * @param {string|Buffer} payload
  * @param {GotScrapingOptions} gotScrapingOptions
- * @ignore
  * @internal
  */ // TODO GotScrapingOptions as interface?
 function normalizePayloadOption(payload: string | Buffer, gotScrapingOptions): void {
@@ -290,7 +288,6 @@ function normalizePayloadOption(payload: string | Buffer, gotScrapingOptions): v
  * compatible we need to figure out which option the user provided.
  * @param {*} json
  * @param {GotScrapingOptions} gotScrapingOptions
- * @ignore
  * @internal
  */ // TODO GotScrapingOptions as interface?
 function normalizeJsonOption(json: boolean | Record<string, unknown>, gotScrapingOptions): void {
@@ -316,7 +313,6 @@ function normalizeJsonOption(json: boolean | Record<string, unknown>, gotScrapin
  * 'connection' and 'host' headers are forbidden when using HTTP2. We delete
  * them from user-provided headers because we switched the default from HTTP1 to 2.
  * @param {GotScrapingOptions} gotScrapingOptions
- * @ignore
  * @internal
  */ // TODO GotScrapingOptions as interface?
 function ensureCorrectHttp2Headers(gotScrapingOptions): void {
@@ -339,7 +335,6 @@ function ensureCorrectHttp2Headers(gotScrapingOptions): void {
  * the response body is read to save bandwidth.
  * @param {function} abortFunction
  * @param {GotScrapingOptions} gotScrapingOptions
- * @ignore
  * @internal
  */ // TODO GotScrapingOptions as interface?
 function maybeAddAbortHook(abortFunction: AbortFunction, gotScrapingOptions) {
@@ -384,7 +379,6 @@ function ensureRequestIsDispatched(duplexStream: Duplex, gotScrapingOptions): vo
 }
 
 /**
- * @ignore
  * @internal
  */
 function logDeprecatedOptions(options: RequestAsBrowserOptions): void {
@@ -431,7 +425,6 @@ function logDeprecatedOptions(options: RequestAsBrowserOptions): void {
  * @param {GotStream} stream
  * @param {http.IncomingMessage} response
  * @return {GotStream}
- * @ignore
  * @internal
  */
 function addResponsePropertiesToStream(stream: Duplex, response: IncomingMessage): Duplex {

--- a/packages/apify/src/utils_social.ts
+++ b/packages/apify/src/utils_social.ts
@@ -42,8 +42,8 @@ const EMAIL_URL_PREFIX_REGEX = /^mailto:/i;
 /**
  * The function extracts email addresses from a plain text.
  * Note that the function preserves the order of emails and keep duplicates.
- * @param {string} text Text to search in.
- * @return {string[]} Array of emails addresses found.
+ * @param text Text to search in.
+ * @return Array of emails addresses found.
  * If no emails are found, the function returns an empty array.
  */
 export function emailsFromText(text: string): string[] {
@@ -56,7 +56,7 @@ export function emailsFromText(text: string): string[] {
  * Basically it looks for all `mailto:` URLs and returns valid email addresses from them.
  * Note that the function preserves the order of emails and keep duplicates.
  * @param urls Array of URLs.
- * @return {string[]} Array of emails addresses found.
+ * @return Array of emails addresses found.
  * If no emails are found, the function returns an empty array.
  */
 export function emailsFromUrls(urls: string[]): string[] {
@@ -138,7 +138,7 @@ const SKIP_PHONE_REGEX = new RegExp(`^(${SKIP_PHONE_REGEXS.join('|')})$`, 'i');
  * the results might not be accurate, since phone numbers appear in a large variety of formats and conventions.
  * If you encounter some problems, please [file an issue](https://github.com/apify/apify-js/issues).
  * @param text Text to search the phone numbers in.
- * @return {string[]} Array of phone numbers found.
+ * @return Array of phone numbers found.
  * If no phone numbers are found, the function returns an empty array.
  */
 export function phonesFromText(text: string): string[] {
@@ -164,7 +164,7 @@ export function phonesFromText(text: string): string[] {
  * Finds phone number links in an array of URLs and extracts the phone numbers from them.
  * Note that the phone number links look like `tel://123456789`, `tel:/123456789` or `tel:123456789`.
  * @param urls Array of URLs.
- * @return {string[]} Array of phone numbers found.
+ * @return Array of phone numbers found.
  * If no phone numbers are found, the function returns an empty array.
  */
 export function phonesFromUrls(urls: string[]): string[] {
@@ -268,7 +268,7 @@ export interface SocialHandles {
  * @param [data] Optional object which will receive the `text` and `$` properties
  *   that contain text content of the HTML and `cheerio` object, respectively. This is an optimization
  *   so that the caller doesn't need to parse the HTML document again, if needed.
- * @return {SocialHandles} An object with the social handles.
+ * @return An object with the social handles.
  */
 export function parseHandlesFromHtml(html: string, data: Record<string, unknown> | null = null): SocialHandles {
     const result: SocialHandles = {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -87,23 +87,16 @@ describe('Apify.Request', () => {
         };
 
         request.pushErrorMessage(undefined);
-        // @ts-expect-error Argument of type 'boolean' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(false);
-        // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(5);
-        // @ts-expect-error Argument of type '() => number' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(() => 2);
         request.pushErrorMessage('bar');
-        // @ts-expect-error Argument of type 'symbol' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(Symbol('A Symbol'));
         request.pushErrorMessage(null);
         request.pushErrorMessage(new Error('foo'), { omitStack: true });
         request.pushErrorMessage({ message: 'A message.' });
-        // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage([1, 2, 3]);
-        // @ts-expect-error Argument of type '{ one: number; two: string; }' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(obj);
-        // @ts-expect-error Argument of type '{ toString(): string; }' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(toStr);
         request.pushErrorMessage(circularObj);
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -87,16 +87,23 @@ describe('Apify.Request', () => {
         };
 
         request.pushErrorMessage(undefined);
+        // @ts-expect-error Argument of type 'boolean' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(false);
+        // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(5);
+        // @ts-expect-error Argument of type '() => number' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(() => 2);
         request.pushErrorMessage('bar');
+        // @ts-expect-error Argument of type 'symbol' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(Symbol('A Symbol'));
         request.pushErrorMessage(null);
         request.pushErrorMessage(new Error('foo'), { omitStack: true });
         request.pushErrorMessage({ message: 'A message.' });
+        // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage([1, 2, 3]);
+        // @ts-expect-error Argument of type '{ one: number; two: string; }' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(obj);
+        // @ts-expect-error Argument of type '{ toString(): string; }' is not assignable to parameter of type 'string | Error'.
         request.pushErrorMessage(toStr);
         request.pushErrorMessage(circularObj);
 


### PR DESCRIPTION
Last batch of types updates.

1. I skipped `utils_log.ts`, it's mentioned that it's for building docs mainly. Should I update `types-apify/apify-shared/log.d.ts` instead, or I could just skip it indeed?
2. Tests should be passing, but I would ask you to kinda double check the `configuration.ts` and `request.ts` (`pushErrorMessage` specifically).
3. `utils_request.ts` - I am kinda confused about this one - there seems to be some mess with types (it's not finished). Should I have `GotScrapingOptions` as an interface here? There's also some mismatch between `stream.Duplex` vs `CancelableRequest` (there was also a TODO about it). Could you point me to what's kinda the right approach here or should I also skip it for now?
4. `request.test.ts` - there's one test failing on `request.pushErrorMessage`. The test is pushing different types to the errors array, while the method expects Error/string/Object. I just don't kinda get it - why is the test done this way? Why random stuff like functions etc should be pushed there? Aren't we explicitly mean in the method signature that it should not be function/symbol/etc?

And well - of course - waiting for other comments. Thanks in advance!
And yeah - sry, I kinda expected this PR to be tiny, but it's not in the end :/