### PR TITLE
refactor: make `Actor.main()` awaitable and rework one E2E test as an example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
                 "jest": "^27.5.1",
                 "lerna": "^4.0.0",
                 "lint-staged": "^12.3.5",
+                "node-gyp": "^9.0.0",
                 "playwright": "1.20.0",
                 "portastic": "^1.0.1",
                 "proxy": "^1.0.2",
@@ -3079,22 +3080,6 @@
                 "node": ">= 10.12.0"
             }
         },
-        "node_modules/@npmcli/run-script/node_modules/nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@octokit/auth-token": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
@@ -4076,10 +4061,9 @@
             }
         },
         "node_modules/agentkeepalive": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
-            "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
-            "license": "MIT",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+            "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
             "dependencies": {
                 "debug": "^4.1.0",
                 "depd": "^1.1.2",
@@ -5735,6 +5719,15 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "dev": true,
+            "bin": {
+                "color-support": "bin.js"
+            }
         },
         "node_modules/colorette": {
             "version": "2.0.16",
@@ -12698,143 +12691,232 @@
             }
         },
         "node_modules/node-gyp": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
-            "integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.0.0.tgz",
+            "integrity": "sha512-Ma6p4s+XCTPxCuAMrOA/IJRmVy16R8Sdhtwl4PrCr7IBlj4cPawF0vg/l7nOT1jPbuNS7lIRJpBSvVsXwEZuzw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
                 "glob": "^7.1.4",
-                "graceful-fs": "^4.2.2",
-                "mkdirp": "^0.5.1",
-                "nopt": "^4.0.1",
-                "npmlog": "^4.1.2",
-                "request": "^2.88.0",
-                "rimraf": "^2.6.3",
-                "semver": "^5.7.1",
-                "tar": "^4.4.12",
-                "which": "^1.3.1"
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^10.0.3",
+                "nopt": "^5.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
             },
             "bin": {
                 "node-gyp": "bin/node-gyp.js"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": "^12.22 || ^14.13 || >=16"
             }
         },
-        "node_modules/node-gyp/node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+        "node_modules/node-gyp/node_modules/@npmcli/fs": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.0.tgz",
+            "integrity": "sha512-DmfBvNXGaetMxj9LTp8NAN9vEidXURrf5ZTslQzEAi/6GbW+4yjaLFQc6Tue5cpZ9Frlk4OBo/Snf1Bh/S7qTQ==",
             "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/node-gyp/node_modules/fs-minipass": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-            "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "minipass": "^2.6.0"
-            }
-        },
-        "node_modules/node-gyp/node_modules/minipass": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-            }
-        },
-        "node_modules/node-gyp/node_modules/minizlib": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^2.9.0"
-            }
-        },
-        "node_modules/node-gyp/node_modules/mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/node-gyp/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/node-gyp/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/node-gyp/node_modules/tar": {
-            "version": "4.4.19",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-            "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "chownr": "^1.1.4",
-                "fs-minipass": "^1.2.7",
-                "minipass": "^2.9.0",
-                "minizlib": "^1.3.3",
-                "mkdirp": "^0.5.5",
-                "safe-buffer": "^5.2.1",
-                "yallist": "^3.1.1"
+                "@gar/promisify": "^1.1.3",
+                "semver": "^7.3.5"
             },
             "engines": {
-                "node": ">=4.5"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
-        "node_modules/node-gyp/node_modules/which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+        "node_modules/node-gyp/node_modules/@npmcli/move-file": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.0.tgz",
+            "integrity": "sha512-UR6D5f4KEGWJV6BGPH3Qb2EtgH+t+1XQ1Tt85c7qicN6cezzuHPdZwwAxqZr4JLtnQu0LZsTza/5gmNmSl8XLg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "isexe": "^2.0.0"
+                "mkdirp": "^1.0.4",
+                "rimraf": "^3.0.2"
             },
-            "bin": {
-                "which": "bin/which"
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
-        "node_modules/node-gyp/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+        "node_modules/node-gyp/node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "dev": true,
-            "license": "ISC"
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/node-gyp/node_modules/are-we-there-yet": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
+            "integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
+            "dev": true,
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16"
+            }
+        },
+        "node_modules/node-gyp/node_modules/cacache": {
+            "version": "16.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.0.4.tgz",
+            "integrity": "sha512-U0D4wF3/W8ZgK4qDA5fTtOVSr0gaDfd5aa7tUdAV0uukVWKsAIn6SzXQCoVlg7RWZiJa+bcsM3/pXLumGaL2Ug==",
+            "dev": true,
+            "dependencies": {
+                "@npmcli/fs": "^2.1.0",
+                "@npmcli/move-file": "^2.0.0",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.1.0",
+                "glob": "^7.2.0",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "mkdirp": "^1.0.4",
+                "p-map": "^4.0.0",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^3.0.2",
+                "ssri": "^9.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^1.1.1"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/gauge": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+            "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+            "dev": true,
+            "dependencies": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.3",
+                "console-control-strings": "^1.1.0",
+                "has-unicode": "^2.0.1",
+                "signal-exit": "^3.0.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/node-gyp/node_modules/lru-cache": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+            "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/node-gyp/node_modules/make-fetch-happen": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.2.tgz",
+            "integrity": "sha512-GWMGiZsKVeJACQGJ1P3Z+iNec7pLsU6YW1q11eaPn3RR8nRXHppFWfP7Eu0//55JK3hSjrAQRl8sDa5uXpq1Ew==",
+            "dev": true,
+            "dependencies": {
+                "agentkeepalive": "^4.2.1",
+                "cacache": "^16.0.2",
+                "http-cache-semantics": "^4.1.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-lambda": "^1.0.1",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-fetch": "^2.0.3",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "promise-retry": "^2.0.1",
+                "socks-proxy-agent": "^6.1.1",
+                "ssri": "^9.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/minipass-fetch": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.0.tgz",
+            "integrity": "sha512-H9U4UVBGXEyyWJnqYDCLp1PwD8XIkJ4akNHp1aGVI+2Ym7wQMlxDKi4IB4JbmyU+pl9pEs/cVrK6cOuvmbK4Sg==",
+            "dev": true,
+            "dependencies": {
+                "minipass": "^3.1.6",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/node-gyp/node_modules/npmlog": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.1.tgz",
+            "integrity": "sha512-BTHDvY6nrRHuRfyjt1MAufLxYdVXZfd099H4+i1f0lPywNQyI4foeNXJRObB/uy+TYqUW0vAD9gbdSOXPst7Eg==",
+            "dev": true,
+            "dependencies": {
+                "are-we-there-yet": "^3.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^4.0.0",
+                "set-blocking": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16"
+            }
+        },
+        "node_modules/node-gyp/node_modules/socks-proxy-agent": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+            "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^6.0.2",
+                "debug": "^4.3.1",
+                "socks": "^2.6.1"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/node-gyp/node_modules/ssri": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.0.tgz",
+            "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
+            "dev": true,
+            "dependencies": {
+                "minipass": "^3.1.1"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
@@ -12851,17 +12933,18 @@
             "license": "MIT"
         },
         "node_modules/nopt": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-            "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1"
             },
             "bin": {
                 "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/normalize-package-data": {
@@ -12942,6 +13025,90 @@
                 "which": "^1.3.1"
             }
         },
+        "node_modules/npm-lifecycle/node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "dev": true
+        },
+        "node_modules/npm-lifecycle/node_modules/fs-minipass": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+            "dev": true,
+            "dependencies": {
+                "minipass": "^2.6.0"
+            }
+        },
+        "node_modules/npm-lifecycle/node_modules/minipass": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            }
+        },
+        "node_modules/npm-lifecycle/node_modules/minizlib": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+            "dev": true,
+            "dependencies": {
+                "minipass": "^2.9.0"
+            }
+        },
+        "node_modules/npm-lifecycle/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/npm-lifecycle/node_modules/node-gyp": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
+            "integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+            "dev": true,
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.2",
+                "mkdirp": "^0.5.1",
+                "nopt": "^4.0.1",
+                "npmlog": "^4.1.2",
+                "request": "^2.88.0",
+                "rimraf": "^2.6.3",
+                "semver": "^5.7.1",
+                "tar": "^4.4.12",
+                "which": "^1.3.1"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/npm-lifecycle/node_modules/nopt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+            "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+            "dev": true,
+            "dependencies": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            }
+        },
         "node_modules/npm-lifecycle/node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -12950,6 +13117,45 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/npm-lifecycle/node_modules/rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            }
+        },
+        "node_modules/npm-lifecycle/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/npm-lifecycle/node_modules/tar": {
+            "version": "4.4.19",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+            "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+            "dev": true,
+            "dependencies": {
+                "chownr": "^1.1.4",
+                "fs-minipass": "^1.2.7",
+                "minipass": "^2.9.0",
+                "minizlib": "^1.3.3",
+                "mkdirp": "^0.5.5",
+                "safe-buffer": "^5.2.1",
+                "yallist": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=4.5"
             }
         },
         "node_modules/npm-lifecycle/node_modules/which": {
@@ -12964,6 +13170,12 @@
             "bin": {
                 "which": "bin/which"
             }
+        },
+        "node_modules/npm-lifecycle/node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true
         },
         "node_modules/npm-normalize-package-bin": {
             "version": "1.0.1",
@@ -13306,7 +13518,6 @@
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13325,7 +13536,6 @@
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -20405,15 +20615,6 @@
                         "tar": "^6.0.2",
                         "which": "^2.0.2"
                     }
-                },
-                "nopt": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-                    "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-                    "dev": true,
-                    "requires": {
-                        "abbrev": "1"
-                    }
                 }
             }
         },
@@ -21204,9 +21405,9 @@
             }
         },
         "agentkeepalive": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
-            "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+            "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
             "requires": {
                 "debug": "^4.1.0",
                 "depd": "^1.1.2",
@@ -22365,6 +22566,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "dev": true
         },
         "colorette": {
@@ -27335,111 +27542,185 @@
             }
         },
         "node-gyp": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
-            "integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.0.0.tgz",
+            "integrity": "sha512-Ma6p4s+XCTPxCuAMrOA/IJRmVy16R8Sdhtwl4PrCr7IBlj4cPawF0vg/l7nOT1jPbuNS7lIRJpBSvVsXwEZuzw==",
             "dev": true,
             "requires": {
                 "env-paths": "^2.2.0",
                 "glob": "^7.1.4",
-                "graceful-fs": "^4.2.2",
-                "mkdirp": "^0.5.1",
-                "nopt": "^4.0.1",
-                "npmlog": "^4.1.2",
-                "request": "^2.88.0",
-                "rimraf": "^2.6.3",
-                "semver": "^5.7.1",
-                "tar": "^4.4.12",
-                "which": "^1.3.1"
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^10.0.3",
+                "nopt": "^5.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
             },
             "dependencies": {
-                "chownr": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+                "@npmcli/fs": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.0.tgz",
+                    "integrity": "sha512-DmfBvNXGaetMxj9LTp8NAN9vEidXURrf5ZTslQzEAi/6GbW+4yjaLFQc6Tue5cpZ9Frlk4OBo/Snf1Bh/S7qTQ==",
+                    "dev": true,
+                    "requires": {
+                        "@gar/promisify": "^1.1.3",
+                        "semver": "^7.3.5"
+                    }
+                },
+                "@npmcli/move-file": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.0.tgz",
+                    "integrity": "sha512-UR6D5f4KEGWJV6BGPH3Qb2EtgH+t+1XQ1Tt85c7qicN6cezzuHPdZwwAxqZr4JLtnQu0LZsTza/5gmNmSl8XLg==",
+                    "dev": true,
+                    "requires": {
+                        "mkdirp": "^1.0.4",
+                        "rimraf": "^3.0.2"
+                    }
+                },
+                "@tootallnate/once": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+                    "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
                     "dev": true
                 },
-                "fs-minipass": {
-                    "version": "1.2.7",
-                    "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-                    "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                "are-we-there-yet": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
+                    "integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
                     "dev": true,
                     "requires": {
-                        "minipass": "^2.6.0"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^3.6.0"
                     }
                 },
-                "minipass": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                    "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+                "cacache": {
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.0.4.tgz",
+                    "integrity": "sha512-U0D4wF3/W8ZgK4qDA5fTtOVSr0gaDfd5aa7tUdAV0uukVWKsAIn6SzXQCoVlg7RWZiJa+bcsM3/pXLumGaL2Ug==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
+                        "@npmcli/fs": "^2.1.0",
+                        "@npmcli/move-file": "^2.0.0",
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.1.0",
+                        "glob": "^7.2.0",
+                        "infer-owner": "^1.0.4",
+                        "lru-cache": "^7.7.1",
+                        "minipass": "^3.1.6",
+                        "minipass-collect": "^1.0.2",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.4",
+                        "mkdirp": "^1.0.4",
+                        "p-map": "^4.0.0",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^3.0.2",
+                        "ssri": "^9.0.0",
+                        "tar": "^6.1.11",
+                        "unique-filename": "^1.1.1"
                     }
                 },
-                "minizlib": {
-                    "version": "1.3.3",
-                    "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-                    "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+                "gauge": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+                    "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
                     "dev": true,
                     "requires": {
-                        "minipass": "^2.9.0"
+                        "aproba": "^1.0.3 || ^2.0.0",
+                        "color-support": "^1.1.3",
+                        "console-control-strings": "^1.1.0",
+                        "has-unicode": "^2.0.1",
+                        "signal-exit": "^3.0.7",
+                        "string-width": "^4.2.3",
+                        "strip-ansi": "^6.0.1",
+                        "wide-align": "^1.1.5"
                     }
                 },
-                "mkdirp": {
-                    "version": "0.5.5",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-                    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+                "http-proxy-agent": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+                    "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.5"
+                        "@tootallnate/once": "2",
+                        "agent-base": "6",
+                        "debug": "4"
                     }
                 },
-                "rimraf": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                "lru-cache": {
+                    "version": "7.8.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+                    "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
                     "dev": true
                 },
-                "tar": {
-                    "version": "4.4.19",
-                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-                    "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+                "make-fetch-happen": {
+                    "version": "10.1.2",
+                    "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.2.tgz",
+                    "integrity": "sha512-GWMGiZsKVeJACQGJ1P3Z+iNec7pLsU6YW1q11eaPn3RR8nRXHppFWfP7Eu0//55JK3hSjrAQRl8sDa5uXpq1Ew==",
                     "dev": true,
                     "requires": {
-                        "chownr": "^1.1.4",
-                        "fs-minipass": "^1.2.7",
-                        "minipass": "^2.9.0",
-                        "minizlib": "^1.3.3",
-                        "mkdirp": "^0.5.5",
-                        "safe-buffer": "^5.2.1",
-                        "yallist": "^3.1.1"
+                        "agentkeepalive": "^4.2.1",
+                        "cacache": "^16.0.2",
+                        "http-cache-semantics": "^4.1.0",
+                        "http-proxy-agent": "^5.0.0",
+                        "https-proxy-agent": "^5.0.0",
+                        "is-lambda": "^1.0.1",
+                        "lru-cache": "^7.7.1",
+                        "minipass": "^3.1.6",
+                        "minipass-collect": "^1.0.2",
+                        "minipass-fetch": "^2.0.3",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.4",
+                        "negotiator": "^0.6.3",
+                        "promise-retry": "^2.0.1",
+                        "socks-proxy-agent": "^6.1.1",
+                        "ssri": "^9.0.0"
                     }
                 },
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                "minipass-fetch": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.0.tgz",
+                    "integrity": "sha512-H9U4UVBGXEyyWJnqYDCLp1PwD8XIkJ4akNHp1aGVI+2Ym7wQMlxDKi4IB4JbmyU+pl9pEs/cVrK6cOuvmbK4Sg==",
                     "dev": true,
                     "requires": {
-                        "isexe": "^2.0.0"
+                        "encoding": "^0.1.13",
+                        "minipass": "^3.1.6",
+                        "minipass-sized": "^1.0.3",
+                        "minizlib": "^2.1.2"
                     }
                 },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-                    "dev": true
+                "npmlog": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.1.tgz",
+                    "integrity": "sha512-BTHDvY6nrRHuRfyjt1MAufLxYdVXZfd099H4+i1f0lPywNQyI4foeNXJRObB/uy+TYqUW0vAD9gbdSOXPst7Eg==",
+                    "dev": true,
+                    "requires": {
+                        "are-we-there-yet": "^3.0.0",
+                        "console-control-strings": "^1.1.0",
+                        "gauge": "^4.0.0",
+                        "set-blocking": "^2.0.0"
+                    }
+                },
+                "socks-proxy-agent": {
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+                    "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^6.0.2",
+                        "debug": "^4.3.1",
+                        "socks": "^2.6.1"
+                    }
+                },
+                "ssri": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.0.tgz",
+                    "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^3.1.1"
+                    }
                 }
             }
         },
@@ -27456,13 +27737,12 @@
             "dev": true
         },
         "nopt": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-            "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
             "dev": true,
             "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -27522,11 +27802,113 @@
                 "which": "^1.3.1"
             },
             "dependencies": {
+                "chownr": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+                    "dev": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.7",
+                    "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+                    "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^2.6.0"
+                    }
+                },
+                "minipass": {
+                    "version": "2.9.0",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+                    "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+                    "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^2.9.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.6",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+                    "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.6"
+                    }
+                },
+                "node-gyp": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
+                    "integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+                    "dev": true,
+                    "requires": {
+                        "env-paths": "^2.2.0",
+                        "glob": "^7.1.4",
+                        "graceful-fs": "^4.2.2",
+                        "mkdirp": "^0.5.1",
+                        "nopt": "^4.0.1",
+                        "npmlog": "^4.1.2",
+                        "request": "^2.88.0",
+                        "rimraf": "^2.6.3",
+                        "semver": "^5.7.1",
+                        "tar": "^4.4.12",
+                        "which": "^1.3.1"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+                    "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
                 "resolve-from": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
                     "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
                     "dev": true
+                },
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "tar": {
+                    "version": "4.4.19",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+                    "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+                    "dev": true,
+                    "requires": {
+                        "chownr": "^1.1.4",
+                        "fs-minipass": "^1.2.7",
+                        "minipass": "^2.9.0",
+                        "minizlib": "^1.3.3",
+                        "mkdirp": "^0.5.5",
+                        "safe-buffer": "^5.2.1",
+                        "yallist": "^3.1.1"
+                    }
                 },
                 "which": {
                     "version": "1.3.1",
@@ -27536,6 +27918,12 @@
                     "requires": {
                         "isexe": "^2.0.0"
                     }
+                },
+                "yallist": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                    "dev": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "jest": "^27.5.1",
         "lerna": "^4.0.0",
         "lint-staged": "^12.3.5",
+        "node-gyp": "^9.0.0",
         "playwright": "1.20.0",
         "portastic": "^1.0.1",
         "proxy": "^1.0.2",

--- a/packages/core/src/autoscaling/system_status.ts
+++ b/packages/core/src/autoscaling/system_status.ts
@@ -81,6 +81,19 @@ export interface ClientInfo {
     actualRatio: number;
 }
 
+export interface FinalStatistics {
+    requestsFinished: number;
+    requestsFailed: number;
+    retryHistogram: number[];
+    requestAvgFailedDurationMillis: number;
+    requestAvgFinishedDurationMillis: number;
+    requestsFinishedPerMinute: number;
+    requestsFailedPerMinute: number;
+    requestTotalDurationMillis: number;
+    requestsTotal: number;
+    crawlerRuntimeMillis: number;
+}
+
 /**
  * Provides a simple interface to reading system status from a {@link Snapshotter} instance.
  * It only exposes two functions {@link SystemStatus.getCurrentStatus}

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -212,8 +212,10 @@ export async function enqueueLinks(options: EnqueueLinksOptions): Promise<BatchA
         urlPatternObjects.push(...constructRegExpObjectsFromRegExps(regexps));
     }
 
+    options.strategy ??= urlPatternObjects.length > 0 ? undefined : EnqueueStrategy.SameSubdomain;
+
     if (options.baseUrl) {
-        switch (options.strategy ?? EnqueueStrategy.SameSubdomain) {
+        switch (options.strategy) {
             case EnqueueStrategy.SameSubdomain:
                 // We need to get the origin of the passed in domain in the event someone sets baseUrl
                 // to an url like https://example.com/deep/default/path and one of the found urls is an

--- a/packages/scraper-tools/src/run_actor.ts
+++ b/packages/scraper-tools/src/run_actor.ts
@@ -1,4 +1,5 @@
 import { Actor } from 'apify';
+import { FinalStatistics } from '@crawlers/core';
 import log from '@apify/log';
 
 export interface CrawlerSetup {
@@ -9,11 +10,11 @@ export interface CrawlerSetup {
 export type CrawlerSetupConstructor = new (input: any) => CrawlerSetup;
 
 export interface CommonCrawler {
-    run(): Promise<void>;
+    run(): Promise<FinalStatistics>;
 }
 
 export function runActor(CrawlerSetup: CrawlerSetupConstructor) {
-    Actor.main(async () => {
+    void Actor.main(async () => {
         log.debug('Reading INPUT.');
         const input = await Actor.getInput();
         if (!input) throw new Error('INPUT cannot be empty!');

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -19,7 +19,7 @@ const testMain = async ({ userFunc, exitCode }: { userFunc?: (sdk?: Actor) => vo
             .then(() => {
                 return new Promise<void>((resolve, reject) => {
                     // Invoke main() function, the promise resolves after the user function is run
-                    Actor.main(() => {
+                    return Actor.main(() => {
                         try {
                             // Wait for all tasks in Node.js event loop to finish
                             resolve();

--- a/test/apify/apify.test.ts
+++ b/test/apify/apify.test.ts
@@ -1,6 +1,5 @@
 import { ACT_JOB_STATUSES, ENV_VARS, KEY_VALUE_STORE_KEYS, WEBHOOK_EVENT_TYPES } from '@apify/consts';
 import log from '@apify/log';
-import path from 'node:path';
 import { Dataset, KeyValueStore, RequestList, StorageManager } from '@crawlers/core';
 import { sleep } from '@crawlers/utils';
 import { Actor, ApifyEnv, ProxyConfiguration } from 'apify';
@@ -17,7 +16,7 @@ const testMain = async ({ userFunc, exitCode }: { userFunc?: (sdk: Actor) => voi
     const sdk = new Actor();
 
     try {
-        sdk.main(() => {
+        await sdk.main(() => {
             if (userFunc) {
                 return userFunc(sdk);
             }

--- a/test/apify/crawlers/basic_crawler.test.ts
+++ b/test/apify/crawlers/basic_crawler.test.ts
@@ -255,17 +255,6 @@ describe('BasicCrawler', () => {
         errors.forEach((error) => expect(error).toBeInstanceOf(Error));
     });
 
-    test('should require at least one of RequestQueue and RequestList', () => {
-        const requestList = new RequestList({ sources: [] });
-        const requestQueue = new RequestQueue({ id: 'xxx', client: Configuration.getStorageClient() });
-        const requestHandler = async () => {};
-
-        expect(() => new BasicCrawler({ requestHandler })).toThrowError();
-        expect(() => new BasicCrawler({ requestHandler, requestList })).not.toThrowError();
-        expect(() => new BasicCrawler({ requestHandler, requestQueue })).not.toThrowError();
-        expect(() => new BasicCrawler({ requestHandler, requestQueue, requestList })).not.toThrowError();
-    });
-
     test('should correctly combine RequestList and RequestQueue', async () => {
         const sources = [
             { url: 'http://example.com/0' },

--- a/test/e2e/test-che-default/test.mjs
+++ b/test/e2e/test-che-default/test.mjs
@@ -1,27 +1,24 @@
-import { getStats, getDatasetItems, run, expect, validateDataset } from '../tools.mjs';
+import { Actor } from 'apify';
+import { CheerioCrawler } from '@crawlers/cheerio';
+import { getDatasetItems, expect, validateDataset } from '../tools.mjs';
 
-await run(import.meta.url, 'cheerio-scraper', {
-    startUrls: [{ url: 'https://apify.com' }],
-    keepUrlFragments: false,
-    pseudoUrls: [{ purl: 'https://apify.com[(/[\\w-]+)?]' }],
-    linkSelector: 'a',
-    pageFunction: async function pageFunction(context) {
-        const { $, request, log } = context;
+const crawler = new CheerioCrawler({
+    async requestHandler({ $, enqueueLinks, request, log }) {
         const { url } = request;
+
+        await enqueueLinks({
+            pseudoUrls: ['https://apify.com[(/[\\w-]+)?]'],
+        });
 
         const pageTitle = $('title').first().text();
         log.info(`URL: ${url} TITLE: ${pageTitle}`);
 
-        return { url, pageTitle };
-    },
-    proxyConfiguration: { useApifyProxy: false },
-    proxyRotation: 'RECOMMENDED',
-    forceResponseEncoding: false,
-    ignoreSslErrors: false,
-    debugLog: false,
+        await Actor.pushData({ url, pageTitle });
+    }
 });
 
-const stats = await getStats(import.meta.url);
+await crawler.addRequests(['https://apify.com']);
+const stats = await Actor.run(crawler, { exit: false, purge: true });
 expect(stats.requestsFinished > 50, 'All requests finished');
 
 const datasetItems = await getDatasetItems(import.meta.url);

--- a/test/e2e/test-che-default/test.mjs
+++ b/test/e2e/test-che-default/test.mjs
@@ -18,7 +18,7 @@ const crawler = new CheerioCrawler({
 });
 
 await crawler.addRequests(['https://apify.com']);
-const stats = await Actor.run(crawler, { exit: false, purge: true });
+const stats = await Actor.main(() => crawler.run(), { exit: false, purge: true });
 expect(stats.requestsFinished > 50, 'All requests finished');
 
 const datasetItems = await getDatasetItems(import.meta.url);


### PR DESCRIPTION
- `BasicCrawler.run()` now returns final statistics
- `Actor.main()` now returns promise, so it can be awaited (still throws synchronously for validation)
- `Actor.main()` is now generic and is typed to return the same as the `UserFunc` callback returns
- ~new method `Actor.run` that calls `crawler.run()` inside `Actor.main` for easier testing~
- fixes `enqueueLinks` default strategy being applied even with explicit pseudoUrls
- fixes creating crawlers with implicit `RequestQueue`