### PR TITLE
refactor: remove `gotoFunction` and `gotoTimeoutSecs`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,8 @@
     ],
     "rules": {
         "no-void": 0,
+        "no-underscore-dangle": 0,
+        "max-classes-per-file": 0,
         "no-console": "error",
         "@typescript-eslint/array-type": "error",
         "@typescript-eslint/no-floating-promises": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - `ProxyConfiguration.newUrlFunction` can be async. `.newUrl()` and `.newProxyInfo()` now return promises.
 - stealth mode has been removed in favour of fingerprints and fingerprints are now enabled by default
 - `prepareRequestFunction` and `postResponseFunction` options are removed, use navigation hooks instead
+- `gotoFunction` and `gotoTimeoutSecs` are removed
 
 2.3.0 / 2022/04/07
 ====================

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -605,6 +605,17 @@ export class BasicCrawler<
         await this.requestHandler(crawlingContext);
     }
 
+    /**
+     * Handles blocked request
+     */
+    protected _throwOnBlockedRequest(session: Session, statusCode: number) {
+        const isBlocked = session.retireOnBlockedStatusCodes(statusCode);
+
+        if (isBlocked) {
+            throw new Error(`Request blocked - received ${statusCode} status code.`);
+        }
+    }
+
     protected async _pauseOnMigration() {
         if (this.autoscaledPool) {
             // if run wasn't called, this is going to crash

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -500,7 +500,6 @@ export class CheerioCrawler<JSONData = Dictionary> extends BasicCrawler<
     public proxyConfiguration?: ProxyConfiguration;
 
     protected userRequestHandlerTimeoutMillis: number;
-    protected defaultGotoOptions!: { timeout: number };
     protected preNavigationHooks: CheerioHook<JSONData>[];
     protected postNavigationHooks: CheerioHook<JSONData>[];
     protected persistCookiesPerSession: boolean;
@@ -908,17 +907,6 @@ export class CheerioCrawler<JSONData = Dictionary> extends BasicCrawler<
                 throw new Error(`Can not parse mime type ${mimeType} from "options.additionalMimeTypes".`);
             }
         });
-    }
-
-    /**
-     * Handles blocked request
-     */
-    protected _throwOnBlockedRequest(session: Session, statusCode: number) {
-        const isBlocked = session.retireOnBlockedStatusCodes(statusCode);
-
-        if (isBlocked) {
-            throw new Error(`Request blocked - received ${statusCode} status code`);
-        }
     }
 
     /**

--- a/packages/core/src/crawlers/crawler_utils.ts
+++ b/packages/core/src/crawlers/crawler_utils.ts
@@ -14,18 +14,6 @@ export function handleRequestTimeout({ session, errorMessage }: { session?: Sess
 }
 
 /**
- * Handles blocked request
- * @internal
- */
-export function throwOnBlockedRequest(session: Session, statusCode: number) {
-    const isBlocked = session.retireOnBlockedStatusCodes(statusCode);
-
-    if (isBlocked) {
-        throw new Error(`Request blocked - received ${statusCode} status code.`);
-    }
-}
-
-/**
  * Merges multiple cookie strings. Keys are compared case-sensitively, warning will be logged
  * if we see two cookies with same keys but different casing.
  * @internal

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -1,7 +1,6 @@
 import ow from 'ow';
 import { LaunchOptions, Page, Response } from 'playwright';
 import { BrowserPoolOptions, PlaywrightPlugin } from '@crawlee/browser-pool';
-import { Dictionary } from '@crawlee/utils';
 import {
     BrowserCrawler,
     BrowserCrawlerOptions,
@@ -23,7 +22,6 @@ export type PlaywrightCookie = Parameters<ReturnType<Page['context']>['addCookie
 
 export interface PlaywrightCrawlerOptions extends BrowserCrawlerOptions<
     PlaywrightCrawlingContext,
-    PlaywrightGotoOptions,
     { browserPlugins: [PlaywrightPlugin] }
 > {
     /**
@@ -246,11 +244,6 @@ export class PlaywrightCrawler extends BrowserCrawler<{ browserPlugins: [Playwri
     }
 
     protected override async _navigationHandler(crawlingContext: PlaywrightCrawlingContext, gotoOptions: DirectNavigationOptions) {
-        if (this.gotoFunction) {
-            this.log.deprecated('PlaywrightCrawler.gotoFunction is deprecated. Use "preNavigationHooks" and "postNavigationHooks" instead.');
-            return this.gotoFunction(crawlingContext, gotoOptions as Dictionary);
-        }
-
         return gotoExtended(crawlingContext.page, crawlingContext.request, gotoOptions);
     }
 

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -5,9 +5,6 @@ import {
     BrowserCrawlingContext,
     BrowserHook,
 } from '@crawlee/browser';
-import {
-    Dictionary,
-} from '@crawlee/utils';
 import { BrowserPoolOptions, PuppeteerPlugin } from '@crawlee/browser-pool';
 import ow from 'ow';
 import { HTTPResponse, LaunchOptions, Page } from 'puppeteer';
@@ -23,7 +20,6 @@ export type PuppeteerGoToOptions = Parameters<Page['goto']>[1];
 
 export interface PuppeteerCrawlerOptions extends BrowserCrawlerOptions<
     PuppeteerCrawlingContext,
-    PuppeteerGoToOptions,
     { browserPlugins: [PuppeteerPlugin] }
 > {
     /**
@@ -166,12 +162,6 @@ export class PuppeteerCrawler extends BrowserCrawler<{ browserPlugins: [Puppetee
     }
 
     protected override async _navigationHandler(crawlingContext: PuppeteerCrawlingContext, gotoOptions: DirectNavigationOptions) {
-        // TODO remove deprecated options in v3
-        if (this.gotoFunction) {
-            this.log.deprecated('PuppeteerCrawlerOptions.gotoFunction is deprecated. Use "preNavigationHooks" and "postNavigationHooks" instead.');
-
-            return this.gotoFunction(crawlingContext, gotoOptions as Dictionary);
-        }
         return gotoExtended(crawlingContext.page, crawlingContext.request, gotoOptions);
     }
 }

--- a/test/apify/crawlers/basic_browser_crawler.ts
+++ b/test/apify/crawlers/basic_browser_crawler.ts
@@ -1,9 +1,13 @@
-import { BrowserCrawler, PuppeteerCrawlingContext, PuppeteerCrawlerOptions } from '@crawlee/puppeteer';
+import { BrowserCrawler, PuppeteerCrawlingContext, PuppeteerCrawlerOptions, PuppeteerGoToOptions } from '@crawlee/puppeteer';
 import { PuppeteerPlugin } from '@crawlee/browser-pool';
-import { LaunchOptions } from 'puppeteer';
+import { HTTPResponse, LaunchOptions } from 'puppeteer';
 
 export class BrowserCrawlerTest extends BrowserCrawler<{ browserPlugins: [PuppeteerPlugin] }, LaunchOptions, PuppeteerCrawlingContext> {
     constructor(options: Partial<PuppeteerCrawlerOptions> = {}) {
         super(options as any);
+    }
+
+    protected _navigationHandler(ctx: PuppeteerCrawlingContext, gotoOptions: PuppeteerGoToOptions): Promise<HTTPResponse | null | undefined> {
+        return ctx.page.goto(ctx.request.url, gotoOptions);
     }
 }

--- a/test/apify/crawlers/playwright_crawler.test.ts
+++ b/test/apify/crawlers/playwright_crawler.test.ts
@@ -8,7 +8,6 @@ import {
     PlaywrightCrawler,
     PlaywrightGotoOptions,
     PlaywrightRequestHandler,
-    PlaywrightRequestHandlerParam,
     Request,
     RequestList,
 } from '@crawlee/playwright';
@@ -110,54 +109,6 @@ describe('PlaywrightCrawler', () => {
         });
     });
 
-    test('should override goto timeout with gotoTimeoutSecs', async () => {
-        const timeoutSecs = 10;
-        let options: PlaywrightGotoOptions;
-        const playwrightCrawler = new PlaywrightCrawler({ //eslint-disable-line
-            requestList,
-            maxRequestRetries: 0,
-            maxConcurrency: 1,
-            requestHandler: () => {
-            },
-            preNavigationHooks: [(_context, gotoOptions) => {
-                options = gotoOptions;
-            }],
-            gotoTimeoutSecs: timeoutSecs,
-        });
-
-        // @ts-expect-error Accessing private prop
-        expect(playwrightCrawler.defaultGotoOptions.timeout).toEqual(timeoutSecs * 1000);
-        await playwrightCrawler.run();
-
-        expect(options.timeout).toEqual(timeoutSecs * 1000);
-
-        expect.hasAssertions();
-    });
-    test('should support custom gotoFunction', async () => {
-        const functions = {
-            requestHandler: () => { },
-            gotoFunction: ({ page, request }: PlaywrightRequestHandlerParam, options: PlaywrightGotoOptions) => {
-                return page.goto(request.url, options);
-            },
-        };
-        jest.spyOn(functions, 'gotoFunction');
-        jest.spyOn(functions, 'requestHandler');
-        const playwrightCrawler = new PlaywrightCrawler({ //eslint-disable-line
-            requestList,
-            maxRequestRetries: 0,
-            maxConcurrency: 1,
-            requestHandler: functions.requestHandler,
-            gotoFunction: functions.gotoFunction,
-        });
-
-        // @ts-expect-error Accessing private method
-        expect(playwrightCrawler.gotoFunction).toEqual(functions.gotoFunction);
-        await playwrightCrawler.run();
-
-        expect(functions.gotoFunction).toBeCalled();
-        expect(functions.requestHandler).toBeCalled();
-    });
-
     test('should override goto timeout with navigationTimeoutSecs', async () => {
         const timeoutSecs = 10;
         let options: PlaywrightGotoOptions;
@@ -173,10 +124,7 @@ describe('PlaywrightCrawler', () => {
             navigationTimeoutSecs: timeoutSecs,
         });
 
-        // @ts-expect-error Accessing private prop
-        expect(playwrightCrawler.defaultGotoOptions.timeout).toEqual(timeoutSecs * 1000);
         await playwrightCrawler.run();
-
         expect(options.timeout).toEqual(timeoutSecs * 1000);
     });
 });

--- a/test/apify/crawlers/puppeteer_crawler.test.ts
+++ b/test/apify/crawlers/puppeteer_crawler.test.ts
@@ -7,7 +7,6 @@ import {
     PuppeteerCrawler,
     PuppeteerGoToOptions,
     PuppeteerRequestHandler,
-    PuppeteerRequestHandlerParam,
     Request,
     RequestList,
     RequestQueue,
@@ -126,53 +125,7 @@ describe('PuppeteerCrawler', () => {
         });
     });
 
-    test('should override goto timeout with gotoTimeoutSecs ', async () => {
-        const timeoutSecs = 10;
-        let options: PuppeteerGoToOptions;
-        const puppeteerCrawler = new PuppeteerCrawler({
-            requestList,
-            maxRequestRetries: 0,
-            maxConcurrency: 1,
-            requestHandler: () => {},
-            preNavigationHooks: [(_context, gotoOptions) => {
-                options = gotoOptions;
-            }],
-            gotoTimeoutSecs: timeoutSecs,
-        });
-
-        // @ts-expect-error Accessing private prop
-        expect(puppeteerCrawler.defaultGotoOptions.timeout).toEqual(timeoutSecs * 1000);
-        await puppeteerCrawler.run();
-
-        expect(options.timeout).toEqual(timeoutSecs * 1000);
-    });
-
-    test('should support custom gotoFunction', async () => {
-        const functions = {
-            requestHandler: async () => {},
-            gotoFunction: ({ page, request }: PuppeteerRequestHandlerParam, options: PuppeteerGoToOptions) => {
-                return page.goto(request.url, options);
-            },
-        };
-        jest.spyOn(functions, 'gotoFunction');
-        jest.spyOn(functions, 'requestHandler');
-        const puppeteerCrawler = new PuppeteerCrawler({
-            requestList,
-            maxRequestRetries: 0,
-            maxConcurrency: 1,
-            requestHandler: functions.requestHandler,
-            gotoFunction: functions.gotoFunction,
-        });
-
-        // @ts-expect-error Accessing private method
-        expect(puppeteerCrawler.gotoFunction).toEqual(functions.gotoFunction);
-        await puppeteerCrawler.run();
-
-        expect(functions.gotoFunction).toBeCalled();
-        expect(functions.requestHandler).toBeCalled();
-    });
-
-    test('should override goto timeout with navigationTimeoutSecs ', async () => {
+    test('should override goto timeout with navigationTimeoutSecs', async () => {
         const timeoutSecs = 10;
         let options: PuppeteerGoToOptions;
         const puppeteerCrawler = new PuppeteerCrawler({
@@ -186,10 +139,7 @@ describe('PuppeteerCrawler', () => {
             navigationTimeoutSecs: timeoutSecs,
         });
 
-        // @ts-expect-error Accessing private method
-        expect(puppeteerCrawler.defaultGotoOptions.timeout).toEqual(timeoutSecs * 1000);
         await puppeteerCrawler.run();
-
         expect(options.timeout).toEqual(timeoutSecs * 1000);
     });
 


### PR DESCRIPTION
BREAKING CHANGE:
`gotoFunction` and `gotoTimeoutSecs` are removed in favour of nav hooks and `gotoTimeoutSecs`.