### PR TITLE
fix: update purgeLocalStorage function to mimic 'purge' param of 'apify run'

### DIFF
--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -1,4 +1,4 @@
-import { ENV_VARS } from '@apify/consts';
+import { ENV_VARS, LOCAL_ENV_VARS, LOCAL_STORAGE_SUBDIRS, KEY_VALUE_STORE_KEYS } from '@apify/consts';
 import contentTypeParser from 'content-type';
 import mime from 'mime-types';
 import fs from 'node:fs/promises';
@@ -6,6 +6,7 @@ import type { IncomingMessage } from 'node:http';
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import { URL } from 'node:url';
+import { pathExists } from 'fs-extra';
 import ow from 'ow';
 
 /**
@@ -98,10 +99,10 @@ export function snakeCaseToCamelCase(snakeCaseStr: string): string {
 }
 
 /**
- * Cleans up the local storage folder created when testing locally.
- * This is useful in the event you are debugging your code locally.
- *
- * Be careful as this will remove the folder you provide and everything in it!
+ * Cleans up the default local storage directories before the run starts:
+ *  - local directory containing the default dataset;
+ *  - all records from the default key-value store in the local directory, except for the "INPUT" key;
+ *  - local directory containing the default request queue.
  *
  * @param [folder] The folder to clean up
  */
@@ -109,10 +110,34 @@ export async function purgeLocalStorage(folder?: string): Promise<void> {
     // If the user did not provide a folder, try to get it from the env variables, or the default one
     if (!folder) {
         folder = process.env[ENV_VARS.LOCAL_STORAGE_DIR] || 'apify_storage';
-    }
 
-    // Clear the folder
-    await fs.rm(folder, { recursive: true, force: true });
+        const defaultDatasetPath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.datasets, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_DATASET_ID]);
+        await removeFiles(defaultDatasetPath);
+
+        const defaultKeyValueStorePath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.keyValueStores, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_KEY_VALUE_STORE_ID]);
+        await removeFiles(defaultKeyValueStorePath);
+
+        const defaultRequestQueuePath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.requestQueues, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_REQUEST_QUEUE_ID]);
+        await removeFiles(defaultRequestQueuePath);
+    }
+}
+
+async function removeFiles(folder: string): Promise<void> {
+    const storagePathExists = await pathExists(folder);
+
+    if (storagePathExists) {
+        const direntNames = await fs.readdir(folder);
+
+        const deletePromises = [];
+        for (const direntName of direntNames) {
+            const fileName = path.join(folder, direntName);
+            if (!RegExp(KEY_VALUE_STORE_KEYS.INPUT).test(fileName)) {
+                deletePromises.push(fs.rm(fileName, { recursive: true, force: true }));
+            }
+        }
+
+        await Promise.all(deletePromises);
+    }
 }
 
 /**

--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -108,18 +108,16 @@ export function snakeCaseToCamelCase(snakeCaseStr: string): string {
  */
 export async function purgeLocalStorage(folder?: string): Promise<void> {
     // If the user did not provide a folder, try to get it from the env variables, or the default one
-    if (!folder) {
-        folder = process.env[ENV_VARS.LOCAL_STORAGE_DIR] || 'apify_storage';
+    if (!folder) folder = process.env[ENV_VARS.LOCAL_STORAGE_DIR] || 'apify_storage';
 
-        const defaultDatasetPath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.datasets, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_DATASET_ID]);
-        await removeFiles(defaultDatasetPath);
+    const defaultDatasetPath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.datasets, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_DATASET_ID]);
+    await removeFiles(defaultDatasetPath);
 
-        const defaultKeyValueStorePath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.keyValueStores, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_KEY_VALUE_STORE_ID]);
-        await removeFiles(defaultKeyValueStorePath);
+    const defaultKeyValueStorePath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.keyValueStores, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_KEY_VALUE_STORE_ID]);
+    await removeFiles(defaultKeyValueStorePath);
 
-        const defaultRequestQueuePath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.requestQueues, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_REQUEST_QUEUE_ID]);
-        await removeFiles(defaultRequestQueuePath);
-    }
+    const defaultRequestQueuePath = path.resolve(folder, LOCAL_STORAGE_SUBDIRS.requestQueues, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_REQUEST_QUEUE_ID]);
+    await removeFiles(defaultRequestQueuePath);
 }
 
 async function removeFiles(folder: string): Promise<void> {

--- a/test/utils/general.test.ts
+++ b/test/utils/general.test.ts
@@ -9,7 +9,10 @@ import {
 import { IncomingMessage } from 'node:http';
 import syncFs from 'node:fs';
 import asyncFs from 'node:fs/promises';
-import { ENV_VARS } from '@apify/consts';
+import path from 'node:path';
+import { ensureDir, writeFile } from 'fs-extra';
+import { ENV_VARS, LOCAL_STORAGE_SUBDIRS } from '@apify/consts';
+import { join } from 'path';
 
 describe('isDocker()', () => {
     test('works for dockerenv && cgroup', async () => {
@@ -101,20 +104,67 @@ describe('snakeCaseToCamelCase()', () => {
 });
 
 describe('purgeLocalStorage()', () => {
-    // Create test folders
-    process.env[ENV_VARS.LOCAL_STORAGE_DIR] = `./test_storage_${Date.now().toString(16)}`;
-    const folder = Date.now().toString(16);
-    syncFs.mkdirSync(folder);
-    syncFs.mkdirSync(process.env[ENV_VARS.LOCAL_STORAGE_DIR]);
+    const folders: string[] = [];
+    let customFolder: string;
+
+    beforeAll(async () => {
+        process.env[ENV_VARS.LOCAL_STORAGE_DIR] = path.resolve('test/utils', `./test_storage_${Date.now().toString(16)}`);
+        folders.push(process.env[ENV_VARS.LOCAL_STORAGE_DIR]);
+
+        customFolder = path.resolve('test/utils', Date.now().toString(16));
+        folders.push(customFolder);
+
+        for (const folder of folders) {
+            for (const storage in LOCAL_STORAGE_SUBDIRS) { // eslint-disable-line
+                const subFolder = LOCAL_STORAGE_SUBDIRS[storage as keyof typeof LOCAL_STORAGE_SUBDIRS];
+
+                for (const storageName of ['default', 'non-default']) {
+                    const storagePath = path.resolve(folder, subFolder, storageName);
+                    await ensureDir(storagePath);
+
+                    const fileData = JSON.stringify({ foo: 'bar' });
+                    await writeFile(join(storagePath, '000000001.json'), fileData);
+
+                    if (storage === 'keyValueStores') {
+                        await writeFile(join(storagePath, 'INPUT.json'), fileData);
+                    }
+                }
+            }
+        }
+    });
+
+    afterAll(async () => {
+        for (const folder of folders) {
+            await asyncFs.rm(folder, { recursive: true, force: true });
+        }
+    });
 
     test('should purge local storage by default', async () => {
         await expect(purgeLocalStorage()).resolves.toBeUndefined();
-        expect(syncFs.existsSync(process.env[ENV_VARS.LOCAL_STORAGE_DIR])).toBe(false);
+        const folder = process.env[ENV_VARS.LOCAL_STORAGE_DIR];
+        // default storages should be empty, except INPUT.json file
+        expect(syncFs.readdirSync(path.join(folder, 'datasets', 'default')).length).toBe(0);
+        expect(syncFs.readdirSync(path.join(folder, 'key_value_stores', 'default')).length).toBe(1);
+        expect(syncFs.readdirSync(path.join(folder, 'key_value_stores', 'default'))[0]).toBe('INPUT.json');
+        expect(syncFs.readdirSync(path.join(folder, 'request_queues', 'default')).length).toBe(0);
+        // non-default storages should keep their state and should not be cleared
+        expect(syncFs.readdirSync(path.join(folder, 'datasets', 'non-default')).length).toBe(1);
+        expect(syncFs.readdirSync(path.join(folder, 'key_value_stores', 'non-default')).length).toBe(2);
+        expect(syncFs.readdirSync(path.join(folder, 'request_queues', 'non-default')).length).toBe(1);
     });
 
     test('should purge local storage when passing custom name', async () => {
-        await expect(purgeLocalStorage(folder)).resolves.toBeUndefined();
-        expect(syncFs.existsSync(folder)).toBe(false);
+        await expect(purgeLocalStorage(customFolder)).resolves.toBeUndefined();
+        const folder = customFolder;
+        // default storages should be empty, except INPUT.json file
+        expect(syncFs.readdirSync(path.join(folder, 'datasets', 'default')).length).toBe(0);
+        expect(syncFs.readdirSync(path.join(folder, 'key_value_stores', 'default')).length).toBe(1);
+        expect(syncFs.readdirSync(path.join(folder, 'key_value_stores', 'default'))[0]).toBe('INPUT.json');
+        expect(syncFs.readdirSync(path.join(folder, 'request_queues', 'default')).length).toBe(0);
+        // non-default storages should keep their state and should not be cleared
+        expect(syncFs.readdirSync(path.join(folder, 'datasets', 'non-default')).length).toBe(1);
+        expect(syncFs.readdirSync(path.join(folder, 'key_value_stores', 'non-default')).length).toBe(2);
+        expect(syncFs.readdirSync(path.join(folder, 'request_queues', 'non-default')).length).toBe(1);
     });
 });
 


### PR DESCRIPTION
This PR fixes the usage of  `{ purge: true }` param of `Actor.main()`. Currently using `{ purge: true }` will lead to the removal of everything inside of the `apify_storage` folder, while it should only remove default storage folders contents (besides `INPUT.json` file), i.e. mimic `apify run -p`.

Closes #102.

Ready for review, but do not merge it yet, also need to update the tests.