### PR TITLE
docs: Apify SDK to Crawlee

### DIFF
--- a/docs/examples/basic_crawler.mdx
+++ b/docs/examples/basic_crawler.mdx
@@ -7,7 +7,7 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import BasicCrawlerSource from '!!raw-loader!./basic_crawler.ts';
 
-This is the most bare-bones example of the Apify SDK, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers
+This is the most bare-bones example of using Crawlee, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers
 like <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> or <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
 
 The script simply downloads several web pages with plain HTTP requests using the [`got-scraping`](https://github.com/apify/got-scraping)

--- a/docs/examples/playwright_crawler.ts
+++ b/docs/examples/playwright_crawler.ts
@@ -17,7 +17,7 @@ const crawler = new PlaywrightCrawler({
 
     // This function will be called for each URL to crawl.
     // Here you can write the Playwright scripts you are familiar with,
-    // with the exception that browsers and pages are automatically managed by the Apify SDK.
+    // with the exception that browsers and pages are automatically managed by Crawlee.
     // The function accepts a single parameter, which is an object with a lot of properties,
     // the most important being:
     // - request: an instance of the Request class with information such as URL and HTTP method

--- a/docs/examples/puppeteer_crawler.ts
+++ b/docs/examples/puppeteer_crawler.ts
@@ -18,7 +18,7 @@ const crawler = new PuppeteerCrawler({
 
     // This function will be called for each URL to crawl.
     // Here you can write the Puppeteer scripts you are familiar with,
-    // with the exception that browsers and pages are automatically managed by the Apify SDK.
+    // with the exception that browsers and pages are automatically managed by Crawlee.
     // The function accepts a single parameter, which is an object with the following fields:
     // - request: an instance of the Request class with information such as URL and HTTP method
     // - page: Puppeteer's Page object (see https://pptr.dev/#show=api-class-page)

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -13,21 +13,21 @@ and [more](https://docs.apify.com/), accessible through a [web interface](https:
 or an [API](https://docs.apify.com/api).
 
 While we think that the Apify platform is super cool, and you should definitely sign up for a
-[free account](https://console.apify.com/sign-up), **Apify SDK is and will always be open source**,
+[free account](https://console.apify.com/sign-up), **Crawlee is and will always be open source**,
 runnable locally or on any cloud infrastructure.
 
-> Note that we do not test Apify SDK in other cloud environments such as Lambda or on specific
+> Note that we do not test Crawlee in other cloud environments such as Lambda or on specific
 > architectures such as Raspberry PI. We strive to make it work, but there are no guarantees.
 
-## Logging into Apify platform from Apify SDK
+## Logging into Apify platform from Crawlee
 
-To access your [Apify account](https://console.apify.com/sign-up) from the SDK, you must provide
+To access your [Apify account](https://console.apify.com/sign-up) from Crawlee, you must provide
 credentials - [your API token](https://console.apify.com/account#/integrations). You can do that
 either by utilizing [Apify CLI](https://github.com/apify/apify-cli) or with environment
 variables.
 
 Once you provide credentials to your scraper, you will be able to use all the Apify platform
-features of the SDK, such as calling actors, saving to cloud storages, using Apify proxies,
+features of Crawlee, such as calling actors, saving to cloud storages, using Apify proxies,
 setting up webhooks and so on.
 
 ### Log in with CLI
@@ -56,7 +56,7 @@ by setting the [`APIFY_TOKEN`](../guides/environment-variables#apify_token) envi
 variable to your API token.
 
 > There's also the [`APIFY_PROXY_PASSWORD`](../guides/environment-variables#apify_proxy_password)
-> environment variable. It is automatically inferred from your token by the SDK, but it can be useful
+> environment variable. Crawlee automatically infers that from your token, but it can be useful
 > when you need to access proxies from a different account than your token represents.
 
 ## What is an actor

--- a/docs/guides/environment_variables.mdx
+++ b/docs/guides/environment_variables.mdx
@@ -6,7 +6,7 @@ title: Environment Variables
 import ApiLink from '@site/src/components/ApiLink';
 
 The following is a list of the environment variables used by Crawlee that are available to the user.
-The SDK is capable of running without any env vars present, but certain features will only become available
+Crawlee is capable of running without any env vars present, but certain features will only become available
 after env vars are properly set. You can use [Apify CLI](https://github.com/apify/apify-cli)
 to set the env vars for you. [Apify platform](../guides/apify-platform) also sets the variables automatically.
 

--- a/docs/guides/environment_variables.mdx
+++ b/docs/guides/environment_variables.mdx
@@ -5,14 +5,14 @@ title: Environment Variables
 
 import ApiLink from '@site/src/components/ApiLink';
 
-The following is a list of the environment variables used by Apify SDK that are available to the user.
+The following is a list of the environment variables used by Crawlee that are available to the user.
 The SDK is capable of running without any env vars present, but certain features will only become available
 after env vars are properly set. You can use [Apify CLI](https://github.com/apify/apify-cli)
 to set the env vars for you. [Apify platform](../guides/apify-platform) also sets the variables automatically.
 
 ## Important env vars
 
-The following environment variables have large impact on the way Apify SDK works and its behavior
+The following environment variables have large impact on the way Crawlee works and its behavior
 can be changed significantly by setting or unsetting them.
 
 ### `APIFY_LOCAL_STORAGE_DIR`
@@ -28,7 +28,7 @@ you should define the `APIFY_LOCAL_STORAGE_DIR` environment variable instead.
 
 ### Combinations of `APIFY_LOCAL_STORAGE_DIR` and `APIFY_TOKEN`
 
-By combining the env vars in various ways, you can greatly influence the behavior of Apify SDK.
+By combining the env vars in various ways, you can greatly influence the Crawlee's behavior.
 
 | Env Vars                                    | API | Storages       |
 | ------------------------------------------- | --- | -------------- |
@@ -52,7 +52,7 @@ your code, such as temporarily switching log level to DEBUG.
 
 ### `APIFY_HEADLESS`
 
-If set to `1`, web browsers launched by Apify SDK will run in the headless mode. You can still override
+If set to `1`, web browsers launched by Crawlee will run in the headless mode. You can still override
 this setting in the code, e.g. by passing the `headless: true` option to the
 <ApiLink to="apify/class/Actor#launchPuppeteer">`Actor.launchPuppeteer()`</ApiLink> function. But having this setting
 in an environment variable allows you to develop the crawler locally in headful mode to simplify the debugging,

--- a/docs/guides/getting_started.mdx
+++ b/docs/guides/getting_started.mdx
@@ -11,22 +11,22 @@ requests, but that only gets you raw HTML and sometimes not even that. Then you 
 extracted, it must be stored in a machine-readable format and easily accessible for further processing, because it is the processed data that holds
 value.
 
-Apify SDK covers the process end-to-end. From crawling the web for links and scraping the raw data to storing it in various machine readable formats,
+Crawlee covers the process end-to-end. From crawling the web for links and scraping the raw data to storing it in various machine readable formats,
 ready for processing. With this guide in hand, you should have your own data extraction solutions up and running in a few hours.
 
 ## Intro
 
-The goal of this getting started guide is to provide a step-by-step introduction to all the features of the Apify SDK. It will walk you through
+The goal of this getting started guide is to provide a step-by-step introduction to all the features of Crawlee. It will walk you through
 creating the simplest of crawlers that only prints text to console, all the way up to complex systems that crawl pages, interact with them as if a real
 user were sitting in front of a real browser and output structured data.
 
-Since Apify SDK is usable both locally on any computer and on the [Apify platform](../guides/apify-platform), you will be able
+Since Crawlee is usable both locally on any computer and on the [Apify platform](../guides/apify-platform), you will be able
 to use the source code in both environments interchangeably. Nevertheless, some initial setup is still required, so choose your preferred starting
 environment and let's get into it.
 
 ## Setting up locally
 
-To run Apify SDK on your own computer, you need to meet the following pre-requisites first:
+To run Crawlee on your own computer, you need to meet the following pre-requisites first:
 
 1. Have Node.js version 15.10 or higher installed.
  - Visit [Node.js website](https://nodejs.org/en/download/) to download or use
@@ -46,7 +46,7 @@ npm -v
 
 ### Creating a new project
 
-The fastest and best way to create new projects with the Apify SDK is to use our own
+The fastest and best way to create new projects with Crawlee is to use our own
 [Apify CLI](https://www.npmjs.com/package/apify-cli). This command line tool allows you to create, run and manage Apify
 projects with ease, including their deployment to the [Apify platform](../guides/apify-platform) if you wish to run them in the
 cloud after developing them locally.
@@ -57,7 +57,7 @@ Let's install the Apify CLI with the following command:
 npm install -g apify-cli
 ```
 
-Once the installation finishes, all you need to do to set up an Apify SDK project is to run:
+Once the installation finishes, all you need to do to set up an Crawlee project is to run:
 
 ```bash
 apify create my-new-project
@@ -127,11 +127,11 @@ options.
 ## First crawler
 
 Whether you've chosen to develop locally or in the cloud, it's time to start writing some actual source code. But before we do, let's just briefly
-introduce all the Apify SDK classes necessary to make it happen.
+introduce all Crawlee classes necessary to make it happen.
 
 ### The general idea
 
-There are 4 crawler classes available for use in the Apify SDK. <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>, <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. We'll talk about their differences later. Now, let's talk about what they have in common.
+There are 4 crawler classes available for use in Crawlee. <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>, <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. We'll talk about their differences later. Now, let's talk about what they have in common.
 
 The general idea of each crawler is to go to a web page, open it, do some stuff there, save some results and continue to the next page, until it's done
 its job. So the crawler always needs to find answers to two questions: **Where should I go?** and **What should I do there?** Answering those two
@@ -496,7 +496,7 @@ first enqueued page and so on and so on.
 > If you need help with running the code, refer back to the chapters on environment setup: [Setting up locally](#setting-up-locally) and
 > [Setting up on the Apify platform](#setting-up-on-the-apify-platform).
 
-## Using Apify SDK to enqueue links like a boss
+## Using Crawlee to enqueue links like a boss
 
 If you were paying attention carefully in the previous chapter, we said that we would show you a way to enqueue new `Requests` with a single function
 call. You might be wondering why we had to go through the whole process of getting the individual links, filtering the same domain ones and then
@@ -504,7 +504,7 @@ manually enqueuing them into the `RequestQueue`, when there is a simpler way.
 
 Well, the obvious reason is practice. This is a tutorial after all. The other reason is to make you think about all the bits and pieces that come
 together, so that in the end, a new page, not previously entered in by you, can be scraped. We think that by seeing the bigger picture, you will be
-able to get the most out of Apify SDK.
+able to get the most out of Crawlee.
 
 ### Meet `Actor.utils`
 
@@ -765,7 +765,7 @@ Actor.main(async () => {
 ```
 
 And that's it! No more parsing the links from HTML using Cheerio, filtering them and enqueueing them one by one It all gets done automatically!
-`enqueueLinks()` is just one example of Apify SDK's powerful helper functions. They're all designed to make your life easier so you can focus on
+`enqueueLinks()` is just one example of Crawlee's powerful helper functions. They're all designed to make your life easier so you can focus on
 getting your data, while leaving the mundane crawling management to your tools.
 
 `Actor.utils.enqueueLinks()` has a lot more tricks up its sleeve. Make sure to check out the
@@ -1057,7 +1057,7 @@ because you absolutely can!
 
 ##### Finally, the `userData` of `enqueueLinks()`
 
-You will see `userData` used often throughout Apify SDK and it's nothing more than a place to store your own data on a `Request` instance. You can
+You will see `userData` used often throughout Crawlee and it's nothing more than a place to store your own data on a `Request` instance. You can
 access it with `request.userData` and it's a plain `Object` that can be used to store anything that needs to survive the full life-cycle of the
 `Request`.
 
@@ -1449,7 +1449,7 @@ also the possibility of downloading only clean items, i.e. a filtered dataset wi
 
 ##### Local Dataset
 
-Unless you changed the environment variables that Apify SDK uses locally, which would suggest that you knew what you were doing and you didn't need
+Unless you changed the environment variables that Crawlee uses locally, which would suggest that you knew what you were doing and you didn't need
 this tutorial anyway, you'll find your data in your local Apify Storage.
 
 ```
@@ -1466,7 +1466,7 @@ The above folder will hold all your saved data in numbered files, as they were p
 
 It may seem that the data are extracted and the actor is done, but honestly, this is just the beginning. For the sake of brevity, we've completely
 omitted error handling, proxies, debug logging, tests, documentation and other stuff that a reliable software should have. The good thing is, **error
-handling is mostly done by Apify SDK itself**, so no worries on that front, unless you need some custom magic.
+handling is mostly done by Crawlee itself**, so no worries on that front, unless you need some custom magic.
 
 Anyway, to spark some ideas, let's look at two more things. First, passing an input to the actor, which will enable us to change the categories we
 want to scrape without changing the source code itself! And then some refactoring, to show you how we reckon is preferable to structure and annotate

--- a/docs/guides/motivation.mdx
+++ b/docs/guides/motivation.mdx
@@ -19,6 +19,6 @@ Python has [Scrapy](https://scrapy.org/) for these tasks, but there was no such 
 the web**. The use of JavaScript is natural, since the same language is used to write the scripts as well as the data extraction code running in a
 browser.
 
-The goal of the Apify SDK is to fill this gap and provide a toolbox for generic web scraping, crawling and automation tasks in JavaScript. So don't
+The goal of Crawlee is to fill this gap and provide a toolbox for generic web scraping, crawling and automation tasks in JavaScript. So don't
 reinvent the wheel every time you need data from the web, and focus on writing code specific to the target website, rather than developing
 commonalities.

--- a/docs/guides/proxy_management.mdx
+++ b/docs/guides/proxy_management.mdx
@@ -11,7 +11,7 @@ a good web scraping library to provide easy to use but powerful tools which can 
 IP blocking. The most powerful weapon in your anti IP blocking arsenal is a
 [proxy server](https://en.wikipedia.org/wiki/Proxy_server).
 
-With Apify SDK you can use your own proxy servers, proxy servers acquired from
+With Crawlee you can use your own proxy servers, proxy servers acquired from
 third-party providers, or you can rely on [Apify Proxy](https://apify.com/proxy)
 for your scraping needs.
 

--- a/docs/guides/quick_start.mdx
+++ b/docs/guides/quick_start.mdx
@@ -5,14 +5,14 @@ title: Quick Start
 
 import ApiLink from '@site/src/components/ApiLink';
 
-This short tutorial will set you up to start using Apify SDK in a minute or two.
+This short tutorial will set you up to start using Crawlee in a minute or two.
 If you want to learn more, proceed to the [Getting Started](../guides/getting-started)
 tutorial that will take you step by step through creating your first scraper.
 
 ## Local stand-alone usage
 
-Apify SDK requires [Node.js](https://nodejs.org/en/) 15.10 or later.
-Add Apify SDK to any Node.js project by running:
+Crawlee requires [Node.js](https://nodejs.org/en/) 15.10 or later.
+Add Crawlee to any Node.js project by running:
 
 ```bash
 npm install apify playwright
@@ -25,7 +25,7 @@ flexibility. That's why we install it with NPM. You can choose one, both, or nei
 
 :::
 
-Run the following example to perform a recursive crawl of a website using Playwright. For more examples showcasing various features of the Apify SDK,
+Run the following example to perform a recursive crawl of a website using Playwright. For more examples showcasing various features of Crawlee,
 [see the Examples section of the documentation](../examples/crawl-multiple-urls).
 
 ```javascript title="src/main.js"
@@ -63,11 +63,11 @@ To read more about what pseudo-URL is, check the [getting-started](getting-start
 
 :::
 
-When you run the example, you should see Apify SDK automating a Chrome browser.
+When you run the example, you should see Crawlee automating a Chrome browser.
 
 ![Chrome Scrape](/img/chrome_scrape.gif)
 
-By default, Apify SDK stores data to `./apify_storage` in the current working directory. You can override this behavior by setting either the
+By default, Crawlee stores data to `./apify_storage` in the current working directory. You can override this behavior by setting either the
 `APIFY_LOCAL_STORAGE_DIR` or `APIFY_TOKEN` environment variable. For details, see [Environment variables](../guides/environment-variables), [Request storage](../guides/request-storage) and [Result storage](../guides/result-storage).
 
 ## Local usage with Apify command-line interface (CLI)

--- a/docs/guides/request_storage.mdx
+++ b/docs/guides/request_storage.mdx
@@ -5,8 +5,8 @@ title: Request Storage
 
 import ApiLink from '@site/src/components/ApiLink';
 
-The Apify SDK has several request storage types that are useful for specific tasks. The requests are stored either on local disk to a directory defined by the
-`APIFY_LOCAL_STORAGE_DIR` environment variable, or on the [Apify platform](/docs/guides/apify-platform) under the user account identified by the API token defined by the `APIFY_TOKEN` environment variable. If neither of these variables is defined, by default Apify SDK sets `APIFY_LOCAL_STORAGE_DIR` to `./apify_storage` in the current working directory and prints a warning.
+Crawlee has several request storage types that are useful for specific tasks. The requests are stored either on local disk to a directory defined by the
+`APIFY_LOCAL_STORAGE_DIR` environment variable, or on the [Apify platform](/docs/guides/apify-platform) under the user account identified by the API token defined by the `APIFY_TOKEN` environment variable. If neither of these variables is defined, by default Crawlee sets `APIFY_LOCAL_STORAGE_DIR` to `./apify_storage` in the current working directory and prints a warning.
 
 Typically, you will be developing the code on your local computer and thus set the `APIFY_LOCAL_STORAGE_DIR` environment variable. Once the code is ready, you will deploy it to the Apify platform, where it will automatically set the `APIFY_TOKEN` environment variable and thus use cloud storage. No code changes are needed.
 
@@ -22,7 +22,7 @@ The request queue is a storage of URLs to crawl. The queue is used for the deep 
 
 Each actor run is associated with a **default request queue**, which is created exclusively for the actor run. Typically, it is used to store URLs to crawl in the specific actor run. Its usage is optional.
 
-In Apify SDK, the request queue is represented by the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> class.
+In Crawlee, the request queue is represented by the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> class.
 
 In local configuration, the request queue is emulated by [@apify/storage-local](https://github.com/apify/apify-storage-local-js) NPM package and its data is stored in SQLite database in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
 
@@ -60,7 +60,7 @@ The request list is not a storage per se - it represents the list of URLs to cra
 
 Request list is created exclusively for the actor run and only if its usage is explicitly specified in the code. Its usage is optional.
 
-In Apify SDK, the request list is represented by the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class.
+In Crawlee, the request list is represented by the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class.
 
 The following code demonstrates basic operations of the request list:
 

--- a/docs/guides/result_storage.mdx
+++ b/docs/guides/result_storage.mdx
@@ -31,7 +31,7 @@ and output is stored in the default key-value store under the `INPUT` and `OUTPU
 although it can be any other format.
 
 In Crawlee, the key-value store is represented by the <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink> class. In order to simplify access to the default
-key-value store, the SDK also provides <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink> and <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink> functions.
+key-value store, Crawlee also provides <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink> and <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink> functions.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
 
@@ -84,7 +84,7 @@ way you can easily share crawling results.
 Each actor run is associated with a **default dataset**, which is created exclusively for the actor run. Typically, it is used to store crawling
 results specific for the actor run. Its usage is optional.
 
-In Crawlee, the dataset is represented by the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, the SDK
+In Crawlee, the dataset is represented by the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, Crawlee
 also provides the <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> function.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:

--- a/docs/guides/result_storage.mdx
+++ b/docs/guides/result_storage.mdx
@@ -5,9 +5,9 @@ title: Result Storage
 
 import ApiLink from '@site/src/components/ApiLink';
 
-The Apify SDK has several result storage types that are useful for specific tasks. The data is stored either on local disk to a directory defined by the
+Crawlee has several result storage types that are useful for specific tasks. The data is stored either on local disk to a directory defined by the
 `APIFY_LOCAL_STORAGE_DIR` environment variable, or on the [Apify platform](../guides/apify-platform) under the user account
-identified by the API token defined by the `APIFY_TOKEN` environment variable. If neither of these variables is defined, by default Apify SDK sets
+identified by the API token defined by the `APIFY_TOKEN` environment variable. If neither of these variables is defined, by default Crawlee sets
 `APIFY_LOCAL_STORAGE_DIR` to `./apify_storage` in the current working directory and prints a warning.
 
 Typically, you will be developing the code on your local computer and thus set the `APIFY_LOCAL_STORAGE_DIR` environment variable. Once the code is
@@ -30,7 +30,7 @@ Each actor run is associated with a **default key-value store**, which is create
 and output is stored in the default key-value store under the `INPUT` and `OUTPUT` key, respectively. Typically the input and output is a JSON file,
 although it can be any other format.
 
-In the Apify SDK, the key-value store is represented by the <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink> class. In order to simplify access to the default
+In Crawlee, the key-value store is represented by the <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink> class. In order to simplify access to the default
 key-value store, the SDK also provides <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink> and <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink> functions.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
@@ -84,7 +84,7 @@ way you can easily share crawling results.
 Each actor run is associated with a **default dataset**, which is created exclusively for the actor run. Typically, it is used to store crawling
 results specific for the actor run. Its usage is optional.
 
-In the Apify SDK, the dataset is represented by the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, the SDK
+In Crawlee, the dataset is represented by the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, the SDK
 also provides the <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> function.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:

--- a/docs/guides/session_management.mdx
+++ b/docs/guides/session_management.mdx
@@ -5,7 +5,7 @@ title: Session Management
 
 import ApiLink from '@site/src/components/ApiLink';
 
-&#8203;<ApiLink to="core/class/SessionPool">`SessionPool`</ApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
+&#8203;<ApiLink to="core/class/SessionPool">`SessionPool`</ApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Crawlee.
 
 The main benefit of a Session pool is that you can filter out blocked or non-working proxies,
 so your actor does not retry requests over known blocked/non-working proxies.

--- a/docs/guides/typescript_actor.mdx
+++ b/docs/guides/typescript_actor.mdx
@@ -83,9 +83,9 @@ To use TypeScript in your actors, you'll need the following prerequisites.
 Auto-completion
 ==============
 
-IDE auto-completion should work in most places. That's true even if you are writting
+IDE auto-completion should work in most places. That's true even if you are writing
 actors in pure JavaScript. For time constraints, we left out the amendment of an
-internal API for the time being, and these need to be added as the SDK developers write
+internal API for the time being, and these need to be added as Crawlee developers write
 new and enhance old code.
 
 SDK Documentation

--- a/docs/guides/typescript_actor.mdx
+++ b/docs/guides/typescript_actor.mdx
@@ -5,7 +5,7 @@ title: TypeScript Actors
 
 import ApiLink from '@site/src/components/ApiLink';
 
-Apify SDK supports TypeScript by covering public APIs with type declarations. This
+Crawlee supports TypeScript by covering public APIs with type declarations. This
 allows writing code with auto-completion for TypeScript and JavaScript code alike.
 Besides that, actors written in TypeScript can take advantage of compile-time
 type-checking and avoid many coding mistakes, while providing documentation for
@@ -93,7 +93,7 @@ SDK Documentation
 
 SDK documentation has grown a lot. There is a new API Reference section **Type definitions**
 that holds documentation for all constructible types, function parameters and
-return types, in the Apify SDK.
+return types, in Crawlee.
 
 Caveats
 ========

--- a/docs/readme/introduction.md
+++ b/docs/readme/introduction.md
@@ -1,12 +1,12 @@
 ---
 ---
-# Apify SDK: The scalable web crawling and scraping library for JavaScript
+# Crawlee: The scalable web crawling and scraping library for JavaScript
 
 <!-- Mirror this part to src/index.js -->
 
 [![npm version](https://badge.fury.io/js/apify.svg)](https://www.npmjs.com/package/apify)
 
-Apify SDK simplifies the development of web crawlers, scrapers, data extractors and web automation jobs.
+Crawlee simplifies the development of web crawlers, scrapers, data extractors and web automation jobs.
 It provides tools to manage and automatically scale a pool of headless browsers,
 to maintain queues of URLs to crawl, store crawling results to a local filesystem or into the cloud,
 rotate proxies and much more.
@@ -15,4 +15,4 @@ It can be used either stand-alone in your own applications
 or in [actors](https://docs.apify.com/actor)
 running on the [Apify Cloud](https://apify.com/).
 
-**View full documentation, guides and examples on the [Apify SDK project website](https://sdk.apify.com)**
+**View full documentation, guides and examples on the [Crawlee project website](https://sdk.apify.com)**

--- a/docs/readme/introduction.md
+++ b/docs/readme/introduction.md
@@ -4,13 +4,13 @@
 
 <!-- Mirror this part to src/index.js -->
 
-[![npm version](https://badge.fury.io/js/apify.svg)](https://www.npmjs.com/package/apify)
+[![npm version](https://badge.fury.io/js/crawlee.svg)](https://www.npmjs.com/package/crawlee)
 
 Crawlee simplifies the development of web crawlers, scrapers, data extractors and web automation jobs.
 It provides tools to manage and automatically scale a pool of headless browsers,
 to maintain queues of URLs to crawl, store crawling results to a local filesystem or into the cloud,
 rotate proxies and much more.
-The SDK is available as the [`apify`](https://www.npmjs.com/package/apify) NPM package.
+Crawlee is available as the [`crawlee`](https://www.npmjs.com/package/crawlee) NPM package.
 It can be used either stand-alone in your own applications
 or in [actors](https://docs.apify.com/actor)
 running on the [Apify Cloud](https://apify.com/).

--- a/docs/readme/overview.md
+++ b/docs/readme/overview.md
@@ -2,7 +2,7 @@
 ---
 ## Overview
 
-Crawlee is available as the [`apify`](https://www.npmjs.com/package/apify) NPM package and it provides the following tools:
+Crawlee is available as the [`crawlee`](https://www.npmjs.com/package/crawlee) NPM package and it provides the following tools:
 
 - [`CheerioCrawler`](https://sdk.apify.com/docs/api/cheerio-crawler) - Enables the parallel crawling of a large
   number of web pages using the [cheerio](https://www.npmjs.com/package/cheerio) HTML parser. This is the most
@@ -47,3 +47,4 @@ Crawlee is available as the [`apify`](https://www.npmjs.com/package/apify) NPM p
 Additionally, the package provides various helper functions to simplify running your code on the Apify Cloud and thus
 take advantage of its pool of proxies, job scheduler, data storage, etc.
 For more information, see the [Crawlee Programmer's Reference](https://sdk.apify.com).
+

--- a/docs/readme/overview.md
+++ b/docs/readme/overview.md
@@ -2,7 +2,7 @@
 ---
 ## Overview
 
-The Apify SDK is available as the [`apify`](https://www.npmjs.com/package/apify) NPM package and it provides the following tools:
+Crawlee is available as the [`apify`](https://www.npmjs.com/package/apify) NPM package and it provides the following tools:
 
 - [`CheerioCrawler`](https://sdk.apify.com/docs/api/cheerio-crawler) - Enables the parallel crawling of a large
   number of web pages using the [cheerio](https://www.npmjs.com/package/cheerio) HTML parser. This is the most
@@ -46,4 +46,4 @@ The Apify SDK is available as the [`apify`](https://www.npmjs.com/package/apify)
 
 Additionally, the package provides various helper functions to simplify running your code on the Apify Cloud and thus
 take advantage of its pool of proxies, job scheduler, data storage, etc.
-For more information, see the [Apify SDK Programmer's Reference](https://sdk.apify.com).
+For more information, see the [Crawlee Programmer's Reference](https://sdk.apify.com).

--- a/docs/readme/support.md
+++ b/docs/readme/support.md
@@ -2,7 +2,7 @@
 ---
 ## Support
 
-If you find any bug or issue with the Apify SDK, please [submit an issue on GitHub](https://github.com/apify/apify-js/issues).
+If you find any bug or issue with Crawlee, please [submit an issue on GitHub](https://github.com/apify/apify-js/issues).
 For questions, you can ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/apify) or contact support@apify.com
 
 ## Contributing

--- a/docs/upgrading/upgrading_v1.md
+++ b/docs/upgrading/upgrading_v1.md
@@ -5,7 +5,7 @@ title: Upgrading to v1
 
 ## Summary
 After 3.5 years of rapid development and a lot of breaking changes and deprecations,
-here comes the result - **Apify SDK v1**. There were two goals for this release. **Stability**
+here comes the result - **Crawlee v1**. There were two goals for this release. **Stability**
 and **adding support for more browsers** - Firefox and Webkit (Safari).
 
 The SDK has grown quite popular over the years, powering thousands of web scraping

--- a/docs/upgrading/upgrading_v1.md
+++ b/docs/upgrading/upgrading_v1.md
@@ -5,7 +5,7 @@ title: Upgrading to v1
 
 ## Summary
 After 3.5 years of rapid development and a lot of breaking changes and deprecations,
-here comes the result - **Crawlee v1**. There were two goals for this release. **Stability**
+here comes the result - **Apify SDK v1**. There were two goals for this release. **Stability**
 and **adding support for more browsers** - Firefox and Webkit (Safari).
 
 The SDK has grown quite popular over the years, powering thousands of web scraping


### PR DESCRIPTION
Following a [PR comment from the past](https://github.com/apify/apify-ts/pull/71#discussion_r849309797), documentation is updated with the new library name.
This does not affect the package name in commands or any URLs, only what has been captured with `(the )?Apify SDK`. 