### PR TITLE
fix: update e2e jquery pagination test, add puppeteerUtils to context

### DIFF
--- a/packages/scraper-tools/src/context.ts
+++ b/packages/scraper-tools/src/context.ts
@@ -10,6 +10,7 @@ import {
     RequestQueue,
     RequestQueueOperationOptions,
 } from 'apify';
+import { puppeteerUtils } from '@crawlers/puppeteer';
 import contentTypeParser, { MediaType } from 'content-type';
 import { saveSnapshot, SnapshotOptions } from './browser_tools';
 import { META_KEY } from './consts';
@@ -60,6 +61,7 @@ class Context<Options extends ContextOptions = ContextOptions, ExtraFields = Opt
 
     public readonly Actor = Actor;
     public readonly log = logUtils;
+    public readonly puppeteerUtils = puppeteerUtils;
     public readonly input: any;
     public readonly env: ApifyEnv;
     public readonly customData: unknown;

--- a/test/e2e/test-pup-store-pagination-jQ/test.mjs
+++ b/test/e2e/test-pup-store-pagination-jQ/test.mjs
@@ -40,8 +40,8 @@ await run(import.meta.url, 'puppeteer-scraper', {
             }
         }
 
-        async function handleDetail({ request, log, skipLinks, page, Apify }) {
-            await Apify.utils.puppeteer.injectJQuery(page);
+        async function handleDetail({ request, log, skipLinks, page, puppeteerUtils }) {
+            await puppeteerUtils.injectJQuery(page);
 
             const { url } = request;
             log.info(`Scraping ${url}`);


### PR DESCRIPTION
One of the tests was using `utils.puppeteer.injectJQuery()` which is now part of `puppeteerUtils`. Added it to context for now.
All tests are passing again (within ~15 mins)