### PR TITLE
docs: rework internal API links and adjust many examples to new API

### DIFF
--- a/docs/examples/add_data_to_dataset.mdx
+++ b/docs/examples/add_data_to_dataset.mdx
@@ -4,11 +4,11 @@ title: Add data to dataset
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import AddDataToDatasetSource from '!!raw-loader!./add_data_to_dataset.ts';
 
 This example saves data to the default dataset. If the dataset doesn't exist, it will be created.
-You can save data to custom datasets by using <VersionedApiLink apiPath="core/class/Dataset#open">`Dataset.open()`</VersionedApiLink>
+You can save data to custom datasets by using <ApiLink to="core/class/Dataset#open">`Dataset.open()`</ApiLink>
 
 <CodeBlock className="language-js">
 	{AddDataToDatasetSource}

--- a/docs/examples/basic_crawler.mdx
+++ b/docs/examples/basic_crawler.mdx
@@ -4,14 +4,13 @@ title: Basic crawler
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import BasicCrawlerSource from '!!raw-loader!./basic_crawler.ts';
 
-This is the most bare-bones example of the Apify SDK, which demonstrates some of its building blocks such as the <VersionedApiLink apiPath="basic-crawler">`BasicCrawler`</VersionedApiLink>.
-You probably don't need to go this deep though, and it would be better to start with one of the full featured crawlers
-like [`CheerioCrawler`](../cheerio/cheerio-crawler) or [`PlaywrightCrawler`](../playwright/playwright-crawler).
+This is the most bare-bones example of the Apify SDK, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers
+like <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> or <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
 
-The script simply downloads several web pages with plain HTTP requests using the <VersionedApiLink apiPath="utils/function/requestAsBrowser">`requestAsBrowser()`</VersionedApiLink>
+The script simply downloads several web pages with plain HTTP requests using the <ApiLink to="utils/function/requestAsBrowser">`requestAsBrowser()`</ApiLink>
 convenience function and stores their raw HTML and URL in the default dataset. In local configuration, the data will be stored as JSON files in
 `./apify_storage/datasets/default`.
 

--- a/docs/examples/cheerio_crawler.mdx
+++ b/docs/examples/cheerio_crawler.mdx
@@ -4,12 +4,10 @@ title: Cheerio crawler
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import CheerioCrawlerSource from '!!raw-loader!./cheerio_crawler.ts';
 
-This example demonstrates how to use <VersionedApiLink apiPath="cheerio-crawler">`CheerioCrawler`</VersionedApiLink> to crawl a list of URLs from an external file, load each URL using
-a plain HTTP request, parse the HTML using the [Cheerio library](https://www.npmjs.com/package/cheerio) and extract some data from it: the page title
-and all `h1` tags.
+This example demonstrates how to use <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> to crawl a list of URLs from an external file, load each URL using a plain HTTP request, parse the HTML using the [Cheerio library](https://www.npmjs.com/package/cheerio) and extract some data from it: the page title and all `h1` tags.
 
 <CodeBlock className="language-js">
 	{CheerioCrawlerSource}

--- a/docs/examples/crawl_relative_links.mdx
+++ b/docs/examples/crawl_relative_links.mdx
@@ -6,30 +6,30 @@ title: Crawl a website with relative links
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 
 import AllLinksSource from '!!raw-loader!./crawl_relative_links_all.ts';
 import SameHostnameSource from '!!raw-loader!./crawl_relative_links_same_hostname.ts';
 import SameSubdomainSource from '!!raw-loader!./crawl_relative_links_same_subdomain.ts';
 
 When crawling a website, you may encounter different types of links present that you may want to crawl.
-To faciliate the easy crawling of such links, we provide the `enqueueLinks()` method on the crawler context, which will
-automatically find links and add them to the crawler's <VersionedApiLink apiPath="core/class/RequestQueue">`RequestQueue`</VersionedApiLink>.
+To facilitate the easy crawling of such links, we provide the `enqueueLinks()` method on the crawler context, which will
+automatically find links and add them to the crawler's <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>.
 
 We provide 3 different strategies for crawling relative links:
 
-- <VersionedApiLink apiPath="core/enum/EnqueueStrategy#All"><inlineCode>All</inlineCode></VersionedApiLink> which will enqueue all links found, regardless of
+- <ApiLink to="core/enum/EnqueueStrategy#All"><inlineCode>All</inlineCode></ApiLink> which will enqueue all links found, regardless of
 the domain they point to.
-- <VersionedApiLink apiPath="core/enum/EnqueueStrategy#SameHostname"><inlineCode>SameHostname</inlineCode></VersionedApiLink> which will enqueue all links
+- <ApiLink to="core/enum/EnqueueStrategy#SameHostname"><inlineCode>SameHostname</inlineCode></ApiLink> which will enqueue all links
 found for the same hostname (regardless of any subdomains present).
-- <VersionedApiLink apiPath="core/enum/EnqueueStrategy#SameSubdomain"><inlineCode>SameSubdomain</inlineCode></VersionedApiLink> which will enqueue all links
+- <ApiLink to="core/enum/EnqueueStrategy#SameSubdomain"><inlineCode>SameSubdomain</inlineCode></ApiLink> which will enqueue all links
 found that have the same subdomain and hostname. This is the default strategy.
 
 :::note
 
-For these examples, we are using the <VersionedApiLink apiPath="cheerio-crawler">`CheerioCrawler`</VersionedApiLink>, however
-the same method is available for both the <VersionedApiLink apiPath="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</VersionedApiLink>
-and <VersionedApiLink apiPath="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</VersionedApiLink>, and you use it
+For these examples, we are using the <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, however
+the same method is available for both the <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>
+and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>, and you use it
 the exact same way.
 
 :::

--- a/docs/examples/crawl_single_url.mdx
+++ b/docs/examples/crawl_single_url.mdx
@@ -4,14 +4,14 @@ title: Crawl a single URL
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./crawl_single_url.ts';
 
-This example uses the <VersionedApiLink apiPath="utils/function/requestAsBrowser">`requestAsBrowser()`</VersionedApiLink>
+This example uses the <ApiLink to="utils/function/requestAsBrowser">`requestAsBrowser()`</ApiLink>
 function to grab the HTML of a web page.
 
 <CodeBlock className="language-js">
 	{CrawlSource}
 </CodeBlock>
 
-If you don't want to hard-code the URL into the script, refer to the [Accept User Input](./basic/accept-user-input) example.
+If you don't want to hard-code the URL into the script, refer to the [Accept User Input](./accept-user-input) example.

--- a/docs/examples/crawl_some_links.mdx
+++ b/docs/examples/crawl_some_links.mdx
@@ -4,13 +4,10 @@ title: Crawl some links on a website
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./crawl_some_links.ts';
 
-This <VersionedApiLink apiPath="cheerio-crawler">`CheerioCrawler`</VersionedApiLink> example uses
-the <VersionedApiLink apiPath="core/class/PseudoUrl">`pseudoUrls`</VersionedApiLink> property in
-the <VersionedApiLink apiPath="cheerio-crawler/interface/CheerioHandlePageInputs#enqueueLinks">`enqueueLinks()`</VersionedApiLink> method
-to only add links to the <VersionedApiLink apiPath="core/class/RequestQueue">`RequestQueue`</VersionedApiLink> queue if they match the specified regular expression.
+This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="core/class/PseudoUrl">`pseudoUrls`</ApiLink> property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified regular expression.
 
 <CodeBlock className="language-js">
 	{CrawlSource}

--- a/docs/examples/forms.mdx
+++ b/docs/examples/forms.mdx
@@ -4,14 +4,14 @@ title: Forms
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./forms.ts';
 
-This example demonstrates how to use <VersionedApiLink apiPath="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</VersionedApiLink> to
+This example demonstrates how to use <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to
 automatically fill and submit a search form to look up repositories on [GitHub](https://github.com) using headless Chrome / Puppeteer.
 The actor first fills in the search term, repository owner, start date and language of the repository, then submits the form
 and prints out the results. Finally, the results are saved either on the Apify platform to the
-default <VersionedApiLink apiPath="core/class/Dataset">`dataset`</VersionedApiLink> or on the local machine as JSON files in `./apify_storage/datasets/default`.
+default <ApiLink to="core/class/Dataset">`dataset`</ApiLink> or on the local machine as JSON files in `./apify_storage/datasets/default`.
 
 :::tip
 

--- a/docs/examples/map_and_reduce.mdx
+++ b/docs/examples/map_and_reduce.mdx
@@ -4,13 +4,13 @@ title: Dataset Map and Reduce methods
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import MapSource from '!!raw-loader!./map.ts';
 import ReduceSource from '!!raw-loader!./reduce.ts';
 
-This example shows an easy use-case of the <VersionedApiLink apiPath="core/class/Dataset">`Dataset`</VersionedApiLink> <VersionedApiLink apiPath="core/class/Dataset#map">`map`</VersionedApiLink>
-and <VersionedApiLink apiPath="core/class/Dataset#reduce">`reduce`</VersionedApiLink> methods. Both methods can be used to simplify
-the dataset results workflow process. Both can be called on the <VersionedApiLink apiPath="core/class/Dataset">dataset</VersionedApiLink> directly.
+This example shows an easy use-case of the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> <ApiLink to="core/class/Dataset#map">`map`</ApiLink>
+and <ApiLink to="core/class/Dataset#reduce">`reduce`</ApiLink> methods. Both methods can be used to simplify
+the dataset results workflow process. Both can be called on the <ApiLink to="core/class/Dataset">dataset</ApiLink> directly.
 
 Important to mention is that both methods return a new result (`map` returns a new array and `reduce` can return any type) - neither method updates
 the dataset in any way.
@@ -19,7 +19,7 @@ Examples for both methods are demonstrated on a simple dataset containing the re
 `h1` - `h3` header elements under the `headingCount` key.
 
 This data structure is stored in the default dataset under `{PROJECT_FOLDER}/apify_storage/datasets/default/`. If you want to simulate the
-functionality, you can use the <VersionedApiLink apiPath="core/class/Dataset#pushData">`dataset.pushData()`</VersionedApiLink>
+functionality, you can use the <ApiLink to="core/class/Dataset#pushData">`dataset.pushData()`</ApiLink>
 method to save the example `JSON array` to your dataset.
 
 ```json
@@ -52,7 +52,7 @@ The `map` method used to check if are there more than 5 header elements on each 
 
 The `moreThan5headers` variable is an array of `headingCount` attributes where the number of headers is greater than 5.
 
-The `map` method's result value saved to the <VersionedApiLink apiPath="core/class/KeyValueStore">`key-value store`</VersionedApiLink> should be:
+The `map` method's result value saved to the <ApiLink to="core/class/KeyValueStore">`key-value store`</ApiLink> should be:
 
 ```javascript
 [11, 8]
@@ -61,7 +61,7 @@ The `map` method's result value saved to the <VersionedApiLink apiPath="core/cla
 ### Reduce
 
 The dataset `reduce` method does not produce a new array of values - it reduces a list of values down to a single value. The method iterates through
-the items in the dataset using the <VersionedApiLink apiPath="core/class/Dataset#reduce">`memo` argument</VersionedApiLink>. After performing the necessary
+the items in the dataset using the <ApiLink to="core/class/Dataset#reduce">`memo` argument</ApiLink>. After performing the necessary
 calculation, the `memo` is sent to the next iteration, while the item just processed is reduced (removed).
 
 Using the `reduce` method to get the total number of headers scraped (all items in the dataset):
@@ -73,7 +73,7 @@ Using the `reduce` method to get the total number of headers scraped (all items 
 The original dataset will be reduced to a single value, `pagesHeadingCount`, which contains the count of all headers for all scraped pages (all
 dataset items).
 
-The `reduce` method's result value saved to the <VersionedApiLink apiPath="core/class/KeyValueStore">`key-value store`</VersionedApiLink> should be:
+The `reduce` method's result value saved to the <ApiLink to="core/class/KeyValueStore">`key-value store`</ApiLink> should be:
 
 ```javascript
 23

--- a/docs/examples/playwright_crawler.mdx
+++ b/docs/examples/playwright_crawler.mdx
@@ -4,11 +4,11 @@ title: Playwright crawler
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./playwright_crawler.ts';
 
-This example demonstrates how to use <VersionedApiLink apiPath="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</VersionedApiLink>
-in combination with <VersionedApiLink apiPath="core/class/RequestQueue">`RequestQueue`</VersionedApiLink> to
+This example demonstrates how to use <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>
+in combination with <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> to
 recursively scrape the [Hacker News website](https://news.ycombinator.com) using headless Chrome / Playwright.
 
 The crawler starts with a single URL, finds links to next pages, enqueues them and continues until no more desired links are available. The results

--- a/docs/examples/puppeteer_capture_screenshot.mdx
+++ b/docs/examples/puppeteer_capture_screenshot.mdx
@@ -1,5 +1,5 @@
 ---
-id: puppeteer-capture-screenshot
+id: capture-screenshot
 title: Capture a screenshot using Puppeteer
 ---
 

--- a/docs/examples/puppeteer_crawler.mdx
+++ b/docs/examples/puppeteer_crawler.mdx
@@ -4,11 +4,11 @@ title: Puppeteer crawler
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./puppeteer_crawler.ts';
 
-This example demonstrates how to use <VersionedApiLink apiPath="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</VersionedApiLink> in combination
-with <VersionedApiLink apiPath="core/class/RequestQueue">`RequestQueue`</VersionedApiLink> 
+This example demonstrates how to use <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> in combination
+with <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>
 to recursively scrape the [Hacker News website](https://news.ycombinator.com) using headless Chrome / Puppeteer.
 
 The crawler starts with a single URL, finds links to next pages, enqueues them and continues until no more desired links are available. The results

--- a/docs/examples/puppeteer_recursive_crawl.mdx
+++ b/docs/examples/puppeteer_recursive_crawl.mdx
@@ -4,10 +4,10 @@ title: Puppeteer recursive crawl
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./puppeteer_recursive_crawl.ts';
 
-Run the following example to perform a recursive crawl of a website using <VersionedApiLink apiPath="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</VersionedApiLink>.
+Run the following example to perform a recursive crawl of a website using <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>.
 
 :::tip
 

--- a/docs/examples/use_stealth_mode.mdx
+++ b/docs/examples/use_stealth_mode.mdx
@@ -4,7 +4,7 @@ title: Use stealth mode
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import VersionedApiLink from '@site/src/components/VersionedApiLink';
+import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./use_stealth_mode.ts';
 
 Stealth mode allows you to bypass anti-scraping techniques that use
@@ -12,7 +12,7 @@ Stealth mode allows you to bypass anti-scraping techniques that use
 [headless](https://developers.google.com/web/updates/2017/04/headless-chrome) browser mode, making your headless browser harder to distinguish from
 the full Chrome browser.
 
-To activate stealth mode, you need to turn `useChrome` on, run `headless` and turn `stealth` on in your <VersionedApiLink apiPath="puppeteer-crawler/interface/PuppeteerCrawlerOptions#launchContext">`launchContext`</VersionedApiLink>.
+To activate stealth mode, you need to turn `useChrome` on, run `headless` and turn `stealth` on in your <ApiLink to="puppeteer-crawler/interface/PuppeteerCrawlerOptions#launchContext">`launchContext`</ApiLink>.
 
 ```js
 const launchContext = {
@@ -28,12 +28,12 @@ const launchContext = {
 	{CrawlSource}
 </CodeBlock>
 
-You can then specify the <VersionedApiLink apiPath="puppeteer-crawler/namespace/puppeteerStealth#StealthOptions">`stealthOptions`</VersionedApiLink> you want,
+You can then specify the <ApiLink to="puppeteer-crawler/namespace/puppeteerStealth#StealthOptions">`stealthOptions`</ApiLink> you want,
 which allow you to adapt to different anti-scraping techniques. All the options are set to `true` by default. The number of options does not affect performance.
 
 While the default configuration will be fine in many cases, you can adapt the options to your use case.
 
 ### Single-browser instances
 
-You can also use stealth mode in single-browser instances when using <VersionedApiLink apiPath="puppeteer-crawler/function/launchPuppeteer">`launchPuppeteer`</VersionedApiLink>.
+You can also use stealth mode in single-browser instances when using <ApiLink to="puppeteer-crawler/function/launchPuppeteer">`launchPuppeteer`</ApiLink>.
 The `launchContext` is the same.

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -3,6 +3,8 @@ id: apify-platform
 title: Apify Platform
 ---
 
+import ApiLink from '@site/src/components/ApiLink';
+
 Apify is a [platform](https://apify.com) built to serve large-scale and high-performance web scraping
 and automation needs. It provides easy access to [compute instances (Actors)](#what-is-an-actor),
 convenient [request](../guides/request-storage) and [result](../guides/result-storage) storages, [proxies](../guides/proxy-management),

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -3,7 +3,9 @@ id: docker-images
 title: Running in Docker
 ---
 
-Running headless browsers in Docker requires a lot of setup to do it right. But you don't need to worry about that, because we already did it for you and created base images that you can freely use. We use them every day on the [Apify Platform](../guides/apify_platform.md).
+import ApiLink from '@site/src/components/ApiLink';
+
+Running headless browsers in Docker requires a lot of setup to do it right. But you don't need to worry about that, because we already did it for you and created base images that you can freely use. We use them every day on the [Apify Platform](../guides/apify_platform.mdx).
 
 All images can be found in their [GitHub repo](https://github.com/apify/apify-actor-docker) and in our [DockerHub](https://hub.docker.com/orgs/apify).
 
@@ -20,7 +22,7 @@ Browsers are pretty big, so we try to provide a wide variety of images to suit y
 
 ## Example Dockerfile
 
-To use our images, you need a [`Dockerfile`](https://docs.docker.com/engine/reference/builder/). You can either use this example, or bootstrap your projects with the [Apify CLI](./getting_started.md#creating-a-new-project) which automatically copies the correct Dockerfile into your project folder.
+To use our images, you need a [`Dockerfile`](https://docs.docker.com/engine/reference/builder/). You can either use this example, or bootstrap your projects with the [Apify CLI](./getting_started.mdx#creating-a-new-project) which automatically copies the correct Dockerfile into your project folder.
 
 ```dockerfile
 # First, specify the base Docker image. You can read more about
@@ -126,11 +128,9 @@ Use only what you need, and you'll be rewarded with reasonable build and start t
 
 ## actor-node
 
-This is the smallest image we have based on Alpine Linux. It does not include any browsers, and it's therefore
-best used with [`CheerioCrawler`](../api/cheerio-crawler). It benefits from lightning fast builds and container startups.
+This is the smallest image we have based on Alpine Linux. It does not include any browsers, and it's therefore best used with <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>. It benefits from lightning fast builds and container startups.
 
-[`PuppeteerCrawler`](../api/puppeteer-crawler), [`PlaywrightCrawler`](../api/playwright-crawler)
-and other browser based features will **NOT** work with this image.
+<ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PuppeteerCrawler`](../api/puppeteer-crawler), [`PlaywrightCrawler`</ApiLink> and other browser based features will **NOT** work with this image.
 
 ```dockerfile
 FROM apify/actor-node:16
@@ -139,8 +139,7 @@ FROM apify/actor-node:16
 ## actor-node-puppeteer-chrome
 
 This image includes Puppeteer (Chromium) and the Chrome browser. It can be used with
-[`CheerioCrawler`](../api/cheerio-crawler) and [`PuppeteerCrawler`](../api/puppeteer-crawler), but **NOT** with
-[`PlaywrightCrawler`](../api/playwright-crawler).
+<ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`CheerioCrawler`](../api/cheerio-crawler) and [`PuppeteerCrawler`</ApiLink>, but **NOT** with <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
 
 The image supports XVFB by default, so you can run both `headless` and `headful` browsers with it.
 
@@ -150,9 +149,7 @@ FROM apify/actor-node-puppeteer-chrome:16
 
 ## actor-node-playwright
 
-A very large and slow image that can run all Playwright browsers: Chromium, Chrome, Firefox,
-WebKit. Everything is installed. If you need to develop or test with multiple browsers, this is the image to choose,
-but in most cases, we suggest using the specialized images below.
+A very large and slow image that can run all Playwright browsers: Chromium, Chrome, Firefox, WebKit. Everything is installed. If you need to develop or test with multiple browsers, this is the image to choose, but in most cases, we suggest using the specialized images below.
 
 ```dockerfile
 FROM apify/actor-node-playwright:16
@@ -161,8 +158,7 @@ FROM apify/actor-node-playwright:16
 ## actor-node-playwright-chrome
 
 Similar to [`actor-node-puppeteer-chrome`](#actor-node-puppeteer-chrome), but for Playwright. You can run
-[`CheerioCrawler`](../api/cheerio-crawler) and [`PlaywrightCrawler`](../api/playwright-crawler),
-but **NOT** [`PuppeteerCrawler`](../api/puppeteer-crawler).
+<ApiLink to="cheerio-crawler/class/CheerioCrawler">`PlaywrightCrawler`</ApiLink> and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>, but **NOT** <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>.
 
 It uses the [`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`](https://playwright.dev/docs/api/environment-variables/)
 environment variable to block installation of more browsers into your images (to keep them small).

--- a/docs/guides/environment_variables.mdx
+++ b/docs/guides/environment_variables.mdx
@@ -3,6 +3,8 @@ id: environment-variables
 title: Environment Variables
 ---
 
+import ApiLink from '@site/src/components/ApiLink';
+
 The following is a list of the environment variables used by Apify SDK that are available to the user.
 The SDK is capable of running without any env vars present, but certain features will only become available
 after env vars are properly set. You can use [Apify CLI](https://github.com/apify/apify-cli)
@@ -15,10 +17,7 @@ can be changed significantly by setting or unsetting them.
 
 ### `APIFY_LOCAL_STORAGE_DIR`
 
-Defines the path to a local directory where [`KeyValueStore`](../api/key-value-store),
-[`Dataset`](../api/dataset), and [`RequestQueue`](../api/request-queue) store their data.
-Typically it is set to `./apify_storage`. If omitted, you should define the [`APIFY_TOKEN`](#apify_token)
-environment variable instead.
+Defines the path to a local directory where <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="core/class/Dataset">`Dataset`</ApiLink>, and <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> store their data. Typically, it is set to `./apify_storage`. If omitted, you should define the [`APIFY_TOKEN`](#apify_token) environment variable instead.
 
 ### `APIFY_TOKEN`
 
@@ -42,8 +41,8 @@ features and your data will be stored locally by default. If you want to access 
 you can use the `{ forceCloud: true }` option in their respective functions.
 
 ```js
-const localDataset = await Apify.openDataset('my-local-data');
-const remoteDataset = await Apify.openDataset('my-remote-data', { forceCloud: true });
+const localDataset = await Actor.openDataset('my-local-data');
+const remoteDataset = await Actor.openDataset('my-remote-data', { forceCloud: true });
 ```
 
 ## Convenience env vars
@@ -55,7 +54,7 @@ your code, such as temporarily switching log level to DEBUG.
 
 If set to `1`, web browsers launched by Apify SDK will run in the headless mode. You can still override
 this setting in the code, e.g. by passing the `headless: true` option to the
-[`Apify.launchPuppeteer()`](../api/apify#launchpuppeteer) function. But having this setting
+<ApiLink to="apify/class/Actor#launchPuppeteer">`Actor.launchPuppeteer()`</ApiLink> function. But having this setting
 in an environment variable allows you to develop the crawler locally in headful mode to simplify the debugging,
 and only run the crawler in headless mode once you deploy it to the Apify platform. By default, the browsers
 are launched in headful mode, i.e. with windows.
@@ -64,14 +63,14 @@ are launched in headful mode, i.e. with windows.
 
 Specifies the minimum log level, which can be one of the following values (in order of severity):
 `DEBUG`, `INFO`, `WARNING` and `ERROR`. By default, the log level is set to `INFO`,
-which means that `DEBUG` messages are not printed to console. See the [`utils.log`](../api/log)
+which means that `DEBUG` messages are not printed to console. See the <ApiLink to="core/class/Log">`utils.log`</ApiLink>
 namespace for logging utilities.
 
 ### `APIFY_MEMORY_MBYTES`
 
-Sets the amount of system memory in megabytes to be used by the [`AutoscaledPool`](../api/autoscaled-pool).
+Sets the amount of system memory in megabytes to be used by the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink>.
 It is used to limit the number of concurrently running tasks. By default, the max amount of memory
-to be used is set to one quarter of total system memory, i. e. on a system with 8192 MB of memory,
+to be used is set to one quarter of total system memory, i.e. on a system with 8192 MB of memory,
 the autoscaling feature will only use up to 2048 MB of memory.
 
 ### `APIFY_PROXY_PASSWORD`

--- a/docs/guides/getting_started.mdx
+++ b/docs/guides/getting_started.mdx
@@ -3,6 +3,9 @@ id: getting-started
 title: Getting Started
 ---
 
+
+import ApiLink from '@site/src/components/ApiLink';
+
 Without the right tools, crawling and scraping the web can be difficult. At the very least, you need an HTTP client to make the necessary
 requests, but that only gets you raw HTML and sometimes not even that. Then you have to read this HTML and extract the data you're interested in. Once
 extracted, it must be stored in a machine-readable format and easily accessible for further processing, because it is the processed data that holds
@@ -26,10 +29,10 @@ environment and let's get into it.
 To run Apify SDK on your own computer, you need to meet the following pre-requisites first:
 
 1. Have Node.js version 10.17 or higher, with the exception of Node.js 11, installed.
-    - Visit [Node.js website](https://nodejs.org/en/download/) to download or use
-      [nvm](https://github.com/creationix/nvm)
+ - Visit [Node.js website](https://nodejs.org/en/download/) to download or use
+[nvm](https://github.com/creationix/nvm)
 2. Have NPM installed.
-    - NPM comes bundled with Node.js so you should already have it. If not, reinstall Node.js.
+ - NPM comes bundled with Node.js so you should already have it. If not, reinstall Node.js.
 
 If you're not certain, confirm the prerequisites by running:
 
@@ -128,7 +131,7 @@ introduce all the Apify SDK classes necessary to make it happen.
 
 ### The general idea
 
-There are 4 crawler classes available for use in the Apify SDK. [`BasicCrawler`](../api/basic-crawler), [`CheerioCrawler`](../api/cheerio-crawler), [`PuppeteerCrawler`](../api/puppeteer-crawler) and [`PlaywrightCrawler`](../api/playwright-crawler). We'll talk about their differences later. Now, let's talk about what they have in common.
+There are 4 crawler classes available for use in the Apify SDK. <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>, <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. We'll talk about their differences later. Now, let's talk about what they have in common.
 
 The general idea of each crawler is to go to a web page, open it, do some stuff there, save some results and continue to the next page, until it's done
 its job. So the crawler always needs to find answers to two questions: **Where should I go?** and **What should I do there?** Answering those two
@@ -136,16 +139,16 @@ questions is the only setup mandatory for running the crawlers.
 
 ### The Where - `Request`, `RequestList` and `RequestQueue`
 
-All crawlers use instances of the [`Request`](../api/request) class to determine where they need to go. Each request may hold a lot of information,
+All crawlers use instances of the <ApiLink to="core/class/Request">`Request`</ApiLink> class to determine where they need to go. Each request may hold a lot of information,
 but at the very least, it must hold a URL - a web page to open. But having only one URL would not make sense for crawling. We need to either have a
 pre-existing list of our own URLs that we wish to visit, perhaps a thousand, or a million, or we need to build this list dynamically as we crawl,
 adding more and more URLs to the list as we progress.
 
-A representation of the pre-existing list is an instance of the [`RequestList`](../api/request-list) class. It is a static, immutable list of URLs and
-other metadata (see the [`Request`](../api/request) object) that the crawler will visit, one by one, retrying whenever an error occurs, until there
+A representation of the pre-existing list is an instance of the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class. It is a static, immutable list of URLs and
+other metadata (see the <ApiLink to="core/class/Request">`Request`</ApiLink> object) that the crawler will visit, one by one, retrying whenever an error occurs, until there
 are no more `Requests` to process.
 
-[`RequestQueue`](../api/request-queue) on the other hand, represents a dynamic queue of `Requests`. One that can be updated at runtime by adding more
+<ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> on the other hand, represents a dynamic queue of `Requests`. One that can be updated at runtime by adding more
 pages - `Requests` to process. This allows the crawler to open one page, extract interesting URLs, such as links to other pages on the same domain,
 add them to the queue (called _enqueuing_) and repeat this process to build a queue of tens of thousands or more URLs while knowing only a single one
 at the beginning.
@@ -158,11 +161,7 @@ crawlers. At least one of them always needs to be provided while setting up. You
 The `handlePageFunction` is the brain of the crawler. It tells it what to do at each and every page it visits. Generally it handles extraction of data
 from the page, processing the data, saving it, calling APIs, doing calculations and whatever else you need it to do.
 
-The `handlePageFunction` is provided by you, the user, and invoked automatically by the crawler for each `Request` from either the `RequestList` or
-`RequestQueue`. It always receives a single argument and that is a plain `Object`. Its properties change depending on the crawler class used, but it
-always includes at least the `request` property, which represents the currently crawled `Request` instance (i.e. the URL the crawler is visiting and
-related metadata) and the `autoscaledPool` property, which is an instance of the [`AutoscaledPool`](../api/autoscaled-pool) class and we'll talk about
-it in detail later.
+The `handlePageFunction` is provided by you, the user, and invoked automatically by the crawler for each `Request` from either the `RequestList` or `RequestQueue`. It always receives a single argument and that is a plain `Object`. Its properties change depending on the crawler class used, but it always includes at least the `request` property, which represents the currently crawled `Request` instance (i.e. the URL the crawler is visiting and related metadata) and the `autoscaledPool` property, which is an instance of the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink> class and we'll talk about it in detail later.
 
 ```js
 // The object received as a single argument by the handlePageFunction
@@ -174,14 +173,12 @@ it in detail later.
 
 ### Putting it all together
 
-Enough theory! Let's put some of those hard-learned facts into practice. We learned above that we need `Requests` and a `handlePageFunction` to setup
-a crawler. We will also use the [`Apify.main()`](../api/apify#main) function. It's not mandatory, but it makes our life easier. We'll
-learn about it in detail later on.
+Enough theory! Let's put some of those hard-learned facts into practice. We learned above that we need `Requests` and a `handlePageFunction` to setup a crawler. We will also use the <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> function. It's not mandatory, but it makes our life easier. We'll learn about it in detail later on.
 
 Let's start with something super easy. Visit a page, get its title and close. First of all we need to require Apify, to make all of its features available to us:
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 ```
 
 Easy, right? It really doesn't get much more difficult than that. For the purposes of this tutorial, we'll be scraping our own webpage
@@ -189,12 +186,12 @@ Easy, right? It really doesn't get much more difficult than that. For the purpos
 `RequestList` or `RequestQueue`. Let's go with `RequestQueue` for now.
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 
-// This is how you use the Apify.main() function.
-Apify.main(async () => {
+// This is how you use the Actor.main() function.
+Actor.main(async () => {
     // First we create the request queue instance.
-    const requestQueue = await Apify.openRequestQueue();
+    const requestQueue = await RequestQueue.open();
     // And then we add a request to it.
     await requestQueue.addRequest({ url: 'https://apify.com' });
 });
@@ -203,7 +200,7 @@ Apify.main(async () => {
 > If you're not familiar with the `async` and `await` keywords used in the example, you should know that these are native syntax in modern JavaScript. You can
 > [learn more about them here](https://nikgrozev.com/2017/10/01/async-await/).
 
-The [`requestQueue.addRequest()`](../api/request-queue#addrequest) function automatically converts the plain object we passed to it to a
+The <ApiLink to="core/class/RequestQueue#addRequest">`requestQueue.addRequest()`</ApiLink> function automatically converts the plain object we passed to it to a
 `Request` instance, so now we have a `requestQueue` that holds one `request` which points to `https://apify.com`. Now we need the
 `handlePageFunction`.
 
@@ -223,10 +220,10 @@ will always have a `request` property, but it will also have other properties, d
 by the `CheerioCrawler` class, which we'll set up right now.
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 
-Apify.main(async () => {
-    const requestQueue = await Apify.openRequestQueue();
+Actor.main(async () => {
+    const requestQueue = await RequestQueue.open();
     await requestQueue.addRequest({ url: 'https://apify.com' });
 
     const handlePageFunction = async ({ request, $ }) => {
@@ -236,7 +233,7 @@ Apify.main(async () => {
     };
 
     // Set up the crawler, passing a single options object as an argument.
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         requestQueue,
         handlePageFunction,
     });
@@ -254,28 +251,28 @@ created earlier and run `apify run` from that project's directory.
 To run the code on Apify Platform, just replace the original example with your new code and hit Run.
 
 Whichever environment you choose, you should see the message
-`The title of "https://apify.com" is: Web Scraping, Data Extraction and Automation - Apify.` printed to the screen. If you do, congratulations and
+`The title of "https://apify.com" is: Web Scraping, Data Extraction and Automation - Actor.` printed to the screen. If you do, congratulations and
 let's move onto some bigger challenges! And if you feel like you don't really know what just happened there, no worries, it will all become clear when
 you learn more about `CheerioCrawler`.
 
 ## CheerioCrawler aka jQuery crawler
 
 This is the crawler that we used in our earlier example. Our simplest and also the fastest crawling solution. If you're familiar with `jQuery`, you'll
-understand [`CheerioCrawler`](../api/cheerio-crawler) in minutes. [Cheerio](https://www.npmjs.com/package/cheerio) is
+understand <ApiLink to="cheerio-crawler/class/CheerioCrawler">CheerioCrawler</ApiLink> in minutes. [`Cheerio`](https://www.npmjs.com/package/cheerio) is
 essentially `jQuery` for Node.js. It offers the same API, including the familiar `$` object. You can use it, as you would `jQuery`, for manipulating
-the DOM of a HTML page. In crawling, you'll mostly use it to select the right elements and extract their text values - the data you're interested in.
+the DOM of an HTML page. In crawling, you'll mostly use it to select the right elements and extract their text values - the data you're interested in.
 But `jQuery` runs in a browser and attaches directly to the browser's DOM. Where does `cheerio` get its HTML? This is where the `Crawler` part of
-[`CheerioCrawler`](../api/cheerio-crawler) comes in.
+<ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> comes in.
 
 ### Overview
 
-[`CheerioCrawler`](../api/cheerio-crawler) crawls by making plain HTTP requests to the provided URLs. As you remember from the previous section, the
-URLs are fed to the crawler using either the [`RequestList`](../api/cheerio-crawler) or the [`RequestQueue`](../api/cheerio-crawler). The HTTP responses
+<ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> crawls by making plain HTTP requests to the provided URLs. As you remember from the previous section, the
+URLs are fed to the crawler using either the <ApiLink to="cheerio-crawler/class/CheerioCrawler">`RequestList`](../api/cheerio-crawler) or the [`RequestQueue`</ApiLink>. The HTTP responses
 it gets back are HTML pages, the same pages you would get in your browser when you first load a URL.
 
 > Note, however, that modern web pages often do not serve all of their content in the first HTML response, but rather the first HTML contains links to
 > other resources such as CSS and JavaScript that get downloaded afterwards and together they create the final page. See our
-> [`PuppeteerCrawler`](../api/puppeteer-crawler) to crawl those.
+<ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to crawl those.
 
 Once the page's HTML is retrieved, the crawler will pass it to [Cheerio](https://www.npmjs.com/package/cheerio) for
 parsing. The result is the typical `$` function, which should be familiar to `jQuery` users. You can use this `$` to do all sorts of lookups and
@@ -304,9 +301,9 @@ Even though using `CheerioCrawler` is extremely easy, it probably will not be yo
 environments. Since most websites nowadays use modern JavaScript to create rich, responsive and data-driven user experiences, the plain HTTP requests
 the crawler uses may just fall short of your needs.
 
-But [`CheerioCrawler`](../api/cheerio-crawler) is far from useless! It really shines when you need to cope with extremely high workloads. With just 4 GBs of memory and a single CPU
+But <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> is far from useless! It really shines when you need to cope with extremely high workloads. With just 4 GBs of memory and a single CPU
 core, you can scrape 500 or more pages a minute! _(assuming each page contains approximately 400KB of HTML)_ To scrape this fast with a full browser
-scraper, such as the [`PuppeteerCrawler`](../api/puppeteer-crawler), you'd need significantly more computing power.
+scraper, such as the <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>, you'd need significantly more computing power.
 
 **Advantages:**
 
@@ -333,10 +330,10 @@ Just to refresh your memory, in the previous section we built a very simple craw
 it to the console. This is the original source code:
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 
-Apify.main(async () => {
-    const requestQueue = await Apify.openRequestQueue();
+Actor.main(async () => {
+    const requestQueue = await RequestQueue.open();
     await requestQueue.addRequest({ url: 'https://apify.com' });
 
     const handlePageFunction = async ({ request, $ }) => {
@@ -346,7 +343,7 @@ Apify.main(async () => {
     };
 
     // Set up the crawler, passing a single options object as an argument.
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         requestQueue,
         handlePageFunction,
     });
@@ -379,11 +376,11 @@ const links = $('a[href]')
 Our new function finds all the `<a>` elements that contain the `href` attribute and extracts the attributes into an array of strings. But there's a problem. There could be relative links in the list and those can't be used on their own. We need to resolve them using our domain as base URL and
 we will use one of Node.js' standard libraries to do this.
 
-Apify exposes two URL properties: [`request.url`](../api/request#url) and [`request.loadedUrl`](../api/request#loadedurl). What's the difference? Well, `request.url` is the URL of the first request. In case of redirects, the URL changes. The final one is stored as `request.loadedUrl`.
+Apify exposes two URL properties: <ApiLink to="core/class/Request#url">`request.url`</ApiLink> and <ApiLink to="core/class/Request#loadedUrl">`request.loadedUrl`</ApiLink>. What's the difference? Well, `request.url` is the URL of the first request. In case of redirects, the URL changes. The final one is stored as `request.loadedUrl`.
 
 ```js
 // At the top of the file:
-const { URL } = require('url');
+import { URL } from 'url';
 
 // ...
 
@@ -401,7 +398,7 @@ keep the ones that lead to the same domain.
 
 ```js
 // At the top of the file:
-const { URL } = require('url');
+import { URL } from 'url';
 
 // ...
 
@@ -435,7 +432,7 @@ links. This will add them to the end of the queue for processing.
 
 ```js
 // At the top of the file:
-const { URL } = require('url');
+import { URL } from 'url';
 
 // ...
 
@@ -471,7 +468,7 @@ very useful when you're just testing your code or when your crawler could potent
 add it to the crawler options like this:
 
 ```js
-const crawler = new Apify.CheerioCrawler({
+const crawler = new CheerioCrawler({
     maxRequestsPerCrawl: 20,
     requestQueue,
     handlePageFunction,
@@ -485,11 +482,11 @@ will be allowed to finish too.
 #### Putting it all together
 
 ```js
-const { URL } = require('url'); // <------ This is new.
-const Apify = require('apify');
+import { URL } from 'url'; // <------ This is new.
+import { Actor } from 'apify';
 
-Apify.main(async () => {
-    const requestQueue = await Apify.openRequestQueue();
+Actor.main(async () => {
+    const requestQueue = await RequestQueue.open();
     await requestQueue.addRequest({ url: 'https://apify.com' });
 
     const handlePageFunction = async ({ request, $ }) => {
@@ -512,7 +509,7 @@ Apify.main(async () => {
         }
     };
 
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         maxRequestsPerCrawl: 20, // <------ This is new too.
         requestQueue,
         handlePageFunction,
@@ -539,13 +536,13 @@ Well, the obvious reason is practice. This is a tutorial after all. The other re
 together, so that in the end, a new page, not previously entered in by you, can be scraped. We think that by seeing the bigger picture, you will be
 able to get the most out of Apify SDK.
 
-### Meet `Apify.utils`
+### Meet `Actor.utils`
 
-We will talk at length about them later, but in short, `Apify.utils` is a namespace where you can find various helpful functions and constants that
-make your life easier. One of the available functions is `Apify.utils.enqueueLinks()` which encapsulates the whole enqueueing process and even adds
+We will talk at length about them later, but in short, `Actor.utils` is a namespace where you can find various helpful functions and constants that
+make your life easier. One of the available functions is `Actor.utils.enqueueLinks()` which encapsulates the whole enqueueing process and even adds
 some extra functionality.
 
-### Introduction to `Apify.utils.enqueueLinks()`
+### Introduction to `Actor.utils.enqueueLinks()`
 
 Since enqueuing new links to crawl is such an integral part of web crawling, we created a function that attempts to simplify this process as much as
 possible. With a single function call, it allows you to find all the links on a page that match specified criteria and add them to a `RequestQueue`.
@@ -553,13 +550,13 @@ It also allows you to modify the resulting `Requests` to match your crawling nee
 
 `enqueueLinks` is quite a powerful function so, like crawlers, it gets its arguments from an options object. This is useful, because you don't have to
 remember their order! But also because we can easily extend its API and add new features. You can
-[find the full reference here](../api/utils#enqueuelinks).
+<ApiLink to="utils#enqueuelinks">find the full reference here</ApiLink>.
 
-We suggest using ES6 destructuring to grab the `enqueueLinks()` function off of the `utils` object, so you don't have to type `Apify.utils` all the
+We suggest using ES6 destructuring to grab the `enqueueLinks()` function off of the `utils` object, so you don't have to type `Actor.utils` all the
 time.
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 const {
     utils: { enqueueLinks },
 } = Apify;
@@ -682,7 +679,7 @@ That's been quite a lot of theory and examples. We might as well put it to pract
 two arguments. The source, in our case the `$` object, and the destination - the `requestQueue`. To filter links, we need to add a third argument:
 `pseudoUrls`.
 
-The `options.pseudoUrls` argument is always an `Array`, but its contents can take on many forms. [See the reference](../api/utils#enqueueLinks)
+The `options.pseudoUrls` argument is always an `Array`, but its contents can take on many forms. <ApiLink to="utils#enqueueLinks">See the reference</ApiLink>
 for all of them. Since we just need to filter out same domain links, we'll keep it simple and use a pseudo-URL `string`.
 
 ```js
@@ -743,11 +740,11 @@ That was fairly easy, wasn't it. That ticks number 2 off our list and we're done
 enqueued all the links manually.
 
 ```js
-const { URL } = require('url'); // <------ This is new.
-const Apify = require('apify');
+import { URL } from 'url'; // <------ This is new.
+import { Actor } from 'apify';
 
-Apify.main(async () => {
-    const requestQueue = await Apify.openRequestQueue();
+Actor.main(async () => {
+    const requestQueue = await RequestQueue.open();
     await requestQueue.addRequest({ url: 'https://apify.com' });
 
     const handlePageFunction = async ({ request, $ }) => {
@@ -770,7 +767,7 @@ Apify.main(async () => {
         }
     };
 
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         maxRequestsPerCrawl: 20, // <------ This is new too.
         requestQueue,
         handlePageFunction,
@@ -783,13 +780,13 @@ Apify.main(async () => {
 Since we've already prepared the `enqueueLinks()` options, we can just replace all the above enqueuing logic with a single function call, as promised.
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 const {
     utils: { enqueueLinks },
 } = Apify;
 
-Apify.main(async () => {
-    const requestQueue = await Apify.openRequestQueue();
+Actor.main(async () => {
+    const requestQueue = await RequestQueue.open();
     await requestQueue.addRequest({ url: 'https://apify.com' });
 
     const handlePageFunction = async ({ request, $ }) => {
@@ -806,7 +803,7 @@ Apify.main(async () => {
         console.log(`Enqueued ${enqueued.length} URLs.`);
     };
 
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         maxRequestsPerCrawl: 20,
         requestQueue,
         handlePageFunction,
@@ -820,8 +817,8 @@ And that's it! No more parsing the links from HTML using Cheerio, filtering them
 `enqueueLinks()` is just one example of Apify SDK's powerful helper functions. They're all designed to make your life easier so you can focus on
 getting your data, while leaving the mundane crawling management to your tools.
 
-`Apify.utils.enqueueLinks()` has a lot more tricks up its sleeve. Make sure to check out the
-[reference documentation](../api/utils#enqueueLinks) to see what else it can do for you. Namely the feature to prepopulate the `Request`
+`Actor.utils.enqueueLinks()` has a lot more tricks up its sleeve. Make sure to check out the
+<ApiLink to="utils#enqueueLinks">reference documentation</ApiLink> to see what else it can do for you. Namely the feature to prepopulate the `Request`
 instances it creates with `userData` of your choice is extremely useful!
 
 ## Getting some real-world data
@@ -940,10 +937,10 @@ const sources = [
     'https://apify.com/store?category=ENTERTAINMENT',
 ];
 
-const requestList = await Apify.openRequestList('categories', sources);
+const requestList = await RequestList.open('categories', sources);
 ```
 
-As you can see, similarly to the `Apify.openRequestQueue()` function, there is an `Apify.openRequestList()` function that will create a `RequestList`
+As you can see, similarly to the `RequestQueue.open()` function, there is an `RequestList.open()` function that will create a `RequestList`
 instance for you. The first argument is the name of the `RequestList`. It is used to persist the crawling state of the list. This is useful when you
 want to continue where you left off after an error or a process restart. The second argument is the `sources` array, which is nothing more than a list
 of URLs you wish to crawl.
@@ -961,7 +958,7 @@ answer to the second one is simple. `RequestList` and `RequestQueue` are made to
 use them both and the crawlers will do the rest.
 
 ```js
-const crawler = new Apify.CheerioCrawler({
+const crawler = new CheerioCrawler({
     requestList,
     requestQueue,
     handlePageFunction,
@@ -983,18 +980,18 @@ the category URLs we selected and print the text content of all the actors in th
 You should see, albeit very badly formatted, the text of the individual actor cards that are displayed in the selected categories.
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 
-Apify.main(async () => {
+Actor.main(async () => {
     const sources = [
         'https://apify.com/store?category=TRAVEL',
         'https://apify.com/store?category=ECOMMERCE',
         'https://apify.com/store?category=ENTERTAINMENT',
     ];
 
-    const requestList = await Apify.openRequestList('categories', sources);
+    const requestList = await RequestList.open('categories', sources);
 
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         requestList,
         handlePageFunction: async ({ $, request }) => {
             // Select all the actor cards.
@@ -1055,7 +1052,7 @@ You will see that only the actor cards will be returned, and nothing else.
 
 #### Enqueueing the detail links using a custom selector
 
-In the previous chapter, we used the `Apify.utils.enqueueLinks()` function like this:
+In the previous chapter, we used the `Actor.utils.enqueueLinks()` function like this:
 
 ```js
 await enqueueLinks({
@@ -1076,7 +1073,7 @@ const handlePageFunction = async ({ $, request }) => {
 
     // Only enqueue new links from the category pages.
     if (!request.userData.detailPage) {
-        await Apify.utils.enqueueLinks({
+        await Actor.utils.enqueueLinks({
             $,
             requestQueue,
             selector: 'div.item > a',
@@ -1123,19 +1120,19 @@ with a `RequestList`, because we were not enqueueing anything, don't forget to a
 test it out!
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 
-Apify.main(async () => {
+Actor.main(async () => {
     const sources = [
         'https://apify.com/store?category=TRAVEL',
         'https://apify.com/store?category=ECOMMERCE',
         'https://apify.com/store?category=ENTERTAINMENT',
     ];
 
-    const requestList = await Apify.openRequestList('categories', sources);
-    const requestQueue = await Apify.openRequestQueue(); // <----------------
+    const requestList = await RequestList.open('categories', sources);
+    const requestQueue = await RequestQueue.open(); // <----------------
 
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         maxRequestsPerCrawl: 50, // <----------------------------------------
         requestList,
         requestQueue, // <---------------------------------------------------
@@ -1144,7 +1141,7 @@ Apify.main(async () => {
 
             // Only enqueue new links from the category pages.
             if (!request.userData.detailPage) {
-                await Apify.utils.enqueueLinks({
+                await Actor.utils.enqueueLinks({
                     $,
                     requestQueue,
                     selector: 'div.item > a',
@@ -1335,19 +1332,19 @@ console.log('RESULTS: ', results);
 We have everything we need so just grab our newly created scraping logic, dump it into our original `handlePageFunction()` and see the magic happen!
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 
-Apify.main(async () => {
+Actor.main(async () => {
     const sources = [
         'https://apify.com/store?category=TRAVEL',
         'https://apify.com/store?category=ECOMMERCE',
         'https://apify.com/store?category=ENTERTAINMENT',
     ];
 
-    const requestList = await Apify.openRequestList('categories', sources);
-    const requestQueue = await Apify.openRequestQueue();
+    const requestList = await RequestList.open('categories', sources);
+    const requestQueue = await RequestQueue.open();
 
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         maxRequestsPerCrawl: 50,
         requestList,
         requestQueue,
@@ -1381,7 +1378,7 @@ Apify.main(async () => {
 
             // Only enqueue new links from the category pages.
             if (!request.userData.detailPage) {
-                await Apify.utils.enqueueLinks({
+                await Actor.utils.enqueueLinks({
                     $,
                     requestQueue,
                     selector: 'div.item > a',
@@ -1412,25 +1409,25 @@ this chapter so make sure to pay attention very carefully!
 First, replace the `console.log('RESULTS', results)` call with
 
 ```js
-await Apify.pushData(results);
+await Actor.pushData(results);
 ```
 
 and that's it. Unlike in the previous paragraph, I'm being serious now. That's it, we're done. The final code therefore looks exactly like this:
 
 ```js
-const Apify = require('apify');
+import { Actor } from 'apify';
 
-Apify.main(async () => {
+Actor.main(async () => {
     const sources = [
         'https://apify.com/store?category=TRAVEL',
         'https://apify.com/store?category=ECOMMERCE',
         'https://apify.com/store?category=ENTERTAINMENT',
     ];
 
-    const requestList = await Apify.openRequestList('categories', sources);
-    const requestQueue = await Apify.openRequestQueue();
+    const requestList = await RequestList.open('categories', sources);
+    const requestQueue = await RequestQueue.open();
 
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         maxRequestsPerCrawl: 50,
         requestList,
         requestQueue,
@@ -1459,12 +1456,12 @@ Apify.main(async () => {
                             .replace(',', ''),
                     ),
                 };
-                await Apify.pushData(results);
+                await Actor.pushData(results);
             }
 
             // Only enqueue new links from the category pages.
             if (!request.userData.detailPage) {
-                await Apify.utils.enqueueLinks({
+                await Actor.utils.enqueueLinks({
                     $,
                     requestQueue,
                     selector: 'div.item > a',
@@ -1482,11 +1479,9 @@ Apify.main(async () => {
 });
 ```
 
-#### What's `Apify.pushData()`
+#### What's `Actor.pushData()`
 
-[`Apify.pushData()`](../api/apify#pushdata) is a helper function that saves data to the default [`Dataset`](../api/dataset). `Dataset` is a
-storage designed to hold virtually unlimited amount of data in a format similar to a table. Each time you call `Apify.pushData()` a new row in the
-table is created, with the property names serving as column titles.
+<ApiLink to="core/class/Dataset#pushData">`Actor.pushData()`</ApiLink> is a helper function that saves data to the default <ApiLink to="core/class/Dataset">`Dataset`</ApiLink>. `Dataset` is a storage designed to hold virtually unlimited amount of data in a format similar to a table. Each time you call `Actor.pushData()` a new row in the table is created, with the property names serving as column titles.
 
 > Each actor run has one default `Dataset` so no need to initialize it or create an instance first. It just gets done automatically for you. You can
 > also create named datasets at will.
@@ -1511,7 +1506,7 @@ this tutorial anyway, you'll find your data in your local Apify Storage.
 ```
 
 The above folder will hold all your saved data in numbered files, as they were pushed into the dataset. Each file represents one invocation of
-`Apify.pushData()` or one table row.
+`Actor.pushData()` or one table row.
 
 > Unfortunately, the local datasets don't yet support the export in various formats functionality that the Platform Dataset page offers, so for the
 > time being, we're stuck with JSON.
@@ -1529,17 +1524,17 @@ actor code.
 #### Meet the `INPUT`
 
 `INPUT` is just a convention on how we call the actor's input. Because there's no magic in actors, just features, the `INPUT` is actually nothing more
-than a key in the default [`KeyValueStore`](../api/key-value-store) that's, by convention, used as input on the Apify platform. Also by convention, the
+than a key in the default <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink> that's, by convention, used as input on the Apify platform. Also by convention, the
 `INPUT` is mostly expected to be of `Content-Type: application/json`.
 
 We will not go into `KeyValueStore` details here, but for the sake of `INPUT` you need to remember that there is a function that helps you get it.
 
 ```js
-const input = await Apify.getInput();
+const input = await Actor.getInput();
 ```
 
 On the Apify Platform, the actor's input that you can set in the Console is automatically saved to the default `KeyValueStore` under the key `INPUT`
-and by calling [`Apify.getInput()`](../api/apify#getvalue) you retrieve the value from the `KeyValueStore`.
+and by calling <ApiLink to="apify/class/Actor#getvalue">`Actor.getInput()`</ApiLink> you retrieve the value from the `KeyValueStore`.
 
 Running locally, you need to place an `INPUT.json` file in your default key value store for this to work.
 
@@ -1566,7 +1561,7 @@ automatically contain this `userData`.
 
 ```js
 // ...
-const input = await Apify.getInput();
+const input = await Actor.getInput();
 
 const sources = input.map(category => ({
     url: `https://apify.com/store?category=${category}`,
@@ -1575,7 +1570,7 @@ const sources = input.map(category => ({
     },
 }));
 
-const requestList = await Apify.openRequestList('categories', sources);
+const requestList = await RequestList.open('categories', sources);
 // ...
 ```
 
@@ -1593,7 +1588,7 @@ importantly - easier to reason about and make changes to.
 In the following code we've made several changes.
 
 -   Split the code into multiple files.
--   Added the `Apify.utils.log` and replaced `console.log` with it.
+-   Added the `Actor.utils.log` and replaced `console.log` with it.
 -   Added a `getSources()` function to encapsulate `INPUT` consumption.
 -   Added a `createRouter()` function to make our routing cleaner, without nested `if` clauses.
 -   Removed the `maxRequestsPerCrawl` limit.
@@ -1604,20 +1599,18 @@ In our `main.js` file, we place the general structure of the crawler:
 
 ```js
 // main.js
-const Apify = require('apify');
-const tools = require('./tools');
-const {
-    utils: { log },
-} = Apify;
+import { Actor } from 'apify';
+import { CheerioCrawler, log } from '@crawlers/cheerio';
+import * as tools from './tools';
 
-Apify.main(async () => {
+Actor.main(async () => {
     log.info('Starting actor.');
-    const requestList = await Apify.openRequestList('categories', await tools.getSources());
-    const requestQueue = await Apify.openRequestQueue();
+    const requestList = await RequestList.open('categories', await tools.getSources());
+    const requestQueue = await RequestQueue.open();
     const router = tools.createRouter({ requestQueue });
 
     log.debug('Setting up crawler.');
-    const crawler = new Apify.CheerioCrawler({
+    const crawler = new CheerioCrawler({
         requestList,
         requestQueue,
         handlePageFunction: async context => {
@@ -1637,24 +1630,22 @@ Then in a separate `tools.js`, we add our helper functions:
 
 ```js
 // tools.js
-const Apify = require('apify');
-const routes = require('./routes');
-const {
-    utils: { log },
-} = Apify;
+import { Actor } from 'apify';
+import { log } from '@crawlers/core';
+import * as routes from './routes';
 
-exports.getSources = async () => {
+export async function getSources() {
     log.debug('Getting sources.');
-    const input = await Apify.getInput();
+    const input = await Actor.getInput();
     return input.map(category => ({
         url: `https://apify.com/store?category=${category}`,
         userData: {
             label: 'CATEGORY',
         },
     }));
-};
+}
 
-exports.createRouter = globalContext => {
+export async function createRouter(globalContext) {
     return async function(routeName, requestContext) {
         const route = routes[routeName];
         if (!route) throw new Error(`No route for name: ${routeName}`);
@@ -1668,15 +1659,11 @@ And finally our routes in a separate `routes.js` file:
 
 ```js
 // routes.js
-const Apify = require('apify');
-const {
-    utils: { log },
-} = Apify;
+import { Actor } from 'apify';
+import { log } from '@crawlers/core';
 
-exports.CATEGORY = async ({ $, request }, { requestQueue }) => {
-    return Apify.utils.enqueueLinks({
-        $,
-        requestQueue,
+export const CATEGORY = async ({ enqueueLinks }) => {
+    return enqueueLinks({
         selector: 'div.item > a',
         baseUrl: request.loadedUrl,
         transformRequestFunction: req => {
@@ -1686,7 +1673,7 @@ exports.CATEGORY = async ({ $, request }, { requestQueue }) => {
     });
 };
 
-exports.DETAIL = async ({ $, request }) => {
+export const DETAIL = async ({ $, request }) => {
     const urlArr = request.url.split('/').slice(-2);
 
     log.debug('Scraping results.');
@@ -1710,7 +1697,7 @@ exports.DETAIL = async ({ $, request }) => {
     };
 
     log.debug('Pushing data to dataset.');
-    await Apify.pushData(results);
+    await Actor.pushData(results);
 };
 ```
 
@@ -1722,9 +1709,9 @@ manageable.
 This was not always the case, but now that the Apify platform has a multifile editor, there's no reason not to split your code into multiple files and keep
 your logic separate. Less code in a single file means less code you need to think about at any time, and that's a great thing!
 
-#### Using `Apify.utils.log` instead of `console.log`
+#### Using `Actor.utils.log` instead of `console.log`
 
-We wont go to great lengths here to talk about `utils.log`, because you can read [it all in the documentation](../api/log), but there's just
+We wont go to great lengths here to talk about `utils.log`, because you can read <ApiLink to="core/class/Log">it all in the documentation</ApiLink>, but there's just
 one thing that we need to stress: **log levels**.
 
 `utils.log` enables you to use different log levels, such as `log.debug`, `log.info` or `log.warning`. It not only makes your log more readable, but
@@ -1732,7 +1719,7 @@ it also allows selective turning off of some levels by either calling the `utils
 This is huge! Because you can now add a lot of debug logs in your actor, which will help you when something goes wrong and turn them on or off with a
 simple `INPUT` change, or by setting an environment variable.
 
-The punch line? Use `Apify.utils.log` instead of `console.log` now and thank us later when something goes wrong!
+The punch line? Use `Actor.utils.log` instead of `console.log` now and thank us later when something goes wrong!
 
 #### Using a router to structure your crawling
 

--- a/docs/guides/motivation.mdx
+++ b/docs/guides/motivation.mdx
@@ -4,6 +4,8 @@ title: Motivation
 slug: /
 ---
 
+import ApiLink from '@site/src/components/ApiLink';
+
 Thanks to tools like [Playwright](https://github.com/microsoft/playwright), [Puppeteer](https://github.com/puppeteer/puppeteer) or
 [Cheerio](https://www.npmjs.com/package/cheerio), it is easy to write Node.js code to extract data from web pages. But
 eventually things will get complicated. For example, when you try to:

--- a/docs/guides/proxy_management.mdx
+++ b/docs/guides/proxy_management.mdx
@@ -3,6 +3,8 @@ id: proxy-management
 title: Proxy Management
 ---
 
+import ApiLink from '@site/src/components/ApiLink';
+
 [IP address blocking](https://en.wikipedia.org/wiki/IP_address_blocking) is one of the oldest
 and most effective ways of preventing access to a website. It is therefore paramount for
 a good web scraping library to provide easy to use but powerful tools which can work around
@@ -25,13 +27,13 @@ them immediately in only a few lines of code.
 <!-- Apify Proxy -->
 
 ```javascript
-const proxyConfiguration = await Apify.createProxyConfiguration();
+const proxyConfiguration = await Actor.createProxyConfiguration();
 const proxyUrl = proxyConfiguration.newUrl();
 ```
 
 <!-- Your own proxies -->
 ```javascript
-const proxyConfiguration = await Apify.createProxyConfiguration({
+const proxyConfiguration = await Actor.createProxyConfiguration({
     proxyUrls: [
         'http://proxy-1.com',
         'http://proxy-2.com',
@@ -44,23 +46,19 @@ const proxyUrl = proxyConfiguration.newUrl();
 
 ## Proxy Configuration
 
-All your proxy needs are managed by the [`ProxyConfiguration`](../api/proxy-configuration) class.
-You create an instance using the [`Apify.createProxyConfiguration()`](../api/apify#createproxyconfiguration)
-function. See the [`ProxyConfigurationOptions`](../typedefs/proxy-configuration-options) for all
-the possible constructor options.
+All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. See the <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
 
 ### Crawler integration
 
-`ProxyConfiguration` integrates seamlessly into [`CheerioCrawler`](../api/cheerio-crawler)
-and [`PuppeteerCrawler`](../api/puppeteer-crawler).
+`ProxyConfiguration` integrates seamlessly into <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> and <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!-- CheerioCrawler -->
 
 ```javascript
-const proxyConfiguration = await Apify.createProxyConfiguration({ /* your proxy opts */ });
-const crawler = new Apify.CheerioCrawler({
+const proxyConfiguration = await Actor.createProxyConfiguration({ /* your proxy opts */ });
+const crawler = new CheerioCrawler({
     proxyConfiguration,
     // ...
 });
@@ -68,8 +66,8 @@ const crawler = new Apify.CheerioCrawler({
 
 <!-- PuppeteerCrawler -->
 ```javascript
-const proxyConfiguration = await Apify.createProxyConfiguration({ /* your proxy opts */ });
-const crawler = new Apify.PuppeteerCrawler({
+const proxyConfiguration = await Actor.createProxyConfiguration({ /* your proxy opts */ });
+const crawler = new PuppeteerCrawler({
     proxyConfiguration,
     // ...
 });
@@ -81,12 +79,12 @@ Your crawlers will now use the selected proxies for all connections.
 
 ### IP Rotation and session management
 
-[`proxyConfiguration.newUrl()`](../api/proxy-configuration#newurl) allows you to pass
+<ApiLink to="core/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass
 a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair,
 and subsequent `newUrl()` calls with the same `sessionId` will always return the same
 `proxyUrl`. This is extremely useful in scraping, because you want to create the impression
 of a real user. See the [session management guide](../guides/session-management) and
-[`SessionPool`](../api/session-pool) class for more information on how keeping
+<ApiLink to="core/class/SessionPool">`SessionPool`</ApiLink> class for more information on how keeping
 a real session helps you avoid blocking.
 
 When no `sessionId` is provided, your proxy URLs are rotated round-robin, whereas
@@ -97,16 +95,16 @@ Apify Proxy manages their rotation using black magic to get the best performance
 <!-- Standalone -->
 
 ```javascript
-const proxyConfiguration = await Apify.createProxyConfiguration({ /* opts */ });
-const sessionPool = await Apify.openSessionPool({ /* opts */ });
+const proxyConfiguration = await Actor.createProxyConfiguration({ /* opts */ });
+const sessionPool = await SessionPool.open({ /* opts */ });
 const session = await sessionPool.getSession();
 const proxyUrl = proxyConfiguration.newUrl(session.id);
 ```
 
 <!-- Crawlers -->
 ```javascript
-const proxyConfiguration = await Apify.createProxyConfiguration({ /* opts */ });
-const crawler = new Apify.PuppeteerCrawler({
+const proxyConfiguration = await Actor.createProxyConfiguration({ /* opts */ });
+const crawler = new PuppeteerCrawler({
     useSessionPool: true,
     persistCookiesPerSession: true,
     proxyConfiguration,
@@ -125,11 +123,7 @@ one would call a super-proxy. It's not a single proxy server, but an API endpoin
 that allows connection through millions of different IP addresses. So the class
 essentially has two modes: Apify Proxy or Your proxy.
 
-The difference is easy to remember.
-[`ProxyConfigurationOptions.proxyUrls`](../typedefs/proxy-configuration-options#proxyurls) and
-[`ProxyConfigurationOptions.newUrlFunction`](../typedefs/proxy-configuration-options#newurlfunction)
-enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy.
-Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
+The difference is easy to remember. <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
 
 ## Apify Proxy Configuration
 
@@ -137,7 +131,7 @@ With Apify Proxy, you can select specific proxy groups to use, or countries to c
 This allows you to get better proxy performance after some initial research.
 
 ```javascript
-const proxyConfiguration = await Apify.createProxyConfiguration({
+const proxyConfiguration = await Actor.createProxyConfiguration({
     groups: ['RESIDENTIAL'],
     countryCode: 'US',
 });
@@ -151,6 +145,6 @@ in the [proxy dashboard](https://console.apify.com/proxy).
 ## Inspecting current proxy in Crawlers
 
 `CheerioCrawler` and `PuppeteerCrawler` grant access to information about the currently used proxy
-in their `handlePageFunction` using a [`proxyInfo`](../typedefs/proxy-info) object.
+in their `handlePageFunction` using a <ApiLink to="core/interface/ProxyInfo">`proxyInfo`</ApiLink> object.
 With the  object, you can easily access the proxy URL. If you're using Apify Proxy, the other
 configuration parameters will also be available in the `proxyInfo` object.

--- a/docs/guides/quick_start.mdx
+++ b/docs/guides/quick_start.mdx
@@ -3,6 +3,8 @@ id: quick-start
 title: Quick Start
 ---
 
+import ApiLink from '@site/src/components/ApiLink';
+
 This short tutorial will set you up to start using Apify SDK in a minute or two.
 If you want to learn more, proceed to the [Getting Started](../guides/getting-started)
 tutorial that will take you step by step through creating your first scraper.
@@ -27,15 +29,15 @@ Run the following example to perform a recursive crawl of a website using Playwr
 [see the Examples section of the documentation](../examples/crawl-multiple-urls).
 
 ```javascript title="src/main.js"
-const Apify = require('apify');
+import { Actor } from 'apify';
 
-// Apify.main is a helper function, you don't need to use it.
-Apify.main(async () => {
-    const requestQueue = await Apify.openRequestQueue();
+// Actor.main is a helper function, you don't need to use it.
+Actor.main(async () => {
+    const requestQueue = await RequestQueue.open();
     // Choose the first URL to open.
     await requestQueue.addRequest({ url: 'https://www.iana.org/' });
 
-    const crawler = new Apify.PlaywrightCrawler({
+    const crawler = new PlaywrightCrawler({
         requestQueue,
         handlePageFunction: async ({ request, page }) => {
             // Extract HTML title of the page.
@@ -43,7 +45,7 @@ Apify.main(async () => {
             console.log(`Title of ${request.url}: ${title}`);
 
             // Add URLs that match the provided pattern.
-            await Apify.utils.enqueueLinks({
+            await Actor.utils.enqueueLinks({
                 page,
                 requestQueue,
                 pseudoUrls: ['https://www.iana.org/[.*]'],

--- a/docs/guides/request_storage.mdx
+++ b/docs/guides/request_storage.mdx
@@ -3,6 +3,8 @@ id: request-storage
 title: Request Storage
 ---
 
+import ApiLink from '@site/src/components/ApiLink';
+
 The Apify SDK has several request storage types that are useful for specific tasks. The requests are stored either on local disk to a directory defined by the
 `APIFY_LOCAL_STORAGE_DIR` environment variable, or on the [Apify platform](/docs/guides/apify-platform) under the user account identified by the API token defined by the `APIFY_TOKEN` environment variable. If neither of these variables is defined, by default Apify SDK sets `APIFY_LOCAL_STORAGE_DIR` to `./apify_storage` in the current working directory and prints a warning.
 
@@ -20,7 +22,7 @@ The request queue is a storage of URLs to crawl. The queue is used for the deep 
 
 Each actor run is associated with a **default request queue**, which is created exclusively for the actor run. Typically, it is used to store URLs to crawl in the specific actor run. Its usage is optional.
 
-In Apify SDK, the request queue is represented by the [`RequestQueue`](/docs/api/request-queue) class.
+In Apify SDK, the request queue is represented by the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> class.
 
 In local configuration, the request queue is emulated by [@apify/storage-local](https://github.com/apify/apify-storage-local-js) NPM package and its data is stored in SQLite database in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
 
@@ -34,18 +36,18 @@ The following code demonstrates basic operations of the request queue:
 
 ```javascript
 // Open the default request queue associated with the actor run
-const requestQueue = await Apify.openRequestQueue();
+const requestQueue = await RequestQueue.open();
 // Enqueue the initial request
 await requestQueue.addRequest({ url: 'https://example.com' });
 
 // The crawler will automatically process requests from the queue
-const crawler = new Apify.CheerioCrawler({
+const crawler = new CheerioCrawler({
     requestQueue,
     handlePageFunction: async ({ $, request }) => {
         // Add new request to the queue
         await requestQueue.addRequest({ url: 'https://example.com/new-page' });
         // Add links found on page to the queue
-        await Apify.utils.enqueueLinks({ $, requestQueue });
+        await Actor.utils.enqueueLinks({ $, requestQueue });
     },
 });
 ```
@@ -54,11 +56,11 @@ To see more detailed example of how to use the request queue with a crawler, see
 
 ## Request list
 
-The request list is not a storage per se - it represents the list of URLs to crawl that is stored in a run memory (or optionally in default [Key-Value Store](../guides/results-storage#key-value-store) associated with the run, if specified). The list is used for the crawling of a large number of URLs, when you know all the URLs which should be visited by the crawler and no URLs would be added during the run. The URLs can be provided either in code or parsed from a text file hosted on the web.
+The request list is not a storage per se - it represents the list of URLs to crawl that is stored in a run memory (or optionally in default [Key-Value Store](../guides/result-storage#key-value-store) associated with the run, if specified). The list is used for the crawling of a large number of URLs, when you know all the URLs which should be visited by the crawler and no URLs would be added during the run. The URLs can be provided either in code or parsed from a text file hosted on the web.
 
 Request list is created exclusively for the actor run and only if its usage is explicitly specified in the code. Its usage is optional.
 
-In Apify SDK, the request list is represented by the [`RequestList`](/docs/api/request-list) class.
+In Apify SDK, the request list is represented by the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class.
 
 The following code demonstrates basic operations of the request list:
 
@@ -71,10 +73,10 @@ const sources = [
 ];
 // Open the request list.
 // List name is used to persist the sources and the list state in the key-value store
-const requestList = await Apify.openRequestList('my-list', sources);
+const requestList = await RequestList.open('my-list', sources);
 
 // The crawler will automatically process requests from the list
-const crawler = new Apify.PuppeteerCrawler({
+const crawler = new PuppeteerCrawler({
     requestList,
     handlePageFunction: async ({ page, request }) => {
         // Process the page (extract data, take page screenshot, etc).
@@ -106,13 +108,13 @@ const sources = [
     { url: 'http://www.example.com/page-3' },
 ];
 // Open the request list
-const requestList = await Apify.openRequestList('my-list', sources);
+const requestList = await RequestList.open('my-list', sources);
 
 // Open the default request queue. It's not necessary to add any requests to the queue
-const requestQueue = await Apify.openRequestQueue();
+const requestQueue = await RequestQueue.open();
 
 // The crawler will automatically process requests from the list and the queue
-const crawler = new Apify.PuppeteerCrawler({
+const crawler = new PuppeteerCrawler({
     requestList,
     requestQueue,
     // Each request from the request list is enqueued to the request queue one by one.
@@ -122,7 +124,7 @@ const crawler = new Apify.PuppeteerCrawler({
         await requestQueue.addRequest({ url: 'http://www.example.com/new-page' });
 
         // Add links found on page to the queue
-        await Apify.utils.enqueueLinks({ page, requestQueue });
+        await Actor.utils.enqueueLinks({ page, requestQueue });
 
         // The requests above would be added to the queue (but not to the list)
         // and would be processed after the request list is empty.

--- a/docs/guides/result_storage.mdx
+++ b/docs/guides/result_storage.mdx
@@ -3,6 +3,8 @@ id: result-storage
 title: Result Storage
 ---
 
+import ApiLink from '@site/src/components/ApiLink';
+
 The Apify SDK has several result storage types that are useful for specific tasks. The data is stored either on local disk to a directory defined by the
 `APIFY_LOCAL_STORAGE_DIR` environment variable, or on the [Apify platform](../guides/apify-platform) under the user account
 identified by the API token defined by the `APIFY_TOKEN` environment variable. If neither of these variables is defined, by default Apify SDK sets
@@ -28,9 +30,8 @@ Each actor run is associated with a **default key-value store**, which is create
 and output is stored in the default key-value store under the `INPUT` and `OUTPUT` key, respectively. Typically the input and output is a JSON file,
 although it can be any other format.
 
-In the Apify SDK, the key-value store is represented by the [`KeyValueStore`](../api/key-value-store) class. In order to simplify access to the default
-key-value store, the SDK also provides [`Apify.getValue()`](../api/apify#getvalue) and
-[`Apify.setValue()`](../api/apify#setvalue) functions.
+In the Apify SDK, the key-value store is represented by the <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink> class. In order to simplify access to the default
+key-value store, the SDK also provides <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink> and <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink> functions.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
 
@@ -46,13 +47,13 @@ The following code demonstrates basic operations of key-value stores:
 
 ```javascript
 // Get actor input from the default key-value store
-const input = await Apify.getInput();
+const input = await Actor.getInput();
 
 // Write actor output to the default key-value store.
-await Apify.setValue('OUTPUT', { myResult: 123 });
+await Actor.setValue('OUTPUT', { myResult: 123 });
 
 // Open a named key-value store
-const store = await Apify.openKeyValueStore('some-name');
+const store = await Actor.openKeyValueStore('some-name');
 
 // Write record. JavaScript object is automatically converted to JSON,
 // strings and binary buffers are stored as they are
@@ -66,7 +67,7 @@ const value = await store.getValue('some-key');
 await store.setValue('some-key', null);
 ```
 
-To see a real-world example of how to get the input from the key-value store, see the [Screenshots](../examples/screenshots) example.
+To see a real-world example of how to get the input from the key-value store, see the [Screenshots](../examples/capture-screenshot) example.
 
 ## Dataset
 
@@ -83,8 +84,8 @@ way you can easily share crawling results.
 Each actor run is associated with a **default dataset**, which is created exclusively for the actor run. Typically, it is used to store crawling
 results specific for the actor run. Its usage is optional.
 
-In the Apify SDK, the dataset is represented by the [`Dataset`](../api/dataset) class. In order to simplify writes to the default dataset, the SDK
-also provides the [`Apify.pushData()`](../api/apify#pushdata) function.
+In the Apify SDK, the dataset is represented by the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, the SDK
+also provides the <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> function.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
 
@@ -100,10 +101,10 @@ The following code demonstrates basic operations of the dataset:
 
 ```javascript
 // Write a single row to the default dataset
-await Apify.pushData({ col1: 123, col2: 'val2' });
+await Actor.pushData({ col1: 123, col2: 'val2' });
 
 // Open a named dataset
-const dataset = await Apify.openDataset('some-name');
+const dataset = await Actor.openDataset('some-name');
 
 // Write a single row
 await dataset.pushData({ foo: 'bar' });

--- a/docs/guides/session_management.mdx
+++ b/docs/guides/session_management.mdx
@@ -2,7 +2,10 @@
 id: session-management
 title: Session Management
 ---
-[`SessionPool`](../api/session-pool) is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
+
+import ApiLink from '@site/src/components/ApiLink';
+
+<ApiLink to="core/class/SessionPool"><code>SessionPool</code></ApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
 
 The main benefit of a Session pool is that you can filter out blocked or non-working proxies,
 so your actor does not retry requests over known blocked/non-working proxies.
@@ -13,13 +16,13 @@ which should prevent burning out a small pool of available IPs.
 
 Now let's take a look at how to use a Session pool.
 
-**Example usage in [`PuppeteerCrawler`](../api/puppeteer-crawler)**
+**Example usage in <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>**
 
 ```javascript
 
-const proxyConfiguration = await Apify.createProxyConfiguration();
+const proxyConfiguration = await Actor.createProxyConfiguration();
 
-const crawler = new Apify.PuppeteerCrawler({
+const crawler = new PuppeteerCrawler({
     requestQueue,
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
@@ -47,12 +50,12 @@ const crawler = new Apify.PuppeteerCrawler({
 });
 ```
 
-**Example usage in [`CheerioCrawler`](../api/cheerio-crawler)**
+**Example usage in <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>**
 
 ```javascript
-  const proxyConfiguration = await Apify.createProxyConfiguration();
+  const proxyConfiguration = await Actor.createProxyConfiguration();
 
-  const crawler = new Apify.CheerioCrawler({
+  const crawler = new CheerioCrawler({
         requestQueue,
         // To use the proxy IP session rotation logic, you must turn the proxy usage on.
         proxyConfiguration,
@@ -80,75 +83,73 @@ const crawler = new Apify.PuppeteerCrawler({
     });
 ```
 
-**Example usage in [`BasicCrawler`](../api/basic-crawler)**
+**Example usage in <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>**
 
 ```javascript
- const proxyConfiguration = await Apify.createProxyConfiguration();
+ const proxyConfiguration = await Actor.createProxyConfiguration();
 
- const crawler = new Apify.BasicCrawler({
-        requestQueue,
-        // Allows access to proxyInfo object in handleRequestFunction
-        proxyConfiguration,
-        useSessionPool: true,
-        sessionPoolOptions: {
-            maxPoolSize: 100
-        },
-        handleRequestFunction: async ({request, session, proxyInfo }) => {
-            // To use the proxy IP session rotation logic, you must turn the proxy usage on.
-            const proxyUrl = proxyInfo.url;
-            const requestOptions = {
-                url: request.url,
-                proxyUrl,
-                throwHttpErrors: false,
-                headers: {
-                    // If you want to use the cookieJar.
-                    // This way you get the Cookie headers string from session.
-                    Cookie: session.getCookieString(),
-                }
-            };
-            let response;
-
-            try {
-                response = await Apify.utils.requestAsBrowser(requestOptions);
-            } catch (e) {
-                if (e === "SomeNetworkError") {
-                    // If a network error happens, such as timeout, socket hangup etc...
-                    // There is usually a chance that it was just bad luck and the proxy works.
-                    // No need to throw it away.
-                    session.markBad();
-                }
-                throw e;
+ const crawler = new BasicCrawler({
+    requestQueue,
+    // Allows access to proxyInfo object in handleRequestFunction
+    proxyConfiguration,
+    useSessionPool: true,
+    sessionPoolOptions: {
+        maxPoolSize: 100
+    },
+    handleRequestFunction: async ({request, session, proxyInfo }) => {
+        // To use the proxy IP session rotation logic, you must turn the proxy usage on.
+        const proxyUrl = proxyInfo.url;
+        const requestOptions = {
+            url: request.url,
+            proxyUrl,
+            throwHttpErrors: false,
+            headers: {
+                // If you want to use the cookieJar.
+                // This way you get the Cookie headers string from session.
+                Cookie: session.getCookieString(),
             }
+        };
+        let response;
 
-            // Automatically retires the session based on response HTTP status code.
-            session.retireOnBlockedStatusCodes(response.statusCode);
-
-            if (response.body.blocked) {
-                // You are sure it is blocked.
-                // This will throw away the session.
-                session.retire();
-
+        try {
+            response = await Actor.utils.requestAsBrowser(requestOptions);
+        } catch (e) {
+            if (e === "SomeNetworkError") {
+                // If a network error happens, such as timeout, socket hangup etc...
+                // There is usually a chance that it was just bad luck and the proxy works.
+                // No need to throw it away.
+                session.markBad();
             }
+            throw e;
+        }
 
-            // Everything is ok, you can get the data.
-            // No need to call session.markGood -> BasicCrawler calls it for you.
+        // Automatically retires the session based on response HTTP status code.
+        session.retireOnBlockedStatusCodes(response.statusCode);
 
-            // If you want to use the CookieJar in session you need.
-            session.setCookiesFromResponse(response);
+        if (response.body.blocked) {
+            // You are sure it is blocked.
+            // This will throw away the session.
+            session.retire();
 
         }
-    });
+
+        // Everything is ok, you can get the data.
+        // No need to call session.markGood -> BasicCrawler calls it for you.
+
+        // If you want to use the CookieJar in session you need.
+        session.setCookiesFromResponse(response);
+    }
+});
 ```
 
 **Example solo usage**
 
 ```javascript
-Apify.main(async () => {
-
+Actor.main(async () => {
     const sessionPoolOptions = {
-            maxPoolSize: 100
+        maxPoolSize: 100
     };
-    const sessionPool = await Apify.openSessionPool(sessionPoolOptions);
+    const sessionPool = await SessionPool.open(sessionPoolOptions);
 
     // Get session
     const session = sessionPool.getSession();

--- a/docs/guides/typescript_actor.mdx
+++ b/docs/guides/typescript_actor.mdx
@@ -3,6 +3,8 @@ id: type-script-actor
 title: TypeScript Actors
 ---
 
+import ApiLink from '@site/src/components/ApiLink';
+
 Apify SDK supports TypeScript by covering public APIs with type declarations. This
 allows writing code with auto-completion for TypeScript and JavaScript code alike.
 Besides that, actors written in TypeScript can take advantage of compile-time
@@ -109,7 +111,7 @@ interface MySchema {
     expectedParam2?: number;
 }
 
-const input: MySchema = (await Apify.getInput()) as any; // getInput returns Promise<Object<string, *>|string|Buffer|null> here
+const input: MySchema = (await Actor.getInput()) as any; // getInput returns Promise<Object<string, *>|string|Buffer|null> here
 
 if (!input?.expectedParam1) { // input is MySchema now and you can check in a type-safe way
     throw new Error('Missing expectedParam1');
@@ -124,7 +126,7 @@ interface ExpectedShape {
     someFields: Fields[];
 }
 
-const dataset = await Apify.openDataset();
+const dataset = await Actor.openDataset();
 await dataset.forEach((item: ExpectedShape) => {
     // deal with item.id / item.someFields
     // otherwise item is "any"

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -446,7 +446,7 @@ export class Actor {
     /**
      * Gets the actor input value from the default {@link KeyValueStore} associated with the current actor run.
      *
-     * This is just a convenient shortcut for [`keyValueStore.getValue('INPUT')`](key-value-store#getvalue).
+     * This is just a convenient shortcut for [`keyValueStore.getValue('INPUT')`](core/class/KeyValueStore#getValue).
      * For example, calling the following code:
      * ```javascript
      * const input = await Actor.getInput();
@@ -981,7 +981,7 @@ export class Actor {
     /**
      * Gets the actor input value from the default {@link KeyValueStore} associated with the current actor run.
      *
-     * This is just a convenient shortcut for [`keyValueStore.getValue('INPUT')`](key-value-store#getvalue).
+     * This is just a convenient shortcut for {@link KeyValueStore#getValue | `keyValueStore.getValue('INPUT')`}.
      * For example, calling the following code:
      * ```javascript
      * const input = await Actor.getInput();
@@ -997,8 +997,7 @@ export class Actor {
      * If you need to use the input multiple times in your actor,
      * it is far more efficient to read it once and store it locally.
      *
-     * For more information, see  {@link Actor.openKeyValueStore}
-     * and {@link KeyValueStore.getValue}.
+     * For more information, see {@link Actor.openKeyValueStore} and {@link KeyValueStore.getValue}.
      *
      * @returns
      *   Returns a promise that resolves to an object, string

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -614,7 +614,7 @@ export class BasicCrawler<
                     .catch((err) => {
                         if (err.message.includes('Cannot persist state.')) {
                             this.log.error('The crawler attempted to persist its request list\'s state and failed due to missing or '
-                                + 'invalid config. Make sure to use either Apify.openRequestList() or the "stateKeyPrefix" option of RequestList '
+                                + 'invalid config. Make sure to use either RequestList.open() or the "stateKeyPrefix" option of RequestList '
                                 + 'constructor to ensure your crawling state is persisted through host migrations and restarts.');
                         } else {
                             this.log.exception(err, 'An unexpected error occured when the crawler '

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -9,7 +9,7 @@ import { log as defaultLog } from './log';
  * Gets an instance of a Node.js'
  * [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
  * class that emits various events from the SDK or the Apify platform.
- * The event emitter is initialized by calling the {@link Apify.main} function.
+ * The event emitter is initialized by calling the {@link Actor.main} function.
  *
  * **Example usage:**
  *

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -62,7 +62,7 @@ export interface SessionPoolOptions {
  * Handles the rotation, creation and persistence of user-like sessions.
  * Creates a pool of {@link Session} instances, that are randomly rotated.
  * When some session is marked as blocked, it is removed and new one is created instead (the pool never returns an unusable session).
- * Learn more in the [`Session management guide`](../guides/session-management).
+ * Learn more in the [Session management guide](../../../docs/guides/session-management).
  *
  * You can create one by calling the {@link SessionPool.open} function.
  *

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -167,7 +167,7 @@ export interface DatasetIteratorOptions extends Omit<DatasetDataOptions, 'offset
  * Typically it is used to store crawling results.
  *
  * Do not instantiate this class directly, use the
- * {@link Apify.openDataset} function instead.
+ * {@link Actor.openDataset} function instead.
  *
  * `Dataset` stores its data either on local disk or in the Apify cloud,
  * depending on whether the `APIFY_LOCAL_STORAGE_DIR` or `APIFY_TOKEN` environment variables are set.
@@ -184,7 +184,7 @@ export interface DatasetIteratorOptions extends Omit<DatasetDataOptions, 'offset
  * If the `APIFY_TOKEN` environment variable is set but `APIFY_LOCAL_STORAGE_DIR` not, the data is stored in the
  * [Apify Dataset](https://docs.apify.com/storage/dataset)
  * cloud storage. Note that you can force usage of the cloud storage also by passing the `forceCloud`
- * option to {@link Apify.openDataset} function,
+ * option to {@link Actor.openDataset} function,
  * even if the `APIFY_LOCAL_STORAGE_DIR` variable is set.
  *
  * **Example usage:**

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -53,13 +53,13 @@ export const maybeStringify = <T>(value: T, options: { contentType?: string }) =
  * default key-value store under the `INPUT` and `OUTPUT` key, respectively.
  * Typically, input and output are JSON files, although it can be any other format.
  * To access the default key-value store directly, you can use the
- * {@link Apify.getValue} and {@link Apify.setValue} convenience functions.
+ * {@link Actor.getValue} and {@link Actor.setValue} convenience functions.
  *
- * To access the input, you can also use the {@link Apify.getInput} convenience function.
+ * To access the input, you can also use the {@link Actor.getInput} convenience function.
  *
  * `KeyValueStore` stores its data either on local disk or in the Apify cloud,
- * depending on whether the [`APIFY_LOCAL_STORAGE_DIR`](../guides/environment-variables#apify_local_storage_dir)
- * or [`APIFY_TOKEN`](../guides/environment-variables#apify_token) environment variables are set.
+ * depending on whether the [`APIFY_LOCAL_STORAGE_DIR`](/docs/guides/environment-variables#apify_local_storage_dir)
+ * or [`APIFY_TOKEN`](/docs/guides/environment-variables#apify_token) environment variables are set.
  *
  * If the `APIFY_LOCAL_STORAGE_DIR` environment variable is set, the data is stored in
  * the local directory in the following files:
@@ -70,12 +70,12 @@ export const maybeStringify = <T>(value: T, options: { contentType?: string }) =
  * unless you override it by setting the `APIFY_DEFAULT_KEY_VALUE_STORE_ID` environment variable.
  * The `{KEY}` is the key of the record and `{EXT}` corresponds to the MIME content type of the data value.
  *
- * If the [`APIFY_TOKEN`](../guides/environment-variables#apify_token) environment variable is set but
- * [`APIFY_LOCAL_STORAGE_DIR`](../guides/environment-variables#apify_local_storage_dir) not,
+ * If the [`APIFY_TOKEN`](/docs/guides/environment-variables#apify_token) environment variable is set but
+ * [`APIFY_LOCAL_STORAGE_DIR`](/docs/guides/environment-variables#apify_local_storage_dir) not,
  * the data is stored in the [Apify Key-value store](https://docs.apify.com/storage/key-value-store)
  * cloud storage. Note that you can force usage of the cloud storage also by passing the `forceCloud`
  * option to {@link KeyValueStore.open} function, even if the
- * [`APIFY_LOCAL_STORAGE_DIR`](../guides/environment-variables#apify_local_storage_dir) variable is set.
+ * [`APIFY_LOCAL_STORAGE_DIR`](/docs/guides/environment-variables#apify_local_storage_dir) variable is set.
  *
  * **Example usage:**
  *

--- a/packages/core/src/storages/request_list.ts
+++ b/packages/core/src/storages/request_list.ts
@@ -194,7 +194,7 @@ export interface RequestListOptions {
  * ```javascript
  * // Use a helper function to simplify request list initialization.
  * // State and sources are automatically persisted. This is a preferred usage.
- * const requestList = await Apify.openRequestList('my-request-list', [
+ * const requestList = await RequestList.open('my-request-list', [
  *     'http://www.example.com/page-1',
  *     { url: 'http://www.example.com/page-2', method: 'POST', userData: { foo: 'bar' }},
  *     { requestsFromUrl: 'http://www.example.com/my-url-list.txt', userData: { isFromUrl: true } },
@@ -773,7 +773,7 @@ export class RequestList {
      *     'https://www.bing.com'
      * ];
      *
-     * const requestList = await Apify.openRequestList('my-name', sources);
+     * const requestList = await RequestList.open('my-name', sources);
      * ```
      *
      * @param listName
@@ -828,64 +828,6 @@ export class RequestList {
     private async _downloadListOfUrls(options: { url: string; urlRegExp?: RegExp }): Promise<string[]> {
         return downloadListOfUrls(options);
     }
-}
-
-/**
- * Opens a request list and returns a promise resolving to an instance
- * of the {@link RequestList} class that is already initialized.
- *
- * {@link RequestList} represents a list of URLs to crawl, which is always stored in memory.
- * To enable picking up where left off after a process restart, the request list sources
- * are persisted to the key-value store at initialization of the list. Then, while crawling,
- * a small state object is regularly persisted to keep track of the crawling status.
- *
- * For more details and code examples, see the {@link RequestList} class.
- *
- * **Example usage:**
- *
- * ```javascript
- * const sources = [
- *     'https://www.example.com',
- *     'https://www.google.com',
- *     'https://www.bing.com'
- * ];
- *
- * const requestList = await Apify.openRequestList('my-name', sources);
- * ```
- *
- * @param listName
- *   Name of the request list to be opened. Setting a name enables the `RequestList`'s state to be persisted
- *   in the key-value store. This is useful in case of a restart or migration. Since `RequestList` is only
- *   stored in memory, a restart or migration wipes it clean. Setting a name will enable the `RequestList`'s
- *   state to survive those situations and continue where it left off.
- *
- *   The name will be used as a prefix in key-value store, producing keys such as `NAME-REQUEST_LIST_STATE`
- *   and `NAME-REQUEST_LIST_SOURCES`.
- *
- *   If `null`, the list will not be persisted and will only be stored in memory. Process restart
- *   will then cause the list to be crawled again from the beginning. We suggest always using a name.
- * @param sources
- *  An array of sources of URLs for the {@link RequestList}. It can be either an array of strings,
- *  plain objects that define at least the `url` property, or an array of {@link Request} instances.
- *
- *  **IMPORTANT:** The `sources` array will be consumed (left empty) after {@link RequestList} initializes.
- *  This is a measure to prevent memory leaks in situations when millions of sources are
- *  added.
- *
- *  Additionally, the `requestsFromUrl` property may be used instead of `url`,
- *  which will instruct {@link RequestList} to download the source URLs from a given remote location.
- *  The URLs will be parsed from the received response. In this case you can limit the URLs
- *  using `regex` parameter containing regular expression pattern for URLs to be included.
- *
- *  For details, see the {@link RequestListOptions.sources}
- * @param [options]
- *   The {@link RequestList} options. Note that the `listName` parameter supersedes
- *   the {@link RequestListOptions.persistStateKey} and {@link RequestListOptions.persistRequestsKey}
- *   options and the `sources` parameter supersedes the {@link RequestListOptions.sources} option.
- * @deprecated use `RequestList.open()` instead
- */
-export async function openRequestList(listName: string | null, sources: Source[], options: RequestListOptions = {}): Promise<RequestList> {
-    return RequestList.open(listName, sources, options);
 }
 
 /**

--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -109,8 +109,7 @@ export interface RequestQueueOperationOptions {
  * To add a single URL multiple times to the queue,
  * corresponding {@link Request} objects will need to have different `uniqueKey` properties.
  *
- * Do not instantiate this class directly, use the
- * {@link Apify.openRequestQueue} function instead.
+ * Do not instantiate this class directly, use the {@link RequestQueue.open} function instead.
  *
  * `RequestQueue` is used by {@link BasicCrawler}, {@link CheerioCrawler}, {@link PuppeteerCrawler}
  * and {@link PlaywrightCrawler} as a source of URLs to crawl.
@@ -126,17 +125,17 @@ export interface RequestQueueOperationOptions {
  * If the `APIFY_TOKEN` environment variable is set but `APIFY_LOCAL_STORAGE_DIR` is not, the data is stored in the
  * [Apify Request Queue](https://docs.apify.com/storage/request-queue)
  * cloud storage. Note that you can force usage of the cloud storage also by passing the `forceCloud`
- * option to {@link Apify.openRequestQueue} function,
+ * option to {@link Actor.openRequestQueue} function,
  * even if the `APIFY_LOCAL_STORAGE_DIR` variable is set.
  *
  * **Example usage:**
  *
  * ```javascript
  * // Open the default request queue associated with the actor run
- * const queue = await Apify.openRequestQueue();
+ * const queue = await RequestQueue.open();
  *
  * // Open a named request queue
- * const queueWithName = await Apify.openRequestQueue('some-name');
+ * const queueWithName = await RequestQueue.open('some-name');
  *
  * // Enqueue few requests
  * await queue.addRequest({ url: 'http://example.com/aaa' });
@@ -663,27 +662,6 @@ export class RequestQueue {
         const manager = new StorageManager(RequestQueue);
         return manager.openStorage(queueIdOrName, options);
     }
-}
-
-/**
- * Opens a request queue and returns a promise resolving to an instance
- * of the {@link RequestQueue} class.
- *
- * {@link RequestQueue} represents a queue of URLs to crawl, which is stored either on local filesystem or in the cloud.
- * The queue is used for deep crawling of websites, where you start with several URLs and then
- * recursively follow links to other pages. The data structure supports both breadth-first
- * and depth-first crawling orders.
- *
- * For more details and code examples, see the {@link RequestQueue} class.
- *
- * @param [queueIdOrName]
- *   ID or name of the request queue to be opened. If `null` or `undefined`,
- *   the function returns the default request queue associated with the actor run.
- * @param [options] Open Request Queue options.
- * @deprecated use `RequestQueue.open()` instead
- */
-export async function openRequestQueue(queueIdOrName?: string | null, options: Omit<StorageManagerOptions, 'config'> = {}): Promise<RequestQueue> {
-    return RequestQueue.open(queueIdOrName, options);
 }
 
 export interface RequestQueueOptions {

--- a/packages/core/src/typedefs.ts
+++ b/packages/core/src/typedefs.ts
@@ -3,14 +3,14 @@
 import { ActorRun } from 'apify-client';
 
 /**
- * Represents information about an actor run, as returned by the {@link Apify.call} or {@link Apify.callTask} function.
+ * Represents information about an actor run, as returned by the {@link Actor.call} or {@link Actor.callTask} function.
  * The object is almost equivalent to the JSON response of the [Actor run](https://apify.com/docs/api/v2#/reference/actors/run-collection/run-actor)
  * Apify API endpoint and extended with certain fields. For more details, see [Runs.](https://docs.apify.com/actor/run)
  */
 export interface ActorRunWithOutput extends ActorRun {
      /**
      * Contains output of the actor run. The value is `null` or `undefined` in case the actor is still running,
-     * or if you pass `false` to the `fetchOutput` option of {@link Apify.call}.
+     * or if you pass `false` to the `fetchOutput` option of {@link Actor.call}.
      *
      * For example:
      * ```

--- a/packages/puppeteer-crawler/src/internals/puppeteer-launcher.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-launcher.ts
@@ -210,8 +210,7 @@ export class PuppeteerLauncher extends BrowserLauncher<PuppeteerPlugin, unknown>
  * [Apify Actor documentation](https://docs.apify.com/actor/build#base-images)
  * for details.
  *
- * For an example of usage, see the [Synchronous run Example](../examples/synchronous-run)
- * or the [Puppeteer proxy Example](../examples/puppeteer-with-proxy)
+ * For an example of usage, see the [Puppeteer proxy Example](/docs/examples/puppeteer-with-proxy).
  *
  * @param [launchContext]
  *   All `PuppeteerLauncher` parameters are passed via an launchContext object.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,9 +19,9 @@ module.exports = {
         repoUrl: 'https://github.com/apify/apify-ts',
     },
     onBrokenLinks:
-    /** @type {import('@docusaurus/types').ReportingSeverity} */ ('log'),
+    /** @type {import('@docusaurus/types').ReportingSeverity} */ ('error'),
     onBrokenMarkdownLinks:
-    /** @type {import('@docusaurus/types').ReportingSeverity} */ ('log'),
+    /** @type {import('@docusaurus/types').ReportingSeverity} */ ('error'),
     presets: /** @type {import('@docusaurus/types').PresetConfig[]} */ ([
         [
             '@docusaurus/preset-classic',
@@ -135,10 +135,6 @@ module.exports = {
                         {
                             href: 'https://sdk.apify.com/docs/1.3.1/guides/getting-started',
                             label: '1.3',
-                        },
-                        {
-                            href: 'https://sdk.apify.com/docs/0.22.4/guides/getting-started',
-                            label: '0.22',
                         },
                     ],
                 },

--- a/website/src/components/ApiLink.jsx
+++ b/website/src/components/ApiLink.jsx
@@ -1,25 +1,22 @@
 import React from 'react';
+import Link from '@docusaurus/Link';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { useDocsVersion } from '@docusaurus/theme-common';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-const VersionedApiLink = ({ apiPath, children }) => {
+const ApiLink = ({ to, children }) => {
     const version = useDocsVersion();
     const { siteConfig } = useDocusaurusContext();
 
     if (siteConfig.presets[0][1].docs.disableVersioning) {
         return (
-            <a href={`${siteConfig.baseUrl}api/${apiPath}`}>
-                {children}
-            </a>
+            <Link to={`/api/${to}`}>{children}</Link>
         );
     }
 
     return (
-        <a href={`${siteConfig.baseUrl}api/${version.version === 'current' ? 'next' : version.version}/${apiPath}`}>
-            {children}
-        </a>
+        <Link to={`/api/${version.version === 'current' ? 'next' : version.version}/${to}`}>{children}</Link>
     );
 };
 
-export default VersionedApiLink;
+export default ApiLink;


### PR DESCRIPTION
~TODO:~ done

[ERROR] Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /apify-ts/api/apify/class/Actor:
   -> linking to key-value-store#getvalue (resolved as: /apify-ts/api/apify/class/key-value-store)

- On source page path = /apify-ts/api/core/class/KeyValueStore:
   -> linking to ../guides/environment-variables#apify_local_storage_dir (resolved as: /apify-ts/api/core/guides/environment-variables)
   -> linking to ../guides/environment-variables#apify_token (resolved as: /apify-ts/api/core/guides/environment-variables)

- On source page path = /apify-ts/api/core/class/SessionPool:
   -> linking to ../guides/session-management (resolved as: /apify-ts/api/core/guides/session-management)

- On source page path = /apify-ts/api/puppeteer-crawler/function/launchPuppeteer:
   -> linking to ../examples/synchronous-run (resolved as: /apify-ts/api/puppeteer-crawler/examples/synchronous-run)
   -> linking to ../examples/puppeteer-with-proxy (resolved as: /apify-ts/api/puppeteer-crawler/examples/puppeteer-with-proxy)

- On source page path = /apify-ts/docs/examples/basic-crawler:
   -> linking to /apify-ts/api/core/class/BasicCrawler

- On source page path = /apify-ts/docs/examples/crawl-single-url:
   -> linking to ./basic/accept-user-input (resolved as: /apify-ts/docs/examples/basic/accept-user-input)

- On source page path = /apify-ts/docs/examples/crawl-some-links:
   -> linking to /apify-ts/api/cheerio-crawler/interface/CheerioHandlePageInputs#enqueueLinks (resolved as: /apify-ts/api/cheerio-crawler/interface/CheerioHandlePageInputs)

- On source page path = /apify-ts/docs/guides/getting-started:
   -> linking to /apify-ts/api/basic/class/BasicCrawler
   -> linking to /apify-ts/api/request-list
   -> linking to /apify-ts/api/request-queue#addrequest (resolved as: /apify-ts/api/request-queue)
   -> linking to /apify-ts/api/cheerio-crawler) in minutes. [Cheerio](https://www.npmjs.com/package/cheerio
   -> linking to /apify-ts/api/request#loadedurl (resolved as: /apify-ts/api/request)
   -> linking to /apify-ts/api/dataset

- On source page path = /apify-ts/docs/guides/proxy-management:
   -> linking to ../typedefs/proxy-configuration-options (resolved as: /apify-ts/docs/typedefs/proxy-configuration-options)
   -> linking to /apify-ts/api/proxy-configuration#newurl (resolved as: /apify-ts/api/proxy-configuration)
   -> linking to ../typedefs/proxy-configuration-options#proxyurls (resolved as: /apify-ts/docs/typedefs/proxy-configuration-options)
   -> linking to ../typedefs/proxy-configuration-options#newurlfunction (resolved as: /apify-ts/docs/typedefs/proxy-configuration-options)
   -> linking to ../typedefs/proxy-info (resolved as: /apify-ts/docs/typedefs/proxy-info)

- On source page path = /apify-ts/docs/guides/request-storage:
   -> linking to ../guides/results-storage#key-value-store (resolved as: /apify-ts/docs/guides/results-storage)

- On source page path = /apify-ts/docs/guides/result-storage:
   -> linking to ../examples/screenshots (resolved as: /apify-ts/docs/examples/screenshots)
   -> linking to /apify-ts/api/dataset