### PR TITLE
feat: update enqueueLinksByClickingElements

### DIFF
--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -38,8 +38,9 @@ export interface EnqueueLinksOptions {
     /**
      * An array of glob pattern strings or plain objects
      * containing glob pattern strings matching the URLs to be enqueued.
-     * All remaining keys will be used as request options
-     * for the corresponding enqueued {@link Request} objects.
+     *
+     * The plain objects must include at least the `glob` property, which holds the glob pattern string.
+     * All remaining keys will be used as request options for the corresponding enqueued {@link Request} objects.
      *
      * The matching is always case-insensitive.
      * If you need case-sensitive matching, use `regexps` property directly.
@@ -52,8 +53,9 @@ export interface EnqueueLinksOptions {
     /**
      * An array of regular expressions or plain objects
      * containing regular expressions matching the URLs to be enqueued.
-     * All remaining keys will be used as request options
-     * for the corresponding enqueued {@link Request} objects.
+     *
+     * The plain objects must include at least the `regexp` property, which holds the glob pattern string.
+     * All remaining keys will be used as request options for the corresponding enqueued {@link Request} objects.
      *
      * If `regexps` is an empty array or `undefined`, then the function
      * enqueues the links with the same subdomain.
@@ -66,8 +68,9 @@ export interface EnqueueLinksOptions {
      *
      * An array of {@link PseudoUrl} strings or plain objects
      * containing {@link PseudoUrl} strings matching the URLs to be enqueued.
-     * All remaining keys will be used as request options
-     * for the corresponding enqueued {@link Request} objects.
+     *
+     * The plain objects must include at least the `purl` property, which holds the glob pattern string.
+     * All remaining keys will be used as request options for the corresponding enqueued {@link Request} objects.
      *
      * With a pseudo-URL string, the matching is always case-insensitive.
      * If you need case-sensitive matching, use `regexps` property directly.

--- a/test/apify/enqueue_links/enqueue_links.test.ts
+++ b/test/apify/enqueue_links/enqueue_links.test.ts
@@ -105,44 +105,6 @@ describe('enqueueLinks()', () => {
             expect(enqueued[3]).toBe(undefined);
         });
 
-        test('works with Actor UI output object', async () => {
-            const enqueued: (Request | RequestOptions)[] = [];
-            const requestQueue = new RequestQueue({ id: 'xxx', client: apifyClient });
-
-            // @ts-expect-error Override method for testing
-            requestQueue.addRequests = async (request) => {
-                enqueued.push(...request);
-            };
-
-            const pseudoUrls = [
-                { purl: 'https://example.com/[(\\w|-|/)*]', method: 'POST' as const },
-                { purl: '[http|https]://cool.com/', userData: { foo: 'bar' } },
-            ];
-
-            await browserCrawlerEnqueueLinks({
-                options: {
-                    selector: '.click',
-                    pseudoUrls,
-                },
-                page,
-                requestQueue,
-            });
-
-            expect(enqueued).toHaveLength(3);
-
-            expect(enqueued[0].url).toBe('https://example.com/a/b/first');
-            expect(enqueued[0].method).toBe('POST');
-            expect(enqueued[0].userData).toEqual({});
-
-            expect(enqueued[1].url).toBe('https://example.com/a/b/third');
-            expect(enqueued[1].method).toBe('POST');
-            expect(enqueued[1].userData).toEqual({});
-
-            expect(enqueued[2].url).toBe('http://cool.com/');
-            expect(enqueued[2].method).toBe('GET');
-            expect(enqueued[2].userData.foo).toBe('bar');
-        });
-
         test('works with globs', async () => {
             const enqueued: (Request | RequestOptions)[] = [];
             const requestQueue = new RequestQueue({ id: 'xxx', client: apifyClient });
@@ -562,43 +524,6 @@ describe('enqueueLinks()', () => {
 
         afterEach(async () => {
             $ = null;
-        });
-
-        test('works with Actor UI output object', async () => {
-            const enqueued: (Request | RequestOptions)[] = [];
-            const requestQueue = new RequestQueue({ id: 'xxx', client: apifyClient });
-
-            // @ts-expect-error Override method for testing
-            requestQueue.addRequests = async (request) => {
-                enqueued.push(...request);
-            };
-            const pseudoUrls = [
-                { purl: 'https://example.com/[(\\w|-|/)*]', method: 'POST' as const },
-                { purl: '[http|https]://cool.com/', userData: { foo: 'bar' } },
-            ];
-
-            await cheerioCrawlerEnqueueLinks({
-                options: {
-                    selector: '.click',
-                    pseudoUrls,
-                },
-                $,
-                requestQueue,
-            });
-
-            expect(enqueued).toHaveLength(3);
-
-            expect(enqueued[0].url).toBe('https://example.com/a/b/first');
-            expect(enqueued[0].method).toBe('POST');
-            expect(enqueued[0].userData).toEqual({});
-
-            expect(enqueued[1].url).toBe('https://example.com/a/b/third');
-            expect(enqueued[1].method).toBe('POST');
-            expect(enqueued[1].userData).toEqual({});
-
-            expect(enqueued[2].url).toBe('http://cool.com/');
-            expect(enqueued[2].method).toBe('GET');
-            expect(enqueued[2].userData.foo).toBe('bar');
         });
 
         test('works with globs', async () => {


### PR DESCRIPTION
Follow-up to #63 
- add `globs`/`regexps` options for `enqueueLinksByClickingElements`, deprecate `pseudoUrls` (same as `enqueueLinks`)
- small update to `enqueueLinks` jsdoc
- remove `Actor UI output object` tests for `enqueueLinks` (they were about input objects, it's now covered by other tests).