### PR TITLE
test: enable storage-local for e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
             ],
             "devDependencies": {
                 "@apify/eslint-config-ts": "^0.2.3",
-                "@apify/storage-local": "^2.0.3-beta.3",
+                "@apify/storage-local": "^2.0.3-beta.5",
                 "@apify/tsconfig": "^0.1.0",
                 "@commitlint/config-conventional": "^16.2.4",
                 "@types/content-type": "^1.1.5",
@@ -150,9 +150,9 @@
             "link": true
         },
         "node_modules/@apify/storage-local": {
-            "version": "2.0.3-beta.3",
-            "resolved": "https://registry.npmjs.org/@apify/storage-local/-/storage-local-2.0.3-beta.3.tgz",
-            "integrity": "sha512-Zn2UWr++s2ZE5dmzxzqWixlLYD6jtoPRhGdLzWSd+/quhYzrmw2fQoy8GGvasYI3ps4ZMNwarmZAuLdtqjhaEA==",
+            "version": "2.0.3-beta.5",
+            "resolved": "https://registry.npmjs.org/@apify/storage-local/-/storage-local-2.0.3-beta.5.tgz",
+            "integrity": "sha512-Ue2LXfv+sYKZYJdrnQAbyajEu/yVy7XP72+XYvv1M/H7GdlXmSWwEt7Sv/sy66CrDw2mscHXlJM3d16Z8KNH5A==",
             "dev": true,
             "dependencies": {
                 "@apify/consts": "^1.0.0",
@@ -15940,9 +15940,9 @@
             }
         },
         "@apify/storage-local": {
-            "version": "2.0.3-beta.3",
-            "resolved": "https://registry.npmjs.org/@apify/storage-local/-/storage-local-2.0.3-beta.3.tgz",
-            "integrity": "sha512-Zn2UWr++s2ZE5dmzxzqWixlLYD6jtoPRhGdLzWSd+/quhYzrmw2fQoy8GGvasYI3ps4ZMNwarmZAuLdtqjhaEA==",
+            "version": "2.0.3-beta.5",
+            "resolved": "https://registry.npmjs.org/@apify/storage-local/-/storage-local-2.0.3-beta.5.tgz",
+            "integrity": "sha512-Ue2LXfv+sYKZYJdrnQAbyajEu/yVy7XP72+XYvv1M/H7GdlXmSWwEt7Sv/sy66CrDw2mscHXlJM3d16Z8KNH5A==",
             "dev": true,
             "requires": {
                 "@apify/consts": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.2.3",
-        "@apify/storage-local": "^2.0.3-beta.3",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@apify/tsconfig": "^0.1.0",
         "@commitlint/config-conventional": "^16.2.4",
         "@types/content-type": "^1.1.5",

--- a/test/e2e/autoscaling-max-tasks-per-minute/actor/main.js
+++ b/test/e2e/autoscaling-max-tasks-per-minute/actor/main.js
@@ -1,11 +1,17 @@
 import { Actor } from 'apify';
 import { BasicCrawler, log as defaultLog, LogLevel } from '@crawlee/basic';
+import { ApifyStorageLocal } from '@apify/storage-local';
 
 const crawlerLogger = defaultLog.child({
     prefix: 'AutoscalingTest',
     // Set this to false if you want to see verbose output from the autoscaled pool
     level: true ? defaultLog.getOptions().level : LogLevel.PERF,
 });
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 let crawlCalledAt = Date.now();
 
@@ -21,4 +27,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://example.com/1', 'https://example.com/2']);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/autoscaling-max-tasks-per-minute/actor/package.json
+++ b/test/e2e/autoscaling-max-tasks-per-minute/actor/package.json
@@ -4,9 +4,12 @@
 	"description": "Autoscaling Pool Test - Max Tasks per Minute",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils"
     },
     "scripts": { "start": "node main.js" },

--- a/test/e2e/cheerio-default/actor/main.js
+++ b/test/e2e/cheerio-default/actor/main.js
@@ -2,7 +2,7 @@ import { Actor } from 'apify';
 import { CheerioCrawler } from '@crawlee/cheerio';
 import { ApifyStorageLocal } from '@apify/storage-local';
 
-const mainOpts = {
+const mainOptions = {
     exit: Actor.isAtHome(),
     storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
 };
@@ -22,4 +22,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://apify.com']);
     await crawler.run();
-}, mainOpts);
+}, mainOptions);

--- a/test/e2e/cheerio-default/actor/main.js
+++ b/test/e2e/cheerio-default/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { CheerioCrawler } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOpts = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
@@ -16,4 +22,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://apify.com']);
     await crawler.run();
-}, { exit: false });
+}, mainOpts);

--- a/test/e2e/cheerio-default/actor/package.json
+++ b/test/e2e/cheerio-default/actor/package.json
@@ -5,13 +5,13 @@
 	"dependencies": {
         "apify": "file:./packages/apify",
         "@apify/storage-local": "^2.0.3-beta.5",
-        "@crawlee/core": "file:./packages/core",
         "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
+        "@crawlee/core": "file:./packages/core",
         "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/types": "file:./packages/types",
-        "@crawlee/utils": "file:./packages/utils",
-        "@crawlee/browser-pool": "file:./packages/browser-pool"
+        "@crawlee/utils": "file:./packages/utils"
     },
     "scripts": { "start": "node main.js" },
 	"type": "module",

--- a/test/e2e/cheerio-default/actor/package.json
+++ b/test/e2e/cheerio-default/actor/package.json
@@ -4,9 +4,12 @@
 	"description": "Cheerio Crawler Test - Default",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/core": "file:./packages/core",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "@crawlee/browser-pool": "file:./packages/browser-pool"
     },

--- a/test/e2e/cheerio-enqueue-links/actor/main.js
+++ b/test/e2e/cheerio-enqueue-links/actor/main.js
@@ -1,6 +1,12 @@
 import { Actor } from 'apify';
 import { CheerioCrawler } from '@crawlee/cheerio';
 import deepEqual from 'deep-equal';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
@@ -22,4 +28,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://apify.com/about']);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/cheerio-enqueue-links/actor/package.json
+++ b/test/e2e/cheerio-enqueue-links/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Cheerio Crawler Test - Enqueue Links",
 	"dependencies": {
         "apify": "file:./packages/apify",
-        "@crawlee/core": "file:./packages/core",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
-        "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/utils": "file:./packages/utils",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
+        "@crawlee/cheerio": "file:./packages/cheerio-crawler",
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils",
         "deep-equal": "^2.0.5"
     },
     "scripts": { "start": "node main.js" },

--- a/test/e2e/cheerio-ignore-ssl-errors/actor/main.js
+++ b/test/e2e/cheerio-ignore-ssl-errors/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { CheerioCrawler } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
@@ -23,4 +29,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests([{ url: 'https://badssl.com', userData: { label: 'START' } }]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/cheerio-ignore-ssl-errors/actor/package.json
+++ b/test/e2e/cheerio-ignore-ssl-errors/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Cheerio Crawler Test - Ignore SSL Errors",
 	"dependencies": {
         "apify": "file:./packages/apify",
-        "@crawlee/core": "file:./packages/core",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/utils": "file:./packages/utils",
-        "@crawlee/browser-pool": "file:./packages/browser-pool"
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
     },
     "scripts": { "start": "node main.js" },
 	"type": "module",

--- a/test/e2e/cheerio-initial-cookies/actor/main.js
+++ b/test/e2e/cheerio-initial-cookies/actor/main.js
@@ -1,5 +1,6 @@
 import { Actor } from 'apify';
 import { CheerioCrawler } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
 
 const initialCookies = [
     {
@@ -15,6 +16,11 @@ const initialCookies = [
         value: 'value market place',
     },
 ];
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
@@ -44,4 +50,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://api.apify.com/v2/browser-info']);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/cheerio-initial-cookies/actor/package.json
+++ b/test/e2e/cheerio-initial-cookies/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Cheerio Crawler Test - Initial Cookies",
 	"dependencies": {
         "apify": "file:./packages/apify",
-        "@crawlee/core": "file:./packages/core",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/utils": "file:./packages/utils",
-        "@crawlee/browser-pool": "file:./packages/browser-pool"
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
     },
     "scripts": { "start": "node main.js" },
 	"type": "module",

--- a/test/e2e/cheerio-max-requests/actor/main.js
+++ b/test/e2e/cheerio-max-requests/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { CheerioCrawler } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
@@ -40,4 +46,4 @@ await Actor.main(async () => {
         { url: 'https://apify.com/mshopik', userData: { label: 'START' } },
     ]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/cheerio-max-requests/actor/package.json
+++ b/test/e2e/cheerio-max-requests/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Cheerio Crawler Test - Max Requests Per Crawl",
 	"dependencies": {
         "apify": "file:./packages/apify",
-        "@crawlee/core": "file:./packages/core",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/utils": "file:./packages/utils",
-        "@crawlee/browser-pool": "file:./packages/browser-pool"
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
     },
     "scripts": { "start": "node main.js" },
 	"type": "module",

--- a/test/e2e/cheerio-page-info/actor/main.js
+++ b/test/e2e/cheerio-page-info/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { CheerioCrawler } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
@@ -35,4 +41,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests([{ url: 'https://apify.com/apify', userData: { label: 'START' } }]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/cheerio-page-info/actor/package.json
+++ b/test/e2e/cheerio-page-info/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Cheerio Crawler Test - Page Info",
 	"dependencies": {
         "apify": "file:./packages/apify",
-        "@crawlee/core": "file:./packages/core",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/utils": "file:./packages/utils",
-        "@crawlee/browser-pool": "file:./packages/browser-pool"
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
     },
     "scripts": { "start": "node main.js" },
 	"type": "module",

--- a/test/e2e/cheerio-throw-on-ssl-errors/actor/main.js
+++ b/test/e2e/cheerio-throw-on-ssl-errors/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { CheerioCrawler } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
@@ -24,4 +30,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests([{ url: 'https://badssl.com', userData: { label: 'START' } }]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/cheerio-throw-on-ssl-errors/actor/package.json
+++ b/test/e2e/cheerio-throw-on-ssl-errors/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Cheerio Crawler Test - Should throw on SSL Errors",
 	"dependencies": {
         "apify": "file:./packages/apify",
-        "@crawlee/core": "file:./packages/core",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/utils": "file:./packages/utils",
-        "@crawlee/browser-pool": "file:./packages/browser-pool"
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
     },
     "scripts": { "start": "node main.js" },
 	"type": "module",

--- a/test/e2e/playwright-default/actor/main.js
+++ b/test/e2e/playwright-default/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { PlaywrightCrawler } from '@crawlee/playwright';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PlaywrightCrawler({
@@ -16,4 +22,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://apify.com']);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/playwright-default/actor/package.json
+++ b/test/e2e/playwright-default/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Playwright Test - Default",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/playwright": "file:./packages/playwright-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "playwright": "*"
     },

--- a/test/e2e/proxy-rotation/actor/main.js
+++ b/test/e2e/proxy-rotation/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -25,4 +31,4 @@ await Actor.main(async () => {
         (_, i) => ({ url: 'https://api.apify.com/v2/browser-info', uniqueKey: `${i}` }),
     ));
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/proxy-rotation/actor/package.json
+++ b/test/e2e/proxy-rotation/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Proxy Test - Rotation",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "puppeteer": "*"
     },

--- a/test/e2e/puppeteer-default/actor/main.js
+++ b/test/e2e/puppeteer-default/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -16,4 +22,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://apify.com']);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/puppeteer-default/actor/package.json
+++ b/test/e2e/puppeteer-default/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Puppeteer Test - Default",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "puppeteer": "*"
     },

--- a/test/e2e/puppeteer-enqueue-links/actor/main.js
+++ b/test/e2e/puppeteer-enqueue-links/actor/main.js
@@ -1,6 +1,12 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
 import deepEqual from 'deep-equal';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -22,4 +28,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://apify.com/about']);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/puppeteer-enqueue-links/actor/package.json
+++ b/test/e2e/puppeteer-enqueue-links/actor/package.json
@@ -4,14 +4,17 @@
 	"description": "Puppeteer Test - Enqueue Links",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
-        "puppeteer": "*",
-        "deep-equal": "^2.0.5"
+        "deep-equal": "^2.0.5",
+        "puppeteer": "*"
     },
     "scripts": { "start": "node main.js" },
 	"type": "module",

--- a/test/e2e/puppeteer-ignore-ssl-errors/actor/main.js
+++ b/test/e2e/puppeteer-ignore-ssl-errors/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -26,4 +32,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests([{ url: 'https://badssl.com', userData: { label: 'START' } }]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/puppeteer-ignore-ssl-errors/actor/package.json
+++ b/test/e2e/puppeteer-ignore-ssl-errors/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Puppeteer Test - Ignore SSL Errors",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "puppeteer": "*"
     },

--- a/test/e2e/puppeteer-initial-cookies/actor/main.js
+++ b/test/e2e/puppeteer-initial-cookies/actor/main.js
@@ -1,5 +1,6 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { ApifyStorageLocal } from '@apify/storage-local';
 
 const initialCookies = [
     {
@@ -15,6 +16,11 @@ const initialCookies = [
         value: 'value market place',
     },
 ];
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -40,4 +46,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests(['https://api.apify.com/v2/browser-info']);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/puppeteer-initial-cookies/actor/package.json
+++ b/test/e2e/puppeteer-initial-cookies/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Puppeteer Test - Initial Cookies",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "puppeteer": "*"
     },

--- a/test/e2e/puppeteer-page-info/actor/main.js
+++ b/test/e2e/puppeteer-page-info/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -46,4 +52,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests([{ url: 'https://apify.com/store', userData: { label: 'START' } }]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/puppeteer-page-info/actor/package.json
+++ b/test/e2e/puppeteer-page-info/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Puppeteer Test - Page Info",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "puppeteer": "*"
     },

--- a/test/e2e/puppeteer-store-pagination-jquery/actor/main.js
+++ b/test/e2e/puppeteer-store-pagination-jquery/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -62,4 +68,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests([{ url: 'https://apify.com/store?page=1', userData: { label: 'START' } }]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/puppeteer-store-pagination-jquery/actor/package.json
+++ b/test/e2e/puppeteer-store-pagination-jquery/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Puppeteer Test - Store Pagination with jQuery",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "puppeteer": "*"
     },

--- a/test/e2e/puppeteer-store-pagination/actor/main.js
+++ b/test/e2e/puppeteer-store-pagination/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -72,4 +78,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests([{ url: 'https://apify.com/store?page=1', userData: { label: 'START' } }]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/puppeteer-store-pagination/actor/package.json
+++ b/test/e2e/puppeteer-store-pagination/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Puppeteer Test - Store Pagination",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "puppeteer": "*"
     },

--- a/test/e2e/puppeteer-throw-on-ssl-errors/actor/main.js
+++ b/test/e2e/puppeteer-throw-on-ssl-errors/actor/main.js
@@ -1,5 +1,11 @@
 import { Actor } from 'apify';
 import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -26,4 +32,4 @@ await Actor.main(async () => {
 
     await crawler.addRequests([{ url: 'https://badssl.com', userData: { label: 'START' } }]);
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/puppeteer-throw-on-ssl-errors/actor/package.json
+++ b/test/e2e/puppeteer-throw-on-ssl-errors/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Puppeteer Test - Should throw on SSL Errors",
 	"dependencies": {
         "apify": "file:./packages/apify",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser": "file:./packages/browser-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
+        "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "puppeteer": "*"
     },

--- a/test/e2e/request-queue-zero-concurrency/actor/main.js
+++ b/test/e2e/request-queue-zero-concurrency/actor/main.js
@@ -1,9 +1,15 @@
 import { Actor } from 'apify';
 import { CheerioCrawler, log } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
 
 log.setLevel(log.LEVELS.DEBUG);
 
 process.env.CRAWLEE_INTERNAL_TIMEOUT = '30000';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 // RequestQueue auto-reset when stuck with requests in progress
 await Actor.main(async () => {
@@ -22,4 +28,4 @@ await Actor.main(async () => {
     });
 
     await crawler.run();
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/request-queue-zero-concurrency/actor/package.json
+++ b/test/e2e/request-queue-zero-concurrency/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Request Queue Test - Zero Concurrency",
 	"dependencies": {
         "apify": "file:./packages/apify",
-        "@crawlee/core": "file:./packages/core",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/utils": "file:./packages/utils",
-        "@crawlee/browser-pool": "file:./packages/browser-pool"
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
     },
     "scripts": { "start": "node main.js" },
 	"type": "module",

--- a/test/e2e/request-skip-navigation/actor/main.js
+++ b/test/e2e/request-skip-navigation/actor/main.js
@@ -1,5 +1,6 @@
 import { Actor } from 'apify';
 import { CheerioCrawler, log, Request } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
 
 log.setLevel(log.LEVELS.DEBUG);
 
@@ -18,6 +19,11 @@ r2.userData = { xyz: { kjl: 'mno' } };
 const r3 = new Request({
     url: 'https://example.com/?q=3',
 });
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
 
 // Persisting internal settings of `Request`.
 await Actor.main(async () => {
@@ -40,4 +46,4 @@ await Actor.main(async () => {
     await crawler.run();
 
     await Actor.pushData({ requestCounter, navigationCounter });
-}, { exit: false });
+}, mainOptions);

--- a/test/e2e/request-skip-navigation/actor/package.json
+++ b/test/e2e/request-skip-navigation/actor/package.json
@@ -4,11 +4,14 @@
 	"description": "Request Test - skipNavigation",
 	"dependencies": {
         "apify": "file:./packages/apify",
-        "@crawlee/core": "file:./packages/core",
+        "@apify/storage-local": "^2.0.3-beta.5",
         "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/utils": "file:./packages/utils",
-        "@crawlee/browser-pool": "file:./packages/browser-pool"
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
     },
 	"scripts": { "start": "node main.js" },
 	"type": "module",


### PR DESCRIPTION
By default `process.env.STORAGE_IMPLEMENTATION` is set to `MEMORY` now (as it's default for `Actor`). Tried to run it in CI - finished successfully.

For the `PLATFORM` - it would just run on the platform as before (platform tests are currently running, but it should be fine).

If set to `LOCAL` - `@apify/storage-local` will be used - tried locally - finished with no issues.

UPD: platform tests expectedly finished successfully.