### PR TITLE
test: optimise some e2e tests

### DIFF
--- a/test/e2e/cheerio-enqueue-links/actor/main.js
+++ b/test/e2e/cheerio-enqueue-links/actor/main.js
@@ -10,14 +10,14 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        maxRequestsPerCrawl: 200,
+        maxRequestsPerCrawl: 30,
         async requestHandler({ $, enqueueLinks, request, log }) {
             const { url, loadedUrl } = request;
 
             const pageTitle = $('title').first().text();
             log.info(`URL: ${url}; LOADED_URL: ${loadedUrl}; TITLE: ${pageTitle}`);
 
-            const results = await enqueueLinks();
+            const results = await enqueueLinks({ selector: '[class^=CustomRebass__Box] a' });
 
             if (loadedUrl.startsWith('https://drive')) {
                 const isEqual = deepEqual(results, { processedRequests: [], unprocessedRequests: [] });

--- a/test/e2e/cheerio-max-requests/actor/main.js
+++ b/test/e2e/cheerio-max-requests/actor/main.js
@@ -9,7 +9,6 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        maxRequestsPerCrawl: 500,
         async requestHandler({ $, request }) {
             const { url, userData: { label } } = request;
 
@@ -41,9 +40,6 @@ await Actor.main(async () => {
         },
     });
 
-    await crawler.addRequests([
-        { url: 'https://apify.com/apify', userData: { label: 'START' } },
-        { url: 'https://apify.com/mshopik', userData: { label: 'START' } },
-    ]);
+    await crawler.addRequests([{ url: 'https://apify.com/apify', userData: { label: 'START' } }]);
     await crawler.run();
 }, mainOptions);

--- a/test/e2e/cheerio-max-requests/actor/main.js
+++ b/test/e2e/cheerio-max-requests/actor/main.js
@@ -9,6 +9,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
+        maxRequestsPerCrawl: 10,
         async requestHandler({ $, request }) {
             const { url, userData: { label } } = request;
 

--- a/test/e2e/cheerio-max-requests/test.mjs
+++ b/test/e2e/cheerio-max-requests/test.mjs
@@ -5,8 +5,8 @@ await initialize(testActorDirname);
 
 const { stats, datasetItems } = await runActor(testActorDirname);
 
-await expect(stats.requestsFinished > 35, 'All requests finished');
-await expect(datasetItems.length > 30 && datasetItems.length < 40, 'Number of dataset items');
+await expect(stats.requestsFinished > 10, 'All requests finished');
+await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');
 await expect(
     validateDataset(datasetItems, ['url', 'title', 'uniqueIdentifier', 'description', 'modifiedDate', 'runCount']),
     'Dataset items validation',

--- a/test/e2e/cheerio-max-requests/test.mjs
+++ b/test/e2e/cheerio-max-requests/test.mjs
@@ -5,8 +5,8 @@ await initialize(testActorDirname);
 
 const { stats, datasetItems } = await runActor(testActorDirname);
 
-await expect(stats.requestsFinished > 475, 'All requests finished');
-await expect(datasetItems.length > 475 && datasetItems.length < 525, 'Number of dataset items');
+await expect(stats.requestsFinished > 35, 'All requests finished');
+await expect(datasetItems.length > 30 && datasetItems.length < 40, 'Number of dataset items');
 await expect(
     validateDataset(datasetItems, ['url', 'title', 'uniqueIdentifier', 'description', 'modifiedDate', 'runCount']),
     'Dataset items validation',

--- a/test/e2e/playwright-default/test.mjs
+++ b/test/e2e/playwright-default/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished > 50, 'All requests finished');
 await expect(datasetItems.length > 50 && datasetItems.length < 150, 'Number of dataset items');

--- a/test/e2e/playwright-default/test.mjs
+++ b/test/e2e/playwright-default/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 50, 'All requests finished');
 await expect(datasetItems.length > 50 && datasetItems.length < 150, 'Number of dataset items');

--- a/test/e2e/playwright-default/test.mjs
+++ b/test/e2e/playwright-default/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 50, 'All requests finished');
 await expect(datasetItems.length > 50 && datasetItems.length < 150, 'Number of dataset items');

--- a/test/e2e/proxy-rotation/test.mjs
+++ b/test/e2e/proxy-rotation/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished === 5, 'All requests finished');
 await expect(datasetItems.length === 5, 'Number of dataset items');

--- a/test/e2e/proxy-rotation/test.mjs
+++ b/test/e2e/proxy-rotation/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished === 5, 'All requests finished');
 await expect(datasetItems.length === 5, 'Number of dataset items');

--- a/test/e2e/proxy-rotation/test.mjs
+++ b/test/e2e/proxy-rotation/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished === 5, 'All requests finished');
 await expect(datasetItems.length === 5, 'Number of dataset items');

--- a/test/e2e/puppeteer-default/test.mjs
+++ b/test/e2e/puppeteer-default/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished > 50, 'All requests finished');
 await expect(datasetItems.length > 50 && datasetItems.length < 150, 'Number of dataset items');

--- a/test/e2e/puppeteer-default/test.mjs
+++ b/test/e2e/puppeteer-default/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 50, 'All requests finished');
 await expect(datasetItems.length > 50 && datasetItems.length < 150, 'Number of dataset items');

--- a/test/e2e/puppeteer-default/test.mjs
+++ b/test/e2e/puppeteer-default/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 50, 'All requests finished');
 await expect(datasetItems.length > 50 && datasetItems.length < 150, 'Number of dataset items');

--- a/test/e2e/puppeteer-enqueue-links/actor/main.js
+++ b/test/e2e/puppeteer-enqueue-links/actor/main.js
@@ -10,14 +10,14 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
-        maxRequestsPerCrawl: 200,
+        maxRequestsPerCrawl: 30,
         async requestHandler({ page, enqueueLinks, request, log }) {
             const { url, loadedUrl } = request;
 
             const pageTitle = await page.title();
             log.info(`URL: ${url}; LOADED_URL: ${loadedUrl}; TITLE: ${pageTitle}`);
 
-            const results = await enqueueLinks();
+            const results = await enqueueLinks({ selector: '[class^=CustomRebass__Box] a' });
 
             if (loadedUrl.startsWith('https://drive')) {
                 const isEqual = deepEqual(results, { processedRequests: [], unprocessedRequests: [] });

--- a/test/e2e/puppeteer-enqueue-links/test.mjs
+++ b/test/e2e/puppeteer-enqueue-links/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect } from '../tools.mjs';
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { datasetItems } = await runActor(testActorDirname, 8192);
+const { datasetItems } = await runActor(testActorDirname, 16384);
 const { isEqual } = datasetItems[0];
 
 await expect(isEqual, `Enqueueing on same subdomain but different loaded url doesn't enqueue`);

--- a/test/e2e/puppeteer-enqueue-links/test.mjs
+++ b/test/e2e/puppeteer-enqueue-links/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect } from '../tools.mjs';
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { datasetItems } = await runActor(testActorDirname);
+const { datasetItems } = await runActor(testActorDirname, 16384);
 const { isEqual } = datasetItems[0];
 
 await expect(isEqual, `Enqueueing on same subdomain but different loaded url doesn't enqueue`);

--- a/test/e2e/puppeteer-enqueue-links/test.mjs
+++ b/test/e2e/puppeteer-enqueue-links/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect } from '../tools.mjs';
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { datasetItems } = await runActor(testActorDirname, 16384);
+const { datasetItems } = await runActor(testActorDirname, 8192);
 const { isEqual } = datasetItems[0];
 
 await expect(isEqual, `Enqueueing on same subdomain but different loaded url doesn't enqueue`);

--- a/test/e2e/puppeteer-ignore-ssl-errors/test.mjs
+++ b/test/e2e/puppeteer-ignore-ssl-errors/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished > 20, 'All requests finished');
 await expect(datasetItems.length > 20, 'Minimum number of dataset items');

--- a/test/e2e/puppeteer-ignore-ssl-errors/test.mjs
+++ b/test/e2e/puppeteer-ignore-ssl-errors/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 20, 'All requests finished');
 await expect(datasetItems.length > 20, 'Minimum number of dataset items');

--- a/test/e2e/puppeteer-ignore-ssl-errors/test.mjs
+++ b/test/e2e/puppeteer-ignore-ssl-errors/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 20, 'All requests finished');
 await expect(datasetItems.length > 20, 'Minimum number of dataset items');

--- a/test/e2e/puppeteer-initial-cookies/test.mjs
+++ b/test/e2e/puppeteer-initial-cookies/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect } from '../tools.mjs';
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished === 1, 'All requests finished');
 await expect(datasetItems[0].numberOfMatchingCookies === 3, 'Number of page cookies');

--- a/test/e2e/puppeteer-initial-cookies/test.mjs
+++ b/test/e2e/puppeteer-initial-cookies/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect } from '../tools.mjs';
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished === 1, 'All requests finished');
 await expect(datasetItems[0].numberOfMatchingCookies === 3, 'Number of page cookies');

--- a/test/e2e/puppeteer-initial-cookies/test.mjs
+++ b/test/e2e/puppeteer-initial-cookies/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect } from '../tools.mjs';
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished === 1, 'All requests finished');
 await expect(datasetItems[0].numberOfMatchingCookies === 3, 'Number of page cookies');

--- a/test/e2e/puppeteer-page-info/test.mjs
+++ b/test/e2e/puppeteer-page-info/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished === 2, 'All requests finished');
 await expect(datasetItems.length === 1, 'Number of dataset items');

--- a/test/e2e/puppeteer-page-info/test.mjs
+++ b/test/e2e/puppeteer-page-info/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished === 2, 'All requests finished');
 await expect(datasetItems.length === 1, 'Number of dataset items');

--- a/test/e2e/puppeteer-page-info/test.mjs
+++ b/test/e2e/puppeteer-page-info/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished === 2, 'All requests finished');
 await expect(datasetItems.length === 1, 'Number of dataset items');

--- a/test/e2e/puppeteer-store-pagination-jquery/actor/main.js
+++ b/test/e2e/puppeteer-store-pagination-jquery/actor/main.js
@@ -9,6 +9,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
+        maxRequestsPerCrawl: 10,
         preNavigationHooks: [({ session, request }, goToOptions) => {
             session?.setPuppeteerCookies([{ name: 'OptanonAlertBoxClosed', value: new Date().toISOString() }], request.url);
             goToOptions.waitUntil = ['networkidle2'];

--- a/test/e2e/puppeteer-store-pagination-jquery/actor/main.js
+++ b/test/e2e/puppeteer-store-pagination-jquery/actor/main.js
@@ -9,7 +9,6 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
-        maxRequestsPerCrawl: 750,
         preNavigationHooks: [({ session, request }, goToOptions) => {
             session?.setPuppeteerCookies([{ name: 'OptanonAlertBoxClosed', value: new Date().toISOString() }], request.url);
             goToOptions.waitUntil = ['networkidle2'];
@@ -18,42 +17,25 @@ await Actor.main(async () => {
             const { url, userData: { label } } = request;
 
             if (label === 'START') {
-                log.info('Store opened!');
-                let pageNo = 2;
+                log.info('Store opened');
                 const nextButtonSelector = '[data-test="pagination-button-next"]:not([disabled])';
-
-                while (true) {
-                    // Wait network events
+                // enqueue actor details from the first three pages of the store
+                for (let pageNo = 1; pageNo <= 3; pageNo++) {
+                    // Wait for network events to finish
                     await page.waitForNetworkIdle();
                     // Enqueue all loaded links
                     await enqueueLinks({
                         selector: 'a.ActorStoreItem',
                         globs: [{ glob: 'https://apify.com/*/*', userData: { label: 'DETAIL' } }],
                     });
-
-                    log.info(`Enqueued actors for page ${pageNo++}`);
-
-                    log.info('Going to the next page if possible');
-                    try {
-                        const isButtonClickable = (await page.$(nextButtonSelector)) !== null;
-
-                        if (isButtonClickable) {
-                            await page.evaluate((el) => document.querySelector(el)?.click(), nextButtonSelector);
-                        } else {
-                            log.info('No more pages to load');
-                            break;
-                        }
-                    } catch {
-                        break;
-                    }
+                    log.info(`Enqueued actors for page ${pageNo}`);
+                    log.info('Loading the next page');
+                    await page.evaluate((el) => document.querySelector(el)?.click(), nextButtonSelector);
                 }
             } else if (label === 'DETAIL') {
-                await injectJQuery();
-
                 log.info(`Scraping ${url}`);
-
+                await injectJQuery();
                 const uniqueIdentifier = url.split('/').slice(-2).join('/');
-
                 const results = await page.evaluate(() => ({
                     title: $('header h1').text(), // eslint-disable-line
                     description: $('header span.actor-description').text(), // eslint-disable-line
@@ -66,6 +48,6 @@ await Actor.main(async () => {
         },
     });
 
-    await crawler.addRequests([{ url: 'https://apify.com/store?page=1', userData: { label: 'START' } }]);
+    await crawler.addRequests([{ url: 'https://apify.com/store', userData: { label: 'START' } }]);
     await crawler.run();
 }, mainOptions);

--- a/test/e2e/puppeteer-store-pagination-jquery/test.mjs
+++ b/test/e2e/puppeteer-store-pagination-jquery/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 10, 'All requests finished');
 await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');

--- a/test/e2e/puppeteer-store-pagination-jquery/test.mjs
+++ b/test/e2e/puppeteer-store-pagination-jquery/test.mjs
@@ -5,8 +5,8 @@ await initialize(testActorDirname);
 
 const { stats, datasetItems } = await runActor(testActorDirname);
 
-await expect(stats.requestsFinished > 700, 'All requests finished');
-await expect(datasetItems.length > 700 && datasetItems.length < 1000, 'Number of dataset items');
+await expect(stats.requestsFinished > 70, 'All requests finished');
+await expect(datasetItems.length > 65 && datasetItems.length < 75, 'Number of dataset items');
 await expect(
     validateDataset(datasetItems, ['url', 'title', 'uniqueIdentifier', 'description', 'modifiedDate', 'runCount']),
     'Dataset items validation',

--- a/test/e2e/puppeteer-store-pagination-jquery/test.mjs
+++ b/test/e2e/puppeteer-store-pagination-jquery/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished > 10, 'All requests finished');
 await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');

--- a/test/e2e/puppeteer-store-pagination-jquery/test.mjs
+++ b/test/e2e/puppeteer-store-pagination-jquery/test.mjs
@@ -5,8 +5,8 @@ await initialize(testActorDirname);
 
 const { stats, datasetItems } = await runActor(testActorDirname);
 
-await expect(stats.requestsFinished > 70, 'All requests finished');
-await expect(datasetItems.length > 65 && datasetItems.length < 75, 'Number of dataset items');
+await expect(stats.requestsFinished > 10, 'All requests finished');
+await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');
 await expect(
     validateDataset(datasetItems, ['url', 'title', 'uniqueIdentifier', 'description', 'modifiedDate', 'runCount']),
     'Dataset items validation',

--- a/test/e2e/puppeteer-store-pagination-jquery/test.mjs
+++ b/test/e2e/puppeteer-store-pagination-jquery/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 10, 'All requests finished');
 await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');

--- a/test/e2e/puppeteer-store-pagination/actor/main.js
+++ b/test/e2e/puppeteer-store-pagination/actor/main.js
@@ -9,6 +9,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
+        maxRequestsPerCrawl: 10,
         preNavigationHooks: [({ session, request }, goToOptions) => {
             session?.setPuppeteerCookies([{ name: 'OptanonAlertBoxClosed', value: new Date().toISOString() }], request.url);
             goToOptions.waitUntil = ['networkidle2'];

--- a/test/e2e/puppeteer-store-pagination/test.mjs
+++ b/test/e2e/puppeteer-store-pagination/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 10, 'All requests finished');
 await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');

--- a/test/e2e/puppeteer-store-pagination/test.mjs
+++ b/test/e2e/puppeteer-store-pagination/test.mjs
@@ -5,8 +5,8 @@ await initialize(testActorDirname);
 
 const { stats, datasetItems } = await runActor(testActorDirname);
 
-await expect(stats.requestsFinished > 700, 'All requests finished');
-await expect(datasetItems.length > 700 && datasetItems.length < 1000, 'Number of dataset items');
+await expect(stats.requestsFinished > 70, 'All requests finished');
+await expect(datasetItems.length > 65 && datasetItems.length < 75, 'Number of dataset items');
 await expect(
     validateDataset(datasetItems, ['url', 'title', 'uniqueIdentifier', 'description', 'modifiedDate', 'runCount']),
     'Dataset items validation',

--- a/test/e2e/puppeteer-store-pagination/test.mjs
+++ b/test/e2e/puppeteer-store-pagination/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished > 10, 'All requests finished');
 await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');

--- a/test/e2e/puppeteer-store-pagination/test.mjs
+++ b/test/e2e/puppeteer-store-pagination/test.mjs
@@ -5,8 +5,8 @@ await initialize(testActorDirname);
 
 const { stats, datasetItems } = await runActor(testActorDirname);
 
-await expect(stats.requestsFinished > 70, 'All requests finished');
-await expect(datasetItems.length > 65 && datasetItems.length < 75, 'Number of dataset items');
+await expect(stats.requestsFinished > 10, 'All requests finished');
+await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');
 await expect(
     validateDataset(datasetItems, ['url', 'title', 'uniqueIdentifier', 'description', 'modifiedDate', 'runCount']),
     'Dataset items validation',

--- a/test/e2e/puppeteer-store-pagination/test.mjs
+++ b/test/e2e/puppeteer-store-pagination/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 10, 'All requests finished');
 await expect(datasetItems.length > 5 && datasetItems.length < 15, 'Number of dataset items');

--- a/test/e2e/puppeteer-throw-on-ssl-errors/test.mjs
+++ b/test/e2e/puppeteer-throw-on-ssl-errors/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished >= 5, 'All requests finished');
 await expect(stats.requestsFailed > 20 && stats.requestsFailed < 30, 'Number of failed requests');

--- a/test/e2e/puppeteer-throw-on-ssl-errors/test.mjs
+++ b/test/e2e/puppeteer-throw-on-ssl-errors/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 8192);
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished >= 5, 'All requests finished');
 await expect(stats.requestsFailed > 20 && stats.requestsFailed < 30, 'Number of failed requests');

--- a/test/e2e/puppeteer-throw-on-ssl-errors/test.mjs
+++ b/test/e2e/puppeteer-throw-on-ssl-errors/test.mjs
@@ -3,7 +3,7 @@ import { initialize, getActorTestDir, runActor, expect, validateDataset } from '
 const testActorDirname = getActorTestDir(import.meta.url);
 await initialize(testActorDirname);
 
-const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+const { stats, datasetItems } = await runActor(testActorDirname, 8192);
 
 await expect(stats.requestsFinished >= 5, 'All requests finished');
 await expect(stats.requestsFailed > 20 && stats.requestsFailed < 30, 'Number of failed requests');

--- a/test/e2e/run.mjs
+++ b/test/e2e/run.mjs
@@ -35,6 +35,8 @@ async function run() {
     const paths = await readdir(basePath, { withFileTypes: true });
     const dirs = paths.filter((dirent) => dirent.isDirectory());
 
+    let failure = false;
+
     for (const dir of dirs) {
         if (process.argv.length === 3 && dir.name !== process.argv[2]) {
             continue;
@@ -89,9 +91,13 @@ async function run() {
             if (process.env.STORAGE_IMPLEMENTATION === 'PLATFORM') {
                 await clearPackages(`${basePath}/${dir.name}`);
             }
+
+            if (status === 'failure') failure = true;
         });
         await once(worker, 'exit');
     }
+    // We want to exit with non-zero code if any of the tests failed
+    if (failure) process.exit(1)
 }
 
 if (isMainThread) {


### PR DESCRIPTION
- Lowered max number of requests for pagination tests.
- provided specific selector for enqueueLinks tests + limited number of requests there.
Each test out of what we have now should finish with ~1m tops locally.

Will update memory for platform tests + would wait before at least one full e2e run will finish before merging.