### PR TITLE
docs: update docker images + proxy management guides

### DIFF
--- a/docs/guides/avoid_blocking.mdx
+++ b/docs/guides/avoid_blocking.mdx
@@ -8,18 +8,23 @@ Browser fingerprint is a collection of browser attributes and significant featur
 
 Changing browser fingerprints can be a tedious job. Luckily, Crawlee provides this feature out of the box with zero configuration necessary. Let's take a look at how it is done.
 
- Changing browser fingerprints is available in `PuppeteerCrawler` and `PlaywrightCrawler`. You have to pass the `useFingerprints` option to the `browserPoolOptions`.
+ Changing browser fingerprints is available in `PlaywrightCrawler` and `PuppeteerCrawler`. You have to pass the `useFingerprints` option to the `browserPoolOptions`.
 
  ```javascript
+import { PlaywrightCrawler } from '@crawlee/playwright';
+
 const crawler = new PlaywrightCrawler({
     browserPoolOptions: {
         useFingerprints: true,
     },
+    // ...
 })
  ```
-Now, it is all set. The fingerprints are going to be generated for the default browser and the operating system. The Crawler can have the generation alghoritm customized to reflect particular browser version and many more. Let's take a look at the example bellow:
+Now, it is all set. The fingerprints are going to be generated for the default browser and the operating system. The Crawler can have the generation algorithm customized to reflect particular browser version and many more. Let's take a look at the example bellow:
 
  ```javascript
+import { PlaywrightCrawler } from '@crawlee/playwright';
+
 const crawler = new PlaywrightCrawler({
     browserPoolOptions: {
         useFingerprints: true,
@@ -39,6 +44,7 @@ const crawler = new PlaywrightCrawler({
             },
         },
     },
+    // ...
 })
  ```
  Fingerprint generator has more options available check out the [Fingerprint generator docs](https://github.com/apify/fingerprint-generator#HeaderGeneratorOptions).

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -5,6 +5,13 @@ title: Running in Docker
 
 import ApiLink from '@site/src/components/ApiLink';
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+
+import jsDockerSource from '!!raw-loader!./docker_images_js';
+import tsDockerSource from '!!raw-loader!./docker_images_ts';
+
 Running headless browsers in Docker requires a lot of setup to do it right. But you don't need to worry about that, because we already did it for you and created base images that you can freely use. We use them every day on the [Apify Platform](../guides/apify_platform.mdx).
 
 All images can be found in their [GitHub repo](https://github.com/apify/apify-actor-docker) and in our [DockerHub](https://hub.docker.com/orgs/apify).
@@ -24,77 +31,18 @@ Browsers are pretty big, so we try to provide a wide variety of images to suit y
 
 To use our images, you need a [`Dockerfile`](https://docs.docker.com/engine/reference/builder/). You can either use this example, or bootstrap your projects with the [Apify CLI](./getting_started.mdx#creating-a-new-project) which automatically copies the correct Dockerfile into your project folder.
 
-For JavaScript Projects:
-
-```dockerfile
-# First, specify the base Docker image. You can read more about
-# the available images at https://sdk.apify.com/docs/guides/docker-images
-# You can also use any other image from Docker Hub.
-# The 16 represents the version of Node.js you want to use.
-FROM apify/actor-node:16
-
-# Second, copy just package.json and package-lock.json since it should be
-# the only file that affects "npm install" in the next step, to speed up the build
-COPY package*.json ./
-
-# Install NPM packages, skip optional and development dependencies to
-# keep the image small. Avoid logging too much and print the dependency
-# tree for debugging
-RUN npm --quiet set progress=false \
- && npm install --only=prod --no-optional \
- && echo "Installed NPM packages:" \
- && (npm list || true) \
- && echo "Node.js version:" \
- && node --version \
- && echo "NPM version:" \
- && npm --version
-
-# Next, copy the remaining files and directories with the source code.
-# Since we do this after NPM install, quick build will be really fast
-# for most source file changes.
-COPY . ./
-
-# Optionally, specify how to launch the source code of your actor.
-# By default, Apify's base Docker images define the CMD instruction
-# that runs the Node.js source code using the command specified
-# in the "scripts.start" section of the package.json file.
-# In short, the instruction looks something like this:
-#
-# CMD npm start
-```
-
-For TypeScript Projects:
-
-```dockerfile
-# using multistage build, as we need dev deps to build the TS source code
-FROM apify/actor-node:16 AS builder
-
-# copy all files, install all dependencies (including dev deps) and build the project
-COPY . ./
-RUN npm install --include=dev \
-    && npm run build
-
-# create final image, copy only package.json, readme and compiled code
-FROM apify/actor-node:16
-# copy only necessary files
-COPY --from=builder /usr/src/app/package*.json ./
-COPY --from=builder /usr/src/app/README.md ./
-COPY --from=builder /usr/src/app/dist ./dist
-COPY --from=builder /usr/src/app/INPUT_SCHEMA.json ./INPUT_SCHEMA.json
-
-# install only prod deps
-RUN npm --quiet set progress=false \
-    && npm install --only=prod --no-optional \
-    && echo "Installed NPM packages:" \
-    && (npm list --only=prod --no-optional --all || true) \
-    && echo "Node.js version:" \
-    && node --version \
-    && echo "NPM version:" \
-    && npm --version
-
-# run compiled code
-CMD npm run start:prod
-```
+<Tabs>
+    <TabItem value="js" label="For JavaScript Projects">
+        <CodeBlock language="dockerfile">
+            {jsDockerSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="ts" label="For TypeScript Projects">
+        <CodeBlock language="dockerfile">
+            {tsDockerSource}
+        </CodeBlock>
+    </TabItem>
+</Tabs>
 
 ## Versioning
 
@@ -109,15 +57,18 @@ Our images are built with multiple Node.js versions to ensure backwards compatib
 ```dockerfile
 # Use Node.js 14
 FROM apify/actor-node:14
+```
+
+```dockerfile
 # Use Node.js 16
 FROM apify/actor-node-playwright:16
 ```
 
 ### Automation library versioning
 
-Images that include a pre-installed automation library, which means all images that include `puppeteer` or `playwright` in their name,  are also tagged with the pre-installed version of the library. For example, `apify/actor-node-puppeteer-chrome:16-8.0.0` comes with Node.js 16 and Puppeteer v8.0.0. If you try to install a different version of Puppeteer into this image, you may run into compatibility issues, because the Chromium version bundled with `puppeteer` will not match the version of Chrome we pre-installed.
+Images that include a pre-installed automation library, which means all images that include `puppeteer` or `playwright` in their name,  are also tagged with the pre-installed version of the library. For example, `apify/actor-node-puppeteer-chrome:16-13.7.0` comes with Node.js 16 and Puppeteer v13.7.0. If you try to install a different version of Puppeteer into this image, you may run into compatibility issues, because the Chromium version bundled with `puppeteer` will not match the version of Chrome we pre-installed.
 
-Similarly `apify/actor-node-playwright-firefox:14-1.10.0` runs on Node.js 14 and is pre-installed with the Firefox version that comes with v1.10.0.
+Similarly `apify/actor-node-playwright-firefox:14-1.21.1` runs on Node.js 14 and is pre-installed with the Firefox version that comes with v1.21.1.
 
 Installing `apify/actor-node-puppeteer-chrome` (without a tag) will install the latest available version of Node.js and `puppeteer`.
 
@@ -128,6 +79,9 @@ We also build pre-release versions of the images to test the changes we make. Th
 ```dockerfile
 # Without library version.
 FROM apify/actor-node:16-beta
+```
+
+```dockerfile
 # With library version.
 FROM apify/actor-node-playwright-chrome:16-1.10.0-beta
 ```

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -24,6 +24,8 @@ Browsers are pretty big, so we try to provide a wide variety of images to suit y
 
 To use our images, you need a [`Dockerfile`](https://docs.docker.com/engine/reference/builder/). You can either use this example, or bootstrap your projects with the [Apify CLI](./getting_started.mdx#creating-a-new-project) which automatically copies the correct Dockerfile into your project folder.
 
+For JavaScript Projects:
+
 ```dockerfile
 # First, specify the base Docker image. You can read more about
 # the available images at https://sdk.apify.com/docs/guides/docker-images
@@ -59,6 +61,39 @@ COPY . ./
 # In short, the instruction looks something like this:
 #
 # CMD npm start
+```
+
+For TypeScript Projects:
+
+```dockerfile
+# using multistage build, as we need dev deps to build the TS source code
+FROM apify/actor-node:16 AS builder
+
+# copy all files, install all dependencies (including dev deps) and build the project
+COPY . ./
+RUN npm install --include=dev \
+    && npm run build
+
+# create final image, copy only package.json, readme and compiled code
+FROM apify/actor-node:16
+# copy only necessary files
+COPY --from=builder /usr/src/app/package*.json ./
+COPY --from=builder /usr/src/app/README.md ./
+COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/app/INPUT_SCHEMA.json ./INPUT_SCHEMA.json
+
+# install only prod deps
+RUN npm --quiet set progress=false \
+    && npm install --only=prod --no-optional \
+    && echo "Installed NPM packages:" \
+    && (npm list --only=prod --no-optional --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version
+
+# run compiled code
+CMD npm run start:prod
 ```
 
 ## Versioning
@@ -112,7 +147,8 @@ FROM apify/actor-node-playwright-chrome:16
 ```json
 {
     "dependencies": {
-        "apify": "^1.2.0",
+        "apify": "^3.0.0",
+        "@crawlee/playwright": "^3.0.0",
         "playwright": "*"
     }
 }

--- a/docs/guides/docker_images_js
+++ b/docs/guides/docker_images_js
@@ -1,0 +1,34 @@
+# First, specify the base Docker image. You can read more about
+# the available images at https://sdk.apify.com/docs/guides/docker-images
+# You can also use any other image from Docker Hub.
+# The 16 represents the version of Node.js you want to use.
+FROM apify/actor-node:16
+
+# Second, copy just package.json and package-lock.json since it should be
+# the only file that affects "npm install" in the next step, to speed up the build
+COPY package*.json ./
+
+# Install NPM packages, skip optional and development dependencies to
+# keep the image small. Avoid logging too much and print the dependency
+# tree for debugging
+RUN npm --quiet set progress=false \
+ && npm install --only=prod --no-optional \
+ && echo "Installed NPM packages:" \
+ && (npm list --only=prod --no-optional --all || true) \
+ && echo "Node.js version:" \
+ && node --version \
+ && echo "NPM version:" \
+ && npm --version
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after NPM install, quick build will be really fast
+# for most source file changes.
+COPY . ./
+
+# Optionally, specify how to launch the source code of your actor.
+# By default, Apify's base Docker images define the CMD instruction
+# that runs the Node.js source code using the command specified
+# in the "scripts.start" section of the package.json file.
+# In short, the instruction looks something like this:
+#
+# CMD npm start

--- a/docs/guides/docker_images_ts
+++ b/docs/guides/docker_images_ts
@@ -1,0 +1,28 @@
+# using multistage build, as we need dev deps to build the TS source code
+FROM apify/actor-node:16 AS builder
+
+# copy all files, install all dependencies (including dev deps) and build the project
+COPY . ./
+RUN npm install --include=dev \
+    && npm run build
+
+# create final image, copy only package.json, readme and compiled code
+FROM apify/actor-node:16
+# copy only necessary files
+COPY --from=builder /usr/src/app/package*.json ./
+COPY --from=builder /usr/src/app/README.md ./
+COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/app/INPUT_SCHEMA.json ./INPUT_SCHEMA.json
+
+# install only prod deps
+RUN npm --quiet set progress=false \
+    && npm install --only=prod --no-optional \
+    && echo "Installed NPM packages:" \
+    && (npm list --only=prod --no-optional --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version
+
+# run compiled code
+CMD npm run start:prod

--- a/docs/guides/proxy_management.mdx
+++ b/docs/guides/proxy_management.mdx
@@ -28,25 +28,26 @@ them immediately in only a few lines of code.
 
 ```javascript
 const proxyConfiguration = await Actor.createProxyConfiguration();
-const proxyUrl = proxyConfiguration.newUrl();
+const proxyUrl = await proxyConfiguration.newUrl();
 ```
 
 <!-- Your own proxies -->
 ```javascript
-const proxyConfiguration = await Actor.createProxyConfiguration({
+const proxyConfiguration = new ProxyConfiguration({
     proxyUrls: [
         'http://proxy-1.com',
         'http://proxy-2.com',
     ]
 });
-const proxyUrl = proxyConfiguration.newUrl();
+const proxyUrl = await proxyConfiguration.newUrl();
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Proxy Configuration
 
-All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. See the <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
+All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance based on the provided options. See the <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
+If you're using Apify Proxy you create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function.
 
 ### Crawler integration
 
@@ -57,7 +58,7 @@ All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfigurati
 <!-- CheerioCrawler -->
 
 ```javascript
-const proxyConfiguration = await Actor.createProxyConfiguration({ /* your proxy opts */ });
+const proxyConfiguration = new ProxyConfiguration({ /* your proxy opts */ });
 const crawler = new CheerioCrawler({
     proxyConfiguration,
     // ...
@@ -66,7 +67,7 @@ const crawler = new CheerioCrawler({
 
 <!-- PuppeteerCrawler -->
 ```javascript
-const proxyConfiguration = await Actor.createProxyConfiguration({ /* your proxy opts */ });
+const proxyConfiguration = new ProxyConfiguration({ /* your proxy opts */ });
 const crawler = new PuppeteerCrawler({
     proxyConfiguration,
     // ...
@@ -88,15 +89,15 @@ When no `sessionId` is provided, your proxy URLs are rotated round-robin, wherea
 <!-- Standalone -->
 
 ```javascript
-const proxyConfiguration = await Actor.createProxyConfiguration({ /* opts */ });
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
 const sessionPool = await SessionPool.open({ /* opts */ });
 const session = await sessionPool.getSession();
-const proxyUrl = proxyConfiguration.newUrl(session.id);
+const proxyUrl = await proxyConfiguration.newUrl(session.id);
 ```
 
 <!-- Crawlers -->
 ```javascript
-const proxyConfiguration = await Actor.createProxyConfiguration({ /* opts */ });
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
 const crawler = new PuppeteerCrawler({
     useSessionPool: true,
     persistCookiesPerSession: true,
@@ -116,7 +117,9 @@ one would call a super-proxy. It's not a single proxy server, but an API endpoin
 that allows connection through millions of different IP addresses. So the class
 essentially has two modes: Apify Proxy or Your proxy.
 
-The difference is easy to remember. <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
+The difference is easy to remember.
+If you have access to Apify Proxy and create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function - <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
+If you're not using Apify Proxy - you don't need to use the <ApiLink to="apify/class/Actor">`Actor`</ApiLink> class. Instead - you should create an instance with the <ApiLink to="core/class/ProxyConfiguration#constructor">`ProxyConfiguration`</ApiLink> constructor function based on the provided <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
 
 ## Apify Proxy Configuration
 
@@ -128,7 +131,7 @@ const proxyConfiguration = await Actor.createProxyConfiguration({
     groups: ['RESIDENTIAL'],
     countryCode: 'US',
 });
-const proxyUrl = proxyConfiguration.newUrl();
+const proxyUrl = await proxyConfiguration.newUrl();
 ```
 
 Now your crawlers will use only Residential proxies from the US. Note that you must first get access
@@ -138,6 +141,6 @@ in the [proxy dashboard](https://console.apify.com/proxy).
 ## Inspecting current proxy in Crawlers
 
 `CheerioCrawler` and `PuppeteerCrawler` grant access to information about the currently used proxy
-in their `handlePageFunction` using a <ApiLink to="core/interface/ProxyInfo">`proxyInfo`</ApiLink> object.
+in their `requestHandler` using a <ApiLink to="core/interface/ProxyInfo">`proxyInfo`</ApiLink> object.
 With the  object, you can easily access the proxy URL. If you're using Apify Proxy, the other
 configuration parameters will also be available in the `proxyInfo` object.

--- a/docs/guides/proxy_management.mdx
+++ b/docs/guides/proxy_management.mdx
@@ -5,34 +5,38 @@ title: Proxy Management
 
 import ApiLink from '@site/src/components/ApiLink';
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+
+import CheerioSource from '!!raw-loader!./proxy_management_integration_cheerio.ts';
+import PlaywrightSource from '!!raw-loader!./proxy_management_integration_playwright.ts';
+import PuppeteerSource from '!!raw-loader!./proxy_management_integration_puppeteer.ts';
+import SessionStandalonSource from '!!raw-loader!./proxy_management_session_standalone.ts';
+import SessionCheerioSource from '!!raw-loader!./proxy_management_session_cheerio.ts';
+import SessionPlaywrightSource from '!!raw-loader!./proxy_management_session_playwright.ts';
+import SessionPuppeteerSource from '!!raw-loader!./proxy_management_session_puppeteer.ts';
+import InspectionCheerioSource from '!!raw-loader!./proxy_management_inspection_cheerio.ts';
+import InspectionPlaywrightSource from '!!raw-loader!./proxy_management_inspection_playwright.ts';
+import InspectionPuppeteerSource from '!!raw-loader!./proxy_management_inspection_puppeteer.ts';
+
 [IP address blocking](https://en.wikipedia.org/wiki/IP_address_blocking) is one of the oldest
 and most effective ways of preventing access to a website. It is therefore paramount for
 a good web scraping library to provide easy to use but powerful tools which can work around
 IP blocking. The most powerful weapon in your anti IP blocking arsenal is a
 [proxy server](https://en.wikipedia.org/wiki/Proxy_server).
 
-With Crawlee you can use your own proxy servers, proxy servers acquired from
-third-party providers, or you can rely on [Apify Proxy](https://apify.com/proxy)
-for your scraping needs.
+With Crawlee you can use your own proxy servers or proxy servers acquired from
+third-party providers.
 
 ## Quick start
 
-If you already subscribed to Apify Proxy or have proxy URLs of your own, you can start using
+If you already have proxy URLs of your own, you can start using
 them immediately in only a few lines of code.
 
-> If you want to use Apify Proxy, make sure that your [scraper is logged in](../guides/apify-platform).
-
-<!--DOCUSAURUS_CODE_TABS-->
-
-<!-- Apify Proxy -->
-
 ```javascript
-const proxyConfiguration = await Actor.createProxyConfiguration();
-const proxyUrl = await proxyConfiguration.newUrl();
-```
+import { ProxyConfiguration } from '@crawlee/core';
 
-<!-- Your own proxies -->
-```javascript
 const proxyConfiguration = new ProxyConfiguration({
     proxyUrls: [
         'http://proxy-1.com',
@@ -42,39 +46,31 @@ const proxyConfiguration = new ProxyConfiguration({
 const proxyUrl = await proxyConfiguration.newUrl();
 ```
 
-<!--END_DOCUSAURUS_CODE_TABS-->
-
 ## Proxy Configuration
 
 All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance using the ProxyConfiguration <ApiLink to="core/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided options. See the <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
-If you're using Apify Proxy you should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function instead.
 
 ### Crawler integration
 
-`ProxyConfiguration` integrates seamlessly into <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> and <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>.
+`ProxyConfiguration` integrates seamlessly into <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink> and <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>.
 
-<!--DOCUSAURUS_CODE_TABS-->
-
-<!-- CheerioCrawler -->
-
-```javascript
-const proxyConfiguration = new ProxyConfiguration({ /* your proxy opts */ });
-const crawler = new CheerioCrawler({
-    proxyConfiguration,
-    // ...
-});
-```
-
-<!-- PuppeteerCrawler -->
-```javascript
-const proxyConfiguration = new ProxyConfiguration({ /* your proxy opts */ });
-const crawler = new PuppeteerCrawler({
-    proxyConfiguration,
-    // ...
-});
-```
-
-<!--END_DOCUSAURUS_CODE_TABS-->
+<Tabs groupId="proxy_session_management">
+    <TabItem value="cheerio" label="CheerioCrawler" default>
+        <CodeBlock language="js">
+            {CheerioSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="playwright" label="PlaywrightCrawler">
+        <CodeBlock language="js">
+            {PlaywrightSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="puppeteer" label="PuppeteerCrawler">
+        <CodeBlock language="js">
+            {PuppeteerSource}
+        </CodeBlock>
+    </TabItem>
+</Tabs>
 
 Your crawlers will now use the selected proxies for all connections.
 
@@ -82,65 +78,51 @@ Your crawlers will now use the selected proxies for all connections.
 
 &#8203;<ApiLink to="core/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <ApiLink to="core/class/SessionPool">`SessionPool`</ApiLink> class for more information on how keeping a real session helps you avoid blocking.
 
-When no `sessionId` is provided, your proxy URLs are rotated round-robin, whereas Apify Proxy manages their rotation using black magic to get the best performance.
+When no `sessionId` is provided, your proxy URLs are rotated round-robin.
 
-<!--DOCUSAURUS_CODE_TABS-->
-
-<!-- Standalone -->
-
-```javascript
-const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
-const sessionPool = await SessionPool.open({ /* opts */ });
-const session = await sessionPool.getSession();
-const proxyUrl = await proxyConfiguration.newUrl(session.id);
-```
-
-<!-- Crawlers -->
-```javascript
-const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
-const crawler = new PuppeteerCrawler({
-    useSessionPool: true,
-    persistCookiesPerSession: true,
-    proxyConfiguration,
-    // ...
-});
-```
-
-<!--END_DOCUSAURUS_CODE_TABS-->
-
-## Apify Proxy vs. Your own proxies
-
-The `ProxyConfiguration` class covers both Apify Proxy and custom proxy URLs so that
-you can easily switch between proxy providers, however, some features of the class
-are available only to Apify Proxy users, mainly because Apify Proxy is what
-one would call a super-proxy. It's not a single proxy server, but an API endpoint
-that allows connection through millions of different IP addresses. So the class
-essentially has two modes: Apify Proxy or Your proxy.
-
-The difference is easy to remember.
-- If you're using your own proxies - you should create an instance with the ProxyConfiguration <ApiLink to="core/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
-- If you are planning to use Apify Proxy - you should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function - <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
-
-## Apify Proxy Configuration
-
-With Apify Proxy, you can select specific proxy groups to use, or countries to connect from.
-This allows you to get better proxy performance after some initial research.
-
-```javascript
-const proxyConfiguration = await Actor.createProxyConfiguration({
-    groups: ['RESIDENTIAL'],
-    countryCode: 'US',
-});
-const proxyUrl = await proxyConfiguration.newUrl();
-```
-
-Now your crawlers will use only Residential proxies from the US. Note that you must first get access
-to a proxy group before you are able to use it. You can find your available proxy groups
-in the [proxy dashboard](https://console.apify.com/proxy).
+<Tabs groupId="proxy_session_management">
+    <TabItem value="cheerio" label="CheerioCrawler" default>
+        <CodeBlock language="js">
+            {SessionCheerioSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="playwright" label="PlaywrightCrawler">
+        <CodeBlock language="js">
+            {SessionPlaywrightSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="puppeteer" label="PuppeteerCrawler">
+        <CodeBlock language="js">
+            {SessionPuppeteerSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="standalone" label="Standalone">
+        <CodeBlock language="js">
+            {SessionStandalonSource}
+        </CodeBlock>
+    </TabItem>
+</Tabs>
 
 ## Inspecting current proxy in Crawlers
 
-`CheerioCrawler` and `PuppeteerCrawler` grant access to information about the currently used proxy
+`CheerioCrawler`, `PlaywrightCrawler` and `PuppeteerCrawler` grant access to information about the currently used proxy
 in their `requestHandler` using a <ApiLink to="core/interface/ProxyInfo">`proxyInfo`</ApiLink> object.
-With the  object, you can easily access the proxy URL. If you're using Apify Proxy, the other
-configuration parameters will also be available in the `proxyInfo` object.
+With the  object, you can easily access the proxy URL.
+
+<Tabs groupId="proxy_session_management">
+    <TabItem value="cheerio" label="CheerioCrawler" default>
+        <CodeBlock language="js">
+            {InspectionCheerioSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="playwright" label="PlaywrightCrawler">
+        <CodeBlock language="js">
+            {InspectionPlaywrightSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="puppeteer" label="PuppeteerCrawler">
+        <CodeBlock language="js">
+            {InspectionPuppeteerSource}
+        </CodeBlock>
+    </TabItem>
+</Tabs>

--- a/docs/guides/proxy_management.mdx
+++ b/docs/guides/proxy_management.mdx
@@ -46,8 +46,8 @@ const proxyUrl = await proxyConfiguration.newUrl();
 
 ## Proxy Configuration
 
-All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance based on the provided options. See the <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
-If you're using Apify Proxy you create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function.
+All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance using the ProxyConfiguration <ApiLink to="core/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided options. See the <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
+If you're using Apify Proxy you should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function instead.
 
 ### Crawler integration
 
@@ -118,8 +118,8 @@ that allows connection through millions of different IP addresses. So the class
 essentially has two modes: Apify Proxy or Your proxy.
 
 The difference is easy to remember.
-If you have access to Apify Proxy and create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function - <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
-If you're not using Apify Proxy - you don't need to use the <ApiLink to="apify/class/Actor">`Actor`</ApiLink> class. Instead - you should create an instance with the <ApiLink to="core/class/ProxyConfiguration#constructor">`ProxyConfiguration`</ApiLink> constructor function based on the provided <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
+- If you're using your own proxies - you should create an instance with the ProxyConfiguration <ApiLink to="core/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
+- If you are planning to use Apify Proxy - you should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function - <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
 
 ## Apify Proxy Configuration
 

--- a/docs/guides/proxy_management_inspection_cheerio.ts
+++ b/docs/guides/proxy_management_inspection_cheerio.ts
@@ -1,0 +1,10 @@
+import { CheerioCrawler, ProxyConfiguration } from '@crawlee/cheerio';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new CheerioCrawler({
+    proxyConfiguration,
+    async requestHandler({ proxyInfo }) {
+        console.log(proxyInfo);
+    },
+    // ...
+});

--- a/docs/guides/proxy_management_inspection_playwright.ts
+++ b/docs/guides/proxy_management_inspection_playwright.ts
@@ -1,0 +1,10 @@
+import { PlaywrightCrawler, ProxyConfiguration } from '@crawlee/playwright';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new PlaywrightCrawler({
+    proxyConfiguration,
+    async requestHandler({ proxyInfo }) {
+        console.log(proxyInfo);
+    },
+    // ...
+});

--- a/docs/guides/proxy_management_inspection_puppeteer.ts
+++ b/docs/guides/proxy_management_inspection_puppeteer.ts
@@ -1,0 +1,10 @@
+import { PuppeteerCrawler, ProxyConfiguration } from '@crawlee/puppeteer';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new PuppeteerCrawler({
+    proxyConfiguration,
+    async requestHandler({ proxyInfo }) {
+        console.log(proxyInfo);
+    },
+    // ...
+});

--- a/docs/guides/proxy_management_integration_cheerio.ts
+++ b/docs/guides/proxy_management_integration_cheerio.ts
@@ -1,0 +1,7 @@
+import { CheerioCrawler, ProxyConfiguration } from '@crawlee/cheerio';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new CheerioCrawler({
+    proxyConfiguration,
+    // ...
+});

--- a/docs/guides/proxy_management_integration_playwright.ts
+++ b/docs/guides/proxy_management_integration_playwright.ts
@@ -1,0 +1,7 @@
+import { PlaywrightCrawler, ProxyConfiguration } from '@crawlee/playwright';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new PlaywrightCrawler({
+    proxyConfiguration,
+    // ...
+});

--- a/docs/guides/proxy_management_integration_puppeteer.ts
+++ b/docs/guides/proxy_management_integration_puppeteer.ts
@@ -1,0 +1,7 @@
+import { PuppeteerCrawler, ProxyConfiguration } from '@crawlee/puppeteer';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new PuppeteerCrawler({
+    proxyConfiguration,
+    // ...
+});

--- a/docs/guides/proxy_management_session_cheerio.ts
+++ b/docs/guides/proxy_management_session_cheerio.ts
@@ -1,0 +1,9 @@
+import { CheerioCrawler, ProxyConfiguration } from '@crawlee/cheerio';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new CheerioCrawler({
+    useSessionPool: true,
+    persistCookiesPerSession: true,
+    proxyConfiguration,
+    // ...
+});

--- a/docs/guides/proxy_management_session_playwright.ts
+++ b/docs/guides/proxy_management_session_playwright.ts
@@ -1,0 +1,9 @@
+import { PlaywrightCrawler, ProxyConfiguration } from '@crawlee/playwright';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new PlaywrightCrawler({
+    useSessionPool: true,
+    persistCookiesPerSession: true,
+    proxyConfiguration,
+    // ...
+});

--- a/docs/guides/proxy_management_session_puppeteer.ts
+++ b/docs/guides/proxy_management_session_puppeteer.ts
@@ -1,0 +1,9 @@
+import { PuppeteerCrawler, ProxyConfiguration } from '@crawlee/puppeteer';
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const crawler = new PuppeteerCrawler({
+    useSessionPool: true,
+    persistCookiesPerSession: true,
+    proxyConfiguration,
+    // ...
+});

--- a/docs/guides/proxy_management_session_standalone.ts
+++ b/docs/guides/proxy_management_session_standalone.ts
@@ -1,0 +1,6 @@
+import { ProxyConfiguration, SessionPool } from '@crawlee/core'
+
+const proxyConfiguration = new ProxyConfiguration({ /* opts */ });
+const sessionPool = await SessionPool.open({ /* opts */ });
+const session = await sessionPool.getSession();
+const proxyUrl = await proxyConfiguration.newUrl(session.id);


### PR DESCRIPTION
@B4nan could you please a quick look?

In the docker images - I felt like we should mention the multi-stage build for TS projects.

Proxy management - there was a mention of Apify proxy already, and I am not sure how we should proceed. Now I basically added more info on two options (using Apify proxy vs using own proxies). On one hand - it's about proxy and it should all be there. On the other hand - if we want to separate Apify and Crawlee - maybe it qualifies for "more verbose platfrom guide". But on the other hand - it's not really about the platform, it could also be used locally, but requires the usage of Actor class (and thus apify package). Maybe there shold even be another guide - about using the Actor class locally (proxy, storages etc). What do you think?