### PR TITLE
docs: cleanup examples and make them more accurate

### DIFF
--- a/docs/examples/accept_user_input.mdx
+++ b/docs/examples/accept_user_input.mdx
@@ -15,7 +15,7 @@ This example accepts and logs user input:
 To provide the actor with input, create a `INPUT.json` file inside the "default" key-value store:
 
 ```bash
-{PROJECT_FOLDER}/apify_storage/key_value_stores/default/INPUT.json
+{PROJECT_FOLDER}/crawlee_storage/key_value_stores/default/INPUT.json
 ```
 
 Anything in this file will be available to the actor when it runs.

--- a/docs/examples/add_data_to_dataset.mdx
+++ b/docs/examples/add_data_to_dataset.mdx
@@ -17,5 +17,5 @@ You can save data to custom datasets by using <ApiLink to="core/class/Dataset#op
 Each item in this dataset will be saved to its own file in the following directory:
 
 ```bash
-{PROJECT_FOLDER}/apify_storage/datasets/default/
+{PROJECT_FOLDER}/crawlee_storage/datasets/default/
 ```

--- a/docs/examples/basic_crawler.mdx
+++ b/docs/examples/basic_crawler.mdx
@@ -7,12 +7,13 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import BasicCrawlerSource from '!!raw-loader!./basic_crawler.ts';
 
-This is the most bare-bones example of using Crawlee, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers
-like <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> or <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
+This is the most bare-bones example of using Crawlee, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>.
+You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers like <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>
+or <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
 
-The script simply downloads several web pages with plain HTTP requests using the [`got-scraping`](https://github.com/apify/got-scraping)
-npm package and stores their raw HTML and URL in the default dataset. In local configuration, the data will be stored as JSON files in
-`./apify_storage/datasets/default`.
+The script simply downloads several web pages with plain HTTP requests using the <ApiLink to="basic-crawler/interface/BasicCrawlerCrawlingContext#sendRequest">`sendRequest`</ApiLink> utility function (which uses the
+[`got-scraping`](https://github.com/apify/got-scraping) npm module internally) and stores their raw HTML and URL in the default dataset.
+In local configuration, the data will be stored as JSON files in `./crawlee_storage/datasets/default`.
 
 <CodeBlock className="language-js">
 	{BasicCrawlerSource}

--- a/docs/examples/basic_crawler.mdx
+++ b/docs/examples/basic_crawler.mdx
@@ -7,9 +7,12 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import BasicCrawlerSource from '!!raw-loader!./basic_crawler.ts';
 
-This is the most bare-bones example of using Crawlee, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers like <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> or <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
+This is the most bare-bones example of using Crawlee, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers
+like <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> or <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
 
-The script simply downloads several web pages with plain HTTP requests using the <ApiLink to="basic-crawler/interface/BasicCrawlerCrawlingContext#sendRequest">`sendRequest`</ApiLink> utility function (which uses the [`got-scraping`](https://github.com/apify/got-scraping) npm module internally) and stores their raw HTML and URL in the default dataset. In local configuration, the data will be stored as JSON files in `./crawlee_storage/datasets/default`.
+The script simply downloads several web pages with plain HTTP requests using the <ApiLink to="basic-crawler/interface/BasicCrawlerCrawlingContext#sendRequest">`sendRequest`</ApiLink> utility function (which uses the [`got-scraping`](https://github.com/apify/got-scraping)
+npm module internally) and stores their raw HTML and URL in the default dataset. In local configuration, the data will be stored as JSON files in
+`./crawlee_storage/datasets/default`.
 
 <CodeBlock className="language-js">
 	{BasicCrawlerSource}

--- a/docs/examples/basic_crawler.mdx
+++ b/docs/examples/basic_crawler.mdx
@@ -7,13 +7,9 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import BasicCrawlerSource from '!!raw-loader!./basic_crawler.ts';
 
-This is the most bare-bones example of using Crawlee, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>.
-You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers like <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>
-or <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
+This is the most bare-bones example of using Crawlee, which demonstrates some of its building blocks such as the <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers like <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> or <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
 
-The script simply downloads several web pages with plain HTTP requests using the <ApiLink to="basic-crawler/interface/BasicCrawlerCrawlingContext#sendRequest">`sendRequest`</ApiLink> utility function (which uses the
-[`got-scraping`](https://github.com/apify/got-scraping) npm module internally) and stores their raw HTML and URL in the default dataset.
-In local configuration, the data will be stored as JSON files in `./crawlee_storage/datasets/default`.
+The script simply downloads several web pages with plain HTTP requests using the <ApiLink to="basic-crawler/interface/BasicCrawlerCrawlingContext#sendRequest">`sendRequest`</ApiLink> utility function (which uses the [`got-scraping`](https://github.com/apify/got-scraping) npm module internally) and stores their raw HTML and URL in the default dataset. In local configuration, the data will be stored as JSON files in `./crawlee_storage/datasets/default`.
 
 <CodeBlock className="language-js">
 	{BasicCrawlerSource}

--- a/docs/examples/basic_crawler.ts
+++ b/docs/examples/basic_crawler.ts
@@ -12,7 +12,9 @@ const crawler = new BasicCrawler({
         console.log(`Processing ${url}...`);
 
         // Fetch the page HTML via the crawlee sendRequest utility method
-        const { body } = await sendRequest(request);
+        // By default, the method will use the current request that is being handled, so you don't have to
+        // provide it yourself. You can also provide a custom request if you want.
+        const { body } = await sendRequest();
 
         // Store the HTML and URL to the default dataset.
         await dataset.pushData({

--- a/docs/examples/basic_crawler.ts
+++ b/docs/examples/basic_crawler.ts
@@ -1,5 +1,4 @@
 import { BasicCrawler, Dataset } from '@crawlee/basic';
-import { gotScraping } from 'got-scraping';
 
 // Create a dataset where we will store the results.
 const dataset = await Dataset.open();
@@ -8,16 +7,16 @@ const dataset = await Dataset.open();
 // users to implement the crawling logic themselves.
 const crawler = new BasicCrawler({
     // This function will be called for each URL to crawl.
-    async requestHandler({ request }) {
+    async requestHandler({ request, sendRequest }) {
         const { url } = request;
         console.log(`Processing ${url}...`);
 
-        // Fetch the page HTML via Apify utils gotScraping
-        const { body } = await gotScraping({ url });
+        // Fetch the page HTML via the crawlee sendRequest utility method
+        const { body } = await sendRequest(request);
 
         // Store the HTML and URL to the default dataset.
         await dataset.pushData({
-            url: request.url,
+            url,
             html: body,
         });
     },

--- a/docs/examples/cheerio_crawler.mdx
+++ b/docs/examples/cheerio_crawler.mdx
@@ -7,9 +7,7 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import CheerioCrawlerSource from '!!raw-loader!./cheerio_crawler.ts';
 
-This example demonstrates how to use <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> to crawl a list of URLs from an external
-file, load each URL using a plain HTTP request, parse the HTML using the [Cheerio library](https://www.npmjs.com/package/cheerio) and extract some data from it:
-the page title and all `h1` tags.
+This example demonstrates how to use <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> to crawl a list of URLs from an external file, load each URL using a plain HTTP request, parse the HTML using the [Cheerio library](https://www.npmjs.com/package/cheerio) and extract some data from it: the page title and all `h1` tags.
 
 <CodeBlock className="language-js">
 	{CheerioCrawlerSource}

--- a/docs/examples/cheerio_crawler.mdx
+++ b/docs/examples/cheerio_crawler.mdx
@@ -7,7 +7,9 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import CheerioCrawlerSource from '!!raw-loader!./cheerio_crawler.ts';
 
-This example demonstrates how to use <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> to crawl a list of URLs from an external file, load each URL using a plain HTTP request, parse the HTML using the [Cheerio library](https://www.npmjs.com/package/cheerio) and extract some data from it: the page title and all `h1` tags.
+This example demonstrates how to use <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> to crawl a list of URLs from an external
+file, load each URL using a plain HTTP request, parse the HTML using the [Cheerio library](https://www.npmjs.com/package/cheerio) and extract some data from it:
+the page title and all `h1` tags.
 
 <CodeBlock className="language-js">
 	{CheerioCrawlerSource}

--- a/docs/examples/cheerio_crawler.ts
+++ b/docs/examples/cheerio_crawler.ts
@@ -29,7 +29,7 @@ const crawler = new CheerioCrawler({
     // It accepts a single parameter, which is an object with options as:
     // https://sdk.apify.com/docs/typedefs/cheerio-crawler-options#handlepagefunction
     // We use for demonstration only 2 of them:
-    // - request: an instance of the Request class with information such as URL and HTTP method
+    // - request: an instance of the Request class with information such as the URL that is being crawled and HTTP method
     // - $: the cheerio object containing parsed HTML
     async requestHandler({ request, $ }) {
         log.debug(`Processing ${request.url}...`);
@@ -44,7 +44,7 @@ const crawler = new CheerioCrawler({
         });
 
         // Store the results to the dataset. In local configuration,
-        // the data will be stored as JSON files in ./apify_storage/datasets/default
+        // the data will be stored as JSON files in ./crawlee_storage/datasets/default
         await dataset.pushData({
             url: request.url,
             title,
@@ -52,7 +52,7 @@ const crawler = new CheerioCrawler({
         });
     },
 
-    // This function is called if the page processing failed more than maxRequestRetries+1 times.
+    // This function is called if the page processing failed more than maxRequestRetries + 1 times.
     failedRequestHandler({ request }) {
         log.debug(`Request ${request.url} failed twice.`);
     },

--- a/docs/examples/crawl_all_links.mdx
+++ b/docs/examples/crawl_all_links.mdx
@@ -6,19 +6,25 @@ title: Crawl all links on a website
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import ApiLink from '@site/src/components/ApiLink';
 
 import CheerioSource from '!!raw-loader!./crawl_all_links_cheerio.ts';
 import PuppeteerSource from '!!raw-loader!./crawl_all_links_puppeteer.ts';
 import PlaywrightSource from '!!raw-loader!./crawl_all_links_playwright.ts';
 
-This example uses the `enqueueLinks()` method to add new links to the `RequestQueue` as the crawler navigates from page to page. If only the
-required parameters are defined, all links will be crawled.
+This example uses the `enqueueLinks()` method to add new links to the `RequestQueue`
+as the crawler navigates from page to page.
+
+:::tip
+
+If no options are given, by default the method will only add links that are under the same subdomain. This behavior can be controlled with the <ApiLink to="core/interface/EnqueueLinksOptions#strategy">`strategy`</ApiLink>
+option. You can find more info about this option in the [`Crawl relative links`](./crawl-relative-links) examples.
+
+:::
 
 <Tabs groupId="crawler-type">
 
 <TabItem value="cheerio_crawler" label="Cheerio Crawler" default>
-
-Using `CheerioCrawler`:
 
 <CodeBlock className="language-js">
 	{CheerioSource}
@@ -27,8 +33,6 @@ Using `CheerioCrawler`:
 </TabItem>
 
 <TabItem value="puppeteer_crawler" label="Puppeteer Crawler">
-
-Using `PuppeteerCrawler`:
 
 :::tip
 
@@ -43,8 +47,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 </TabItem>
 
 <TabItem value="playwright_crawler" label="Playwright Crawler">
-
-Using `PlaywrightCrawler`:
 
 :::tip
 

--- a/docs/examples/crawl_multiple_urls.mdx
+++ b/docs/examples/crawl_multiple_urls.mdx
@@ -17,8 +17,6 @@ This example crawls the specified list of URLs.
 
 <TabItem value="cheerio_crawler" label="Cheerio Crawler" default>
 
-Using `CheerioCrawler`:
-
 <CodeBlock className="language-js">
 	{CheerioSource}
 </CodeBlock>
@@ -26,8 +24,6 @@ Using `CheerioCrawler`:
 </TabItem>
 
 <TabItem value="puppeteer_crawler" label="Puppeteer Crawler">
-
-Using `PuppeteerCrawler`:
 
 :::tip
 
@@ -42,8 +38,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 </TabItem>
 
 <TabItem value="playwright_crawler" label="Playwright Crawler">
-
-Using `PlaywrightCrawler`:
 
 :::tip
 

--- a/docs/examples/crawl_relative_links.mdx
+++ b/docs/examples/crawl_relative_links.mdx
@@ -18,12 +18,12 @@ automatically find links and add them to the crawler's <ApiLink to="core/class/R
 
 We provide 3 different strategies for crawling relative links:
 
-- <ApiLink to="core/enum/EnqueueStrategy#All"><inlineCode>All</inlineCode></ApiLink> which will enqueue all links found, regardless of
-the domain they point to.
-- <ApiLink to="core/enum/EnqueueStrategy#SameHostname"><inlineCode>SameHostname</inlineCode></ApiLink> which will enqueue all links
-found for the same hostname (regardless of any subdomains present).
-- <ApiLink to="core/enum/EnqueueStrategy#SameSubdomain"><inlineCode>SameSubdomain</inlineCode></ApiLink> which will enqueue all links
-found that have the same subdomain and hostname. This is the default strategy.
+- <ApiLink to="core/enum/EnqueueStrategy#All"><inlineCode>All</inlineCode> (or the string <inlineCode>"all"</inlineCode>)</ApiLink> which will
+enqueue all links found, regardless of the domain they point to.
+- <ApiLink to="core/enum/EnqueueStrategy#SameHostname"><inlineCode>SameHostname</inlineCode> (or the string <inlineCode>"same-hostname"</inlineCode>)</ApiLink> which
+will enqueue all links found for the same hostname (regardless of any subdomains present).
+- <ApiLink to="core/enum/EnqueueStrategy#SameSubdomain"><inlineCode>SameSubdomain</inlineCode> (or the string <inlineCode>"same-subdomain"</inlineCode>)</ApiLink> which
+will enqueue all links found that have the same subdomain and hostname. This is the default strategy.
 
 :::note
 
@@ -82,7 +82,7 @@ For a url of `https://subdomain.example.com`, `enqueueLinks()` will only match r
 full domain.
 
 For instance, hyperlinks like `https://subdomain.example.com/some/path`, `/absolute/example` or `./relative/example`
-will all be matched by this strategy, while `https://other-subdomain.example.com` or `https://otherexample.com` will not.
+will all be matched by this strategy, while `https://other-subdomain.example.com` or `https://example.com` will not.
 
 :::
 

--- a/docs/examples/crawl_sitemap.mdx
+++ b/docs/examples/crawl_sitemap.mdx
@@ -6,18 +6,18 @@ title: Crawl a sitemap
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import ApiLink from '@site/src/components/ApiLink';
 
 import CheerioSource from '!!raw-loader!./crawl_sitemap_cheerio.ts';
 import PuppeteerSource from '!!raw-loader!./crawl_sitemap_puppeteer.ts';
 import PlaywrightSource from '!!raw-loader!./crawl_sitemap_playwright.ts';
 
-This example downloads and crawls the URLs from a sitemap.
+This example downloads and crawls the URLs from a sitemap, by using the <ApiLink to="utils/function/downloadListOfUrls">`downloadListOfUrls`</ApiLink> utility
+method provided by the <ApiLink to="utils">`@crawlee/utils`</ApiLink> module.
 
 <Tabs groupId="crawler-type">
 
 <TabItem value="cheerio_crawler" label="Cheerio Crawler" default>
-
-Using `CheerioCrawler`:
 
 <CodeBlock className="language-js">
 	{CheerioSource}
@@ -26,8 +26,6 @@ Using `CheerioCrawler`:
 </TabItem>
 
 <TabItem value="puppeteer_crawler" label="Puppeteer Crawler">
-
-Using `PuppeteerCrawler`:
 
 :::tip
 
@@ -42,8 +40,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 </TabItem>
 
 <TabItem value="playwright_crawler" label="Playwright Crawler">
-
-Using `PlaywrightCrawler`:
 
 :::tip
 

--- a/docs/examples/crawl_sitemap.mdx
+++ b/docs/examples/crawl_sitemap.mdx
@@ -12,8 +12,7 @@ import CheerioSource from '!!raw-loader!./crawl_sitemap_cheerio.ts';
 import PuppeteerSource from '!!raw-loader!./crawl_sitemap_puppeteer.ts';
 import PlaywrightSource from '!!raw-loader!./crawl_sitemap_playwright.ts';
 
-This example downloads and crawls the URLs from a sitemap, by using the <ApiLink to="utils/function/downloadListOfUrls">`downloadListOfUrls`</ApiLink> utility
-method provided by the <ApiLink to="utils">`@crawlee/utils`</ApiLink> module.
+This example downloads and crawls the URLs from a sitemap, by using the <ApiLink to="utils/function/downloadListOfUrls">`downloadListOfUrls`</ApiLink> utility method provided by the <ApiLink to="utils">`@crawlee/utils`</ApiLink> module.
 
 <Tabs groupId="crawler-type">
 

--- a/docs/examples/crawl_some_links.mdx
+++ b/docs/examples/crawl_some_links.mdx
@@ -7,9 +7,7 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./crawl_some_links.ts';
 
-This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="core/interface/EnqueueLinksOptions#globs">`globs`</ApiLink>
-property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to
-the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified pattern.
+This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="core/interface/EnqueueLinksOptions#globs">`globs`</ApiLink> property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified pattern.
 
 <CodeBlock className="language-js">
 	{CrawlSource}

--- a/docs/examples/crawl_some_links.mdx
+++ b/docs/examples/crawl_some_links.mdx
@@ -7,7 +7,9 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./crawl_some_links.ts';
 
-This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="core/class/PseudoUrl">`pseudoUrls`</ApiLink> property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified regular expression.
+This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="core/interface/EnqueueLinksOptions#globs">`globs`</ApiLink>
+property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to
+the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified pattern.
 
 <CodeBlock className="language-js">
 	{CrawlSource}

--- a/docs/examples/crawl_some_links.ts
+++ b/docs/examples/crawl_some_links.ts
@@ -9,7 +9,7 @@ const crawler = new CheerioCrawler({
         console.log(request.url);
         // Add some links from page to the crawler's RequestQueue
         await enqueueLinks({
-            pseudoUrls: ['http[s?]://apify.com/[.+]/[.+]'],
+            globs: ['apify.com/*/*'],
         });
     },
 });

--- a/docs/examples/crawl_some_links.ts
+++ b/docs/examples/crawl_some_links.ts
@@ -9,7 +9,7 @@ const crawler = new CheerioCrawler({
         console.log(request.url);
         // Add some links from page to the crawler's RequestQueue
         await enqueueLinks({
-            globs: ['apify.com/*/*'],
+            globs: ['https://apify.com/*/*'],
         });
     },
 });

--- a/docs/examples/crawl_some_links.ts
+++ b/docs/examples/crawl_some_links.ts
@@ -9,7 +9,7 @@ const crawler = new CheerioCrawler({
         console.log(request.url);
         // Add some links from page to the crawler's RequestQueue
         await enqueueLinks({
-            globs: ['https://apify.com/*/*'],
+            globs: ['http?(s)://apify.com/*/*'],
         });
     },
 });

--- a/docs/examples/forms.mdx
+++ b/docs/examples/forms.mdx
@@ -9,9 +9,9 @@ import CrawlSource from '!!raw-loader!./forms.ts';
 
 This example demonstrates how to use <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to
 automatically fill and submit a search form to look up repositories on [GitHub](https://github.com) using headless Chrome / Puppeteer.
-The actor first fills in the search term, repository owner, start date and language of the repository, then submits the form
+The crawler first fills in the search term, repository owner, start date and language of the repository, then submits the form
 and prints out the results. Finally, the results are saved either on the Apify platform to the
-default <ApiLink to="core/class/Dataset">`dataset`</ApiLink> or on the local machine as JSON files in `./apify_storage/datasets/default`.
+default <ApiLink to="core/class/Dataset">`dataset`</ApiLink> or on the local machine as JSON files in `./crawlee_storage/datasets/default`.
 
 :::tip
 

--- a/docs/examples/map.ts
+++ b/docs/examples/map.ts
@@ -1,6 +1,6 @@
 import { Dataset, KeyValueStore } from '@crawlee/core';
 
-const dataset = await Dataset.open<{ headingCount: number }>();
+const dataset = await Dataset.open();
 const keyValueStore = await KeyValueStore.open();
 
 // calling map function and filtering through mapped items

--- a/docs/examples/map.ts
+++ b/docs/examples/map.ts
@@ -1,6 +1,6 @@
 import { Dataset, KeyValueStore } from '@crawlee/core';
 
-const dataset = await Dataset.open();
+const dataset = await Dataset.open<{ headingCount: number }>();
 const keyValueStore = await KeyValueStore.open();
 
 // calling map function and filtering through mapped items

--- a/docs/examples/map_and_reduce.mdx
+++ b/docs/examples/map_and_reduce.mdx
@@ -18,7 +18,7 @@ the dataset in any way.
 Examples for both methods are demonstrated on a simple dataset containing the results scraped from a page: the `URL` and a hypothetical number of
 `h1` - `h3` header elements under the `headingCount` key.
 
-This data structure is stored in the default dataset under `{PROJECT_FOLDER}/apify_storage/datasets/default/`. If you want to simulate the
+This data structure is stored in the default dataset under `{PROJECT_FOLDER}/crawlee_storage/datasets/default/`. If you want to simulate the
 functionality, you can use the <ApiLink to="core/class/Dataset#pushData">`dataset.pushData()`</ApiLink>
 method to save the example `JSON array` to your dataset.
 

--- a/docs/examples/playwright_crawler.mdx
+++ b/docs/examples/playwright_crawler.mdx
@@ -12,7 +12,7 @@ in combination with <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLin
 recursively scrape the [Hacker News website](https://news.ycombinator.com) using headless Chrome / Playwright.
 
 The crawler starts with a single URL, finds links to next pages, enqueues them and continues until no more desired links are available. The results
-are stored to the default dataset. In local configuration, the results are stored as JSON files in `./apify_storage/datasets/default`
+are stored to the default dataset. In local configuration, the results are stored as JSON files in `./crawlee_storage/datasets/default`
 
 :::tip
 

--- a/docs/examples/puppeteer_capture_screenshot.mdx
+++ b/docs/examples/puppeteer_capture_screenshot.mdx
@@ -6,11 +6,14 @@ title: Capture a screenshot using Puppeteer
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import ApiLink from '@site/src/components/ApiLink';
 
 import PuppeteerPageScreenshotSource from '!!raw-loader!./puppeteer_page_screenshot.ts';
 import PuppeteerCrawlerUtilsSnapshotSource from '!!raw-loader!./puppeteer_crawler_utils_snapshot.ts';
 import PuppeteerCrawlerPageScreenshotSource from '!!raw-loader!./puppeteer_crawler_page_screenshot.ts';
 import PuppeteerCrawlerCrawlerUtilsSnapshotSource from '!!raw-loader!./puppeteer_crawler_crawler_utils_snapshot.ts';
+
+## Using Puppeteer directly
 
 :::tip
 
@@ -42,6 +45,8 @@ Using `puppeteerUtils.saveSnapshot()`:
 </TabItem>
 </Tabs>
 
+## Using the `PuppeteerCrawler`
+
 This example captures a screenshot of multiple web pages when using `PuppeteerCrawler`:
 
 <Tabs groupId="puppeteer-capture-screenshot">
@@ -57,7 +62,7 @@ Using `page.screenshot()`:
 
 <TabItem value="crawlerutilsscreenshot" label="Crawler Utils Screenshot" default>
 
-Using `puppeteerUtils.saveSnapshot()`:
+Using the context-aware <ApiLink to="puppeteer-crawler/namespace/puppeteerUtils#saveSnapshot">`saveSnapshot()`</ApiLink> utility:
 
 <CodeBlock className="language-js">
 	{PuppeteerCrawlerCrawlerUtilsSnapshotSource}

--- a/docs/examples/puppeteer_capture_screenshot.mdx
+++ b/docs/examples/puppeteer_capture_screenshot.mdx
@@ -45,7 +45,7 @@ Using `puppeteerUtils.saveSnapshot()`:
 </TabItem>
 </Tabs>
 
-## Using the `PuppeteerCrawler`
+## Using `PuppeteerCrawler`
 
 This example captures a screenshot of multiple web pages when using `PuppeteerCrawler`:
 

--- a/docs/examples/puppeteer_crawler.mdx
+++ b/docs/examples/puppeteer_crawler.mdx
@@ -12,7 +12,7 @@ with <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>
 to recursively scrape the [Hacker News website](https://news.ycombinator.com) using headless Chrome / Puppeteer.
 
 The crawler starts with a single URL, finds links to next pages, enqueues them and continues until no more desired links are available. The results
-are stored to the default dataset. In local configuration, the results are stored as JSON files in `./apify_storage/datasets/default`
+are stored to the default dataset. In local configuration, the results are stored as JSON files in `./crawlee_storage/datasets/default`
 
 :::tip
 

--- a/docs/examples/puppeteer_crawler_crawler_utils_snapshot.ts
+++ b/docs/examples/puppeteer_crawler_crawler_utils_snapshot.ts
@@ -1,12 +1,12 @@
-import { PuppeteerCrawler, puppeteerUtils } from '@crawlee/puppeteer';
+import { PuppeteerCrawler } from '@crawlee/puppeteer';
 
 // Create a PuppeteerCrawler
 const crawler = new PuppeteerCrawler({
-    async requestHandler({ request, page }) {
+    async requestHandler({ request, saveSnapshot }) {
         // Convert the URL into a valid key
         const key = request.url.replace(/[:/]/g, '_');
         // Capture the screenshot
-        await puppeteerUtils.saveSnapshot(page, { key, saveHtml: false });
+        await saveSnapshot({ key, saveHtml: false });
     },
 });
 

--- a/docs/examples/puppeteer_recursive_crawl.ts
+++ b/docs/examples/puppeteer_recursive_crawl.ts
@@ -6,7 +6,7 @@ const crawler = new PuppeteerCrawler({
         console.log(`Title of ${request.url}: ${title}`);
 
         await enqueueLinks({
-            pseudoUrls: ['https://www.iana.org/[.*]'],
+            globs: ['https://www.iana.org/*'],
         });
     },
     maxRequestsPerCrawl: 10,

--- a/docs/examples/puppeteer_recursive_crawl.ts
+++ b/docs/examples/puppeteer_recursive_crawl.ts
@@ -6,7 +6,7 @@ const crawler = new PuppeteerCrawler({
         console.log(`Title of ${request.url}: ${title}`);
 
         await enqueueLinks({
-            globs: ['https://www.iana.org/*'],
+            globs: ['http?(s)://www.iana.org/**'],
         });
     },
     maxRequestsPerCrawl: 10,

--- a/docs/examples/puppeteer_with_proxy.ts
+++ b/docs/examples/puppeteer_with_proxy.ts
@@ -1,7 +1,7 @@
-import { PuppeteerCrawler, createProxyConfiguration } from '@crawlee/puppeteer';
+import { PuppeteerCrawler, ProxyConfiguration } from '@crawlee/puppeteer';
 
 // Proxy connection is automatically established in the Crawler
-const proxyConfiguration = await createProxyConfiguration();
+const proxyConfiguration = new ProxyConfiguration();
 
 const crawler = new PuppeteerCrawler({
     proxyConfiguration,

--- a/docs/examples/reduce.ts
+++ b/docs/examples/reduce.ts
@@ -5,7 +5,7 @@ const keyValueStore = await KeyValueStore.open();
 
 // calling reduce function and using memo to calculate number of headers
 const pagesHeadingCount = await dataset.reduce((memo, value) => {
-    return memo += value.headingCount;
+    return memo + value.headingCount;
 }, 0);
 
 // saving result of map to default Key-value store

--- a/docs/guides/avoid_blocking.mdx
+++ b/docs/guides/avoid_blocking.mdx
@@ -3,7 +3,8 @@ id: avoid-blocking
 title: Avoid getting blocked
 ---
 
-A Scraper might get blocked for numerous reasons. Let's narrow it down to two main reasons. The first one is a bad or blocked IP address. This topic is covered in the [proxy management guide](proxy_management.mdx). The second reason we will explore more is [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/) or signatures.
+A Scraper might get blocked for numerous reasons. Let's narrow it down to two main reasons. The first one is a bad or blocked IP address.
+This topic is covered in the [proxy management guide](./proxy-management). The second reason we will explore more is [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/) or signatures.
 Browser fingerprint is a collection of browser attributes and significant features that can show if your browser is a bot or a real user. Moreover, even most browsers have these unique features that allow the website to track the browser even within different IP addresses. This is the main reason why scrapers should change browser fingerprints while doing browser-based scraping. In addition, it should reduce blocking significantly.
 
 Changing browser fingerprints can be a tedious job. Luckily, Crawlee provides this feature out of the box with zero configuration necessary. Let's take a look at how it is done.

--- a/docs/guides/avoid_blocking.mdx
+++ b/docs/guides/avoid_blocking.mdx
@@ -3,8 +3,7 @@ id: avoid-blocking
 title: Avoid getting blocked
 ---
 
-A Scraper might get blocked for numerous reasons. Let's narrow it down to two main reasons. The first one is a bad or blocked IP address.
-This topic is covered in the [proxy management guide](./proxy-management). The second reason we will explore more is [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/) or signatures.
+A Scraper might get blocked for numerous reasons. Let's narrow it down to two main reasons. The first one is a bad or blocked IP address. This topic is covered in the [proxy management guide](./proxy-management). The second reason we will explore more is [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/) or signatures.
 Browser fingerprint is a collection of browser attributes and significant features that can show if your browser is a bot or a real user. Moreover, even most browsers have these unique features that allow the website to track the browser even within different IP addresses. This is the main reason why scrapers should change browser fingerprints while doing browser-based scraping. In addition, it should reduce blocking significantly.
 
 Changing browser fingerprints can be a tedious job. Luckily, Crawlee provides this feature out of the box with zero configuration necessary. Let's take a look at how it is done.

--- a/docs/guides/getting_started.mdx
+++ b/docs/guides/getting_started.mdx
@@ -130,8 +130,7 @@ introduce all Crawlee classes necessary to make it happen.
 
 ### The general idea
 
-There are 4 crawler classes available for use in Crawlee. <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>, <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
-We'll talk about their differences later. Now, let's talk about what they have in common.
+There are 4 crawler classes available for use in Crawlee. <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>, <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. We'll talk about their differences later. Now, let's talk about what they have in common.
 
 The general idea of each crawler is to go to a web page, open it, do some stuff there, save some results and continue to the next page, until it's done
 its job. So the crawler always needs to find answers to two questions: **Where should I go?** and **What should I do there?** Answering those two
@@ -139,32 +138,19 @@ questions is the only setup mandatory for running the crawlers.
 
 ### The Where - `Request`, `RequestList` and `RequestQueue`
 
-All crawlers use instances of the <ApiLink to="core/class/Request">`Request`</ApiLink> class to determine where they need to go. Each request may hold a lot
-of information, but at the very least, it must hold a URL - a web page to open. But having only one URL would not make sense for crawling. We need to either
-have a pre-existing list of our own URLs that we wish to visit, perhaps a thousand, or a million, or we need to build this list dynamically as we crawl,
-adding more and more URLs to the list as we progress.
+All crawlers use instances of the <ApiLink to="core/class/Request">`Request`</ApiLink> class to determine where they need to go. Each request may hold a lot of information, but at the very least, it must hold a URL - a web page to open. But having only one URL would not make sense for crawling. We need to either have a pre-existing list of our own URLs that we wish to visit, perhaps a thousand, or a million, or we need to build this list dynamically as we crawl, adding more and more URLs to the list as we progress.
 
-A representation of the pre-existing list is an instance of the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class. It is a static, immutable
-list of URLs and other metadata (see the <ApiLink to="core/class/Request">`Request`</ApiLink> object) that the crawler will visit, one by one, retrying whenever
-an error occurs, until there are no more `Requests` to process.
+A representation of the pre-existing list is an instance of the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class. It is a static, immutable list of URLs and other metadata (see the <ApiLink to="core/class/Request">`Request`</ApiLink> object) that the crawler will visit, one by one, retrying whenever an error occurs, until there are no more `Requests` to process.
 
-&#8203;<ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> on the other hand, represents a dynamic queue of `Requests`. One that can be updated
-at runtime by adding more pages - `Requests` to process. This allows the crawler to open one page, extract interesting URLs, such as links to other pages on
-the same domain, add them to the queue (called _enqueuing_) and repeat this process to build a queue of tens of thousands or more URLs while knowing only a
-single one at the beginning.
+&#8203;<ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> on the other hand, represents a dynamic queue of `Requests`. One that can be updated at runtime by adding more pages - `Requests` to process. This allows the crawler to open one page, extract interesting URLs, such as links to other pages on the same domain, add them to the queue (called _enqueuing_) and repeat this process to build a queue of tens of thousands or more URLs while knowing only a single one at the beginning.
 
-`RequestList` and `RequestQueue` are essential for the crawler's operation. There is no other way to supply `Requests` = "pages to crawl" to the crawlers.
-At least one of them always needs to be provided while setting up. You can also use both at the same time, if you wish.
+`RequestList` and `RequestQueue` are essential for the crawler's operation. There is no other way to supply `Requests` = "pages to crawl" to the crawlers. At least one of them always needs to be provided while setting up. You can also use both at the same time, if you wish.
 
 ### The What - `requestHandler`
 
-The `requestHandler` is the brain of the crawler. It tells it what to do at each and every page it visits. Generally it handles extraction of data from
-the page, processing the data, saving it, calling APIs, doing calculations and whatever else you need it to do.
+The `requestHandler` is the brain of the crawler. It tells it what to do at each and every page it visits. Generally it handles extraction of data from the page, processing the data, saving it, calling APIs, doing calculations and whatever else you need it to do.
 
-The `requestHandler` is provided by you, the user, and invoked automatically by the crawler for each `Request` from either the `RequestList` or `RequestQueue`.
-It always receives a single argument and that is a plain `Object`. Its properties change depending on the crawler class used, but it always includes at least the
-`request` property, which represents the currently crawled `Request` instance (i.e. the URL the crawler is visiting and related metadata) and the `autoscaledPool`
-property, which is an instance of the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink> class and we'll talk about it in detail later.
+The `requestHandler` is provided by you, the user, and invoked automatically by the crawler for each `Request` from either the `RequestList` or `RequestQueue`. It always receives a single argument and that is a plain `Object`. Its properties change depending on the crawler class used, but it always includes at least the `request` property, which represents the currently crawled `Request` instance (i.e. the URL the crawler is visiting and related metadata) and the `autoscaledPool` property, which is an instance of the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink> class and we'll talk about it in detail later.
 
 ```ts
 // The object received as a single argument by the requestHandler
@@ -176,9 +162,7 @@ property, which is an instance of the <ApiLink to="core/class/AutoscaledPool">`A
 
 ### Putting it all together
 
-Enough theory! Let's put some of those hard-learned facts into practice. We learned above that we need `Requests` and a `requestHandler` to setup a crawler.
-We will also use the <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> function. It's not mandatory, but it makes our life easier. We'll learn about
-it in detail later on.
+Enough theory! Let's put some of those hard-learned facts into practice. We learned above that we need `Requests` and a `requestHandler` to setup a crawler. We will also use the <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> function. It's not mandatory, but it makes our life easier. We'll learn about it in detail later on.
 
 Let's start with something super easy. Visit a page, get its title and close. First of all we need to require Apify, to make all of its features available to us:
 
@@ -186,8 +170,7 @@ Let's start with something super easy. Visit a page, get its title and close. Fi
 import { Actor } from 'apify';
 ```
 
-Easy, right? It really doesn't get much more difficult than that. For the purposes of this tutorial, we'll be scraping our own webpage [https://apify.com](https://apify.com).
-Now, to get there, we need a `Request` with the page's URL in one of our sources, `RequestList` or `RequestQueue`. Let's go with `RequestQueue` for now.
+Easy, right? It really doesn't get much more difficult than that. For the purposes of this tutorial, we'll be scraping our own webpage [https://apify.com](https://apify.com). Now, to get there, we need a `Request` with the page's URL in one of our sources, `RequestList` or `RequestQueue`. Let's go with `RequestQueue` for now.
 
 ```ts
 import { Actor } from 'apify';
@@ -205,8 +188,7 @@ await Actor.main(async () => {
 > If you're not familiar with the `async` and `await` keywords used in the example, you should know that these are native syntax in modern JavaScript. You can
 > [learn more about them here](https://nikgrozev.com/2017/10/01/async-await/).
 
-The <ApiLink to="core/class/RequestQueue#addRequest">`requestQueue.addRequest()`</ApiLink> function automatically converts the plain object we passed to it
-to a `Request` instance, so now we have a `requestQueue` that holds one `request` which points to `https://apify.com`. Now we need the `requestHandler`.
+The <ApiLink to="core/class/RequestQueue#addRequest">`requestQueue.addRequest()`</ApiLink> function automatically converts the plain object we passed to it to a `Request` instance, so now we have a `requestQueue` that holds one `request` which points to `https://apify.com`. Now we need the `requestHandler`.
 
 ```ts
 import { CheerioCrawlingContext } from '@crawlee/cheerio';
@@ -221,9 +203,7 @@ const requestHandler: CheerioCrawlingContext = async ({ request, $ }) => {
 };
 ```
 
-Wait, where did the `$` come from? Remember what we learned about the `requestHandler` earlier. It expects a plain `Object` as an argument that will always
-have a `request` property, but it will also have other properties, depending on the chosen crawler class. Well, `$` is a property provided by the `CheerioCrawler`
-class, which we'll set up right now.
+Wait, where did the `$` come from? Remember what we learned about the `requestHandler` earlier. It expects a plain `Object` as an argument that will always have a `request` property, but it will also have other properties, depending on the chosen crawler class. Well, `$` is a property provided by the `CheerioCrawler` class, which we'll set up right now.
 
 ```ts
 import { Actor } from 'apify';
@@ -248,9 +228,7 @@ await Actor.main(async () => {
 });
 ```
 
-That starts to look almost good. Almost? Yes, we can do even better! Since v3, the crawler has an implicit `RequestQueue` instance, so we can save ourselves
-from all the `RequestQueue` related code and just use `crawler.addRequests()` method. We can also move the `requestHandler` method definition directly to the
-crawler options, this way we get type inference for free:
+That starts to look almost good. Almost? Yes, we can do even better! Since v3, the crawler has an implicit `RequestQueue` instance, so we can save ourselves from all the `RequestQueue` related code and just use `crawler.addRequests()` method. We can also move the `requestHandler` method definition directly to the crawler options, this way we get type inference for free:
 
 ```ts
 import { Actor } from 'apify';
@@ -270,38 +248,25 @@ await Actor.main(async () => {
 });
 ```
 
-And we're done! You just created your first crawler from scratch. It will download the HTML of `https://apify.com`, find the `<title>` element,
-get its text content and print it to console. Good job!
+And we're done! You just created your first crawler from scratch. It will download the HTML of `https://apify.com`, find the `<title>` element, get its text content and print it to console. Good job!
 
-To run the code locally, copy and paste the code, if you haven't already typed it in yourself, to the `main.mjs` file in the `my-new-project` we created
-earlier and run `apify run` from that project's directory.
+To run the code locally, copy and paste the code, if you haven't already typed it in yourself, to the `main.mjs` file in the `my-new-project` we created earlier and run `apify run` from that project's directory.
 
 To run the code on Apify Platform, just replace the original example with your new code and hit Run.
 
-Whichever environment you choose, you should see the message `The title of "https://apify.com" is: Web Scraping, Data Extraction and Automation - Actor.`
-printed to the screen. If you do, congratulations and let's move onto some bigger challenges! And if you feel like you don't really know what just happened there,
-no worries, it will all become clear when you learn more about `CheerioCrawler`.
+Whichever environment you choose, you should see the message `The title of "https://apify.com" is: Web Scraping, Data Extraction and Automation - Actor.` printed to the screen. If you do, congratulations and let's move onto some bigger challenges! And if you feel like you don't really know what just happened there, no worries, it will all become clear when you learn more about `CheerioCrawler`.
 
 ## CheerioCrawler aka jQuery crawler
 
-This is the crawler that we used in our earlier example. Our simplest and also the fastest crawling solution. If you're familiar with `jQuery`,
-you'll understand <ApiLink to="cheerio-crawler/class/CheerioCrawler">CheerioCrawler</ApiLink> in minutes. [`Cheerio`](https://www.npmjs.com/package/cheerio) is
-essentially `jQuery` for Node.js. It offers the same API, including the familiar `$` object. You can use it, as you would `jQuery`, for manipulating the DOM
-of an HTML page. In crawling, you'll mostly use it to select the right elements and extract their text values - the data you're interested in. But `jQuery` runs
-in a browser and attaches directly to the browser's DOM. Where does `cheerio` get its HTML? This is where the `Crawler` part of <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> comes in.
+This is the crawler that we used in our earlier example. Our simplest and also the fastest crawling solution. If you're familiar with `jQuery`, you'll understand <ApiLink to="cheerio-crawler/class/CheerioCrawler">CheerioCrawler</ApiLink> in minutes. [`Cheerio`](https://www.npmjs.com/package/cheerio) is essentially `jQuery` for Node.js. It offers the same API, including the familiar `$` object. You can use it, as you would `jQuery`, for manipulating the DOM of an HTML page. In crawling, you'll mostly use it to select the right elements and extract their text values - the data you're interested in. But `jQuery` runs in a browser and attaches directly to the browser's DOM. Where does `cheerio` get its HTML? This is where the `Crawler` part of <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> comes in.
 
 ### Overview
 
-&#8203;<ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> crawls by making plain HTTP requests to the provided URLs. As you remember
-from the previous section, the URLs are fed to the crawler using either the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> or the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>.
-The HTTP responses it gets back are HTML pages, the same pages you would get in your browser when you first load a URL.
+&#8203;<ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> crawls by making plain HTTP requests to the provided URLs. As you remember from the previous section, the URLs are fed to the crawler using either the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> or the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>. The HTTP responses it gets back are HTML pages, the same pages you would get in your browser when you first load a URL.
 
-> Note, however, that modern web pages often do not serve all of their content in the first HTML response, but rather the first HTML contains links to other
-> resources such as CSS and JavaScript that get downloaded afterwards and together they create the final page. See our <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to crawl those.
+> Note, however, that modern web pages often do not serve all of their content in the first HTML response, but rather the first HTML contains links to other resources such as CSS and JavaScript that get downloaded afterwards and together they create the final page. See our <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to crawl those.
 
-Once the page's HTML is retrieved, the crawler will pass it to [Cheerio](https://www.npmjs.com/package/cheerio) for
-parsing. The result is the typical `$` function, which should be familiar to `jQuery` users. You can use this `$` to do all sorts of lookups and
-manipulation of the page's HTML, but in scraping, we will mostly use it to find specific HTML elements and extract their data.
+Once the page's HTML is retrieved, the crawler will pass it to [Cheerio](https://www.npmjs.com/package/cheerio) for parsing. The result is the typical `$` function, which should be familiar to `jQuery` users. You can use this `$` to do all sorts of lookups and manipulation of the page's HTML, but in scraping, we will mostly use it to find specific HTML elements and extract their data.
 
 Example use of Cheerio and its `$` function in comparison to browser JavaScript:
 
@@ -394,12 +359,10 @@ const links = $('a[href]')
     .get();
 ```
 
-Our new function finds all the `<a>` elements that contain the `href` attribute and extracts the attributes into an array of strings. But there's a problem.
-There could be relative links in the list and those can't be used on their own. We need to resolve them using our domain as base URL and
+Our new function finds all the `<a>` elements that contain the `href` attribute and extracts the attributes into an array of strings. But there's a problem. There could be relative links in the list and those can't be used on their own. We need to resolve them using our domain as base URL and
 we will use one of Node.js' standard libraries to do this.
 
-Apify exposes two URL properties: <ApiLink to="core/class/Request#url">`request.url`</ApiLink> and <ApiLink to="core/class/Request#loadedUrl">`request.loadedUrl`</ApiLink>.
-What's the difference? Well, `request.url` is the URL of the first request. In case of redirects, the URL changes. The final one is stored as `request.loadedUrl`.
+Apify exposes two URL properties: <ApiLink to="core/class/Request#url">`request.url`</ApiLink> and <ApiLink to="core/class/Request#loadedUrl">`request.loadedUrl`</ApiLink>. What's the difference? Well, `request.url` is the URL of the first request. In case of redirects, the URL changes. The final one is stored as `request.loadedUrl`.
 
 ```ts
 // At the top of the file:
@@ -561,12 +524,9 @@ some extra functionality.
 
 ### Introduction to `Actor.utils.enqueueLinks()`
 
-Since enqueuing new links to crawl is such an integral part of web crawling, we created a function that attempts to simplify this process as much as possible.
-With a single function call, it allows you to find all the links on a page that match specified criteria and add them to a `RequestQueue`. It also allows you
-to modify the resulting `Requests` to match your crawling needs.
+Since enqueuing new links to crawl is such an integral part of web crawling, we created a function that attempts to simplify this process as much as possible. With a single function call, it allows you to find all the links on a page that match specified criteria and add them to a `RequestQueue`. It also allows you to modify the resulting `Requests` to match your crawling needs.
 
-`enqueueLinks` is quite a powerful function so, like crawlers, it gets its arguments from an options object. This is useful, because you don't have to
-remember their order! But also because we can easily extend its API and add new features. You can <ApiLink to="utils#enqueuelinks">find the full reference here</ApiLink>.
+`enqueueLinks` is quite a powerful function so, like crawlers, it gets its arguments from an options object. This is useful, because you don't have to remember their order! But also because we can easily extend its API and add new features. You can <ApiLink to="utils#enqueuelinks">find the full reference here</ApiLink>.
 
 We suggest using ES6 destructuring to grab the `enqueueLinks()` function off of the `utils` object, so you don't have to type `Actor.utils` all the time.
 
@@ -584,8 +544,7 @@ await enqueueLinks({
 
 ### Basic use of `enqueueLinks()` with `CheerioCrawler`
 
-We already implemented logic that takes care of enqueueing new links to a `RequestQueue` in the previous chapter on `CheerioCrawler`. Let's look at that
-logic and implement the same functionality using `enqueueLinks()`.
+We already implemented logic that takes care of enqueueing new links to a `RequestQueue` in the previous chapter on `CheerioCrawler`. Let's look at that logic and implement the same functionality using `enqueueLinks()`.
 
 We found that the crawler needed to do these 4 things to crawl `apify.com`:
 
@@ -594,17 +553,14 @@ We found that the crawler needed to do these 4 things to crawl `apify.com`:
 3. Enqueue them to the `RequestQueue`
 4. Scrape the newly enqueued links
 
-Using `enqueueLinks()` we can squash the first 3 into a single function call, if we set the options correctly. For now, let's just stick to the basics.
-At the very least, we need a source where to find the links and the queue to enqueue them to. The `$` Cheerio object is one of the sources the function accepts,
-and we already know how to work with it in the `requestHandler`. We also know how to get a `requestQueue` instance.
+Using `enqueueLinks()` we can squash the first 3 into a single function call, if we set the options correctly. For now, let's just stick to the basics. At the very least, we need a source where to find the links and the queue to enqueue them to. The `$` Cheerio object is one of the sources the function accepts, and we already know how to work with it in the `requestHandler`. We also know how to get a `requestQueue` instance.
 
 ```ts
 // Assuming previous existence of the '$' and 'requestQueue' variables.
 await enqueueLinks({ $, requestQueue });
 ```
 
-That's all we need to do to enqueue all `<a href="...">` links from the given page to the given queue. Easy, right? Scratch number 1 and 3 off the list.
-Only number 2 remains and to tackle this one, we need to talk about yet another new concept, the pseudo-URL.
+That's all we need to do to enqueue all `<a href="...">` links from the given page to the given queue. Easy, right? Scratch number 1 and 3 off the list. Only number 2 remains and to tackle this one, we need to talk about yet another new concept, the pseudo-URL.
 
 #### Introduction to pseudo-URLs
 
@@ -683,12 +639,9 @@ www.online-store.org/items/7003
 
 #### Using `enqueueLinks()` to filter links
 
-That's been quite a lot of theory and examples. We might as well put it to practice. Going back to our `CheerioCrawler` exercise, we still have number 2
-left to cross off the list - filter links pointing to `apify.com`. We've already shown that at the very least, the `enqueueLinks()` function needs two arguments.
-The source, in our case the `$` object, and the destination - the `requestQueue`. To filter links, we need to add a third argument: `pseudoUrls`.
+That's been quite a lot of theory and examples. We might as well put it to practice. Going back to our `CheerioCrawler` exercise, we still have number 2 left to cross off the list - filter links pointing to `apify.com`. We've already shown that at the very least, the `enqueueLinks()` function needs two arguments. The source, in our case the `$` object, and the destination - the `requestQueue`. To filter links, we need to add a third argument: `pseudoUrls`.
 
-The `options.pseudoUrls` argument is always an `Array`, but its contents can take on many forms. <ApiLink to="utils#enqueueLinks">See the reference</ApiLink> for all of them.
-Since we just need to filter out same domain links, we'll keep it simple and use a pseudo-URL `string`.
+The `options.pseudoUrls` argument is always an `Array`, but its contents can take on many forms. <ApiLink to="utils#enqueueLinks">See the reference</ApiLink> for all of them. Since we just need to filter out same domain links, we'll keep it simple and use a pseudo-URL `string`.
 
 ```ts
 // Assuming previous existence of the '$' and 'requestQueue' variables.
@@ -833,8 +786,7 @@ can find ready-made solutions for crawling [Google Places](https://apify.com/dro
 [Google Search](https://apify.com/apify/google-search-scraper),
 [Booking](https://apify.com/dtrungtin/booking-scraper),
 [Instagram](https://apify.com/jaroslavhejlek/instagram-scraper),
-[Tripadvisor](https://apify.com/maxcopell/tripadvisor) and many other websites. Feel free to check them out! It's also a great place to practice our Jedi
-scraping skills since it has categories, lists and details. That's almost like our imaginary `online-store.com` from the previous chapter.
+[Tripadvisor](https://apify.com/maxcopell/tripadvisor) and many other websites. Feel free to check them out! It's also a great place to practice our Jedi scraping skills since it has categories, lists and details. That's almost like our imaginary `online-store.com` from the previous chapter.
 
 ### The importance of having a plan
 
@@ -861,8 +813,7 @@ scrape all actors (see the `Show` dropdown) in all categories (which can be foun
 6.  Last modification date
 7.  Number of runs
 
-We can see that some of the information is available directly on the list page, but for details such as "Last modification date" or "Number of runs" we'll
-also need
+We can see that some of the information is available directly on the list page, but for details such as "Last modification date" or "Number of runs" we'll also need
 to open the actor detail pages.
 
 ![data to scrape](/img/getting-started/scraping-practice.jpg 'Overview of data to be scraped.')
@@ -1287,8 +1238,8 @@ return {
 };
 ```
 
-The `ul.ActorHeader-stats > li:nth-of-type(3)` looks complicated, but it only reads that we're looking for a `<ul class="ActorHeader-stats ...">` element
-and within that element we're looking for the third `<li>` element. We grab its text, but we're only interested in the number of runs. So we parse the number out
+The `ul.ActorHeader-stats > li:nth-of-type(3)` looks complicated, but it only reads that we're looking for a `<ul class="ActorHeader-stats ...">` element and within that
+element we're looking for the third `<li>` element. We grab its text, but we're only interested in the number of runs. So we parse the number out
 using a regular expression, but its type is still a `string`, so we finally convert the result to a `number` by wrapping it with a `Number()` call.
 
 > The numbers are formatted with commas as thousands separators (e.g. `'1,234,567'`), so to extract it, we
@@ -1708,8 +1659,8 @@ your logic separate. Less code in a single file means less code you need to thin
 
 #### Using `Actor.utils.log` instead of `console.log`
 
-We wont go to great lengths here to talk about `utils.log`, because you can read <ApiLink to="core/class/Log">it all in the documentation</ApiLink>, but
-there's just one thing that we need to stress: **log levels**.
+We wont go to great lengths here to talk about `utils.log`, because you can read <ApiLink to="core/class/Log">it all in the documentation</ApiLink>, but there's just
+one thing that we need to stress: **log levels**.
 
 `utils.log` enables you to use different log levels, such as `log.debug`, `log.info` or `log.warning`. It not only makes your log more readable, but
 it also allows selective turning off of some levels by either calling the `utils.log.setLevel()` function or by setting an `APIFY_LOG_LEVEL` variable.

--- a/docs/guides/getting_started.mdx
+++ b/docs/guides/getting_started.mdx
@@ -266,7 +266,9 @@ This is the crawler that we used in our earlier example. Our simplest and also t
 
 > Note, however, that modern web pages often do not serve all of their content in the first HTML response, but rather the first HTML contains links to other resources such as CSS and JavaScript that get downloaded afterwards and together they create the final page. See our <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to crawl those.
 
-Once the page's HTML is retrieved, the crawler will pass it to [Cheerio](https://www.npmjs.com/package/cheerio) for parsing. The result is the typical `$` function, which should be familiar to `jQuery` users. You can use this `$` to do all sorts of lookups and manipulation of the page's HTML, but in scraping, we will mostly use it to find specific HTML elements and extract their data.
+Once the page's HTML is retrieved, the crawler will pass it to [Cheerio](https://www.npmjs.com/package/cheerio) for
+parsing. The result is the typical `$` function, which should be familiar to `jQuery` users. You can use this `$` to do all sorts of lookups and
+manipulation of the page's HTML, but in scraping, we will mostly use it to find specific HTML elements and extract their data.
 
 Example use of Cheerio and its `$` function in comparison to browser JavaScript:
 
@@ -291,10 +293,8 @@ Even though using `CheerioCrawler` is extremely easy, it probably will not be yo
 environments. Since most websites nowadays use modern JavaScript to create rich, responsive and data-driven user experiences, the plain HTTP requests
 the crawler uses may just fall short of your needs.
 
-But <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> is far from useless! It really shines when you need to cope with extremely
-high workloads. With just 4 GBs of memory and a single CPU core, you can scrape 500 or more pages a minute! _(assuming each page contains approximately 400KB of HTML)_
-To scrape this fast with a full browser scraper, such as the <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>, you'd
-need significantly more computing power.
+But <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> is far from useless! It really shines when you need to cope with extremely high workloads. With just 4 GBs of memory and a single CPU core, you can scrape 500 or more pages a minute! _(assuming each page contains approximately 400KB of HTML)_ To scrape this fast with a full browser
+scraper, such as the <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>, you'd need significantly more computing power.
 
 **Advantages:**
 
@@ -786,7 +786,8 @@ can find ready-made solutions for crawling [Google Places](https://apify.com/dro
 [Google Search](https://apify.com/apify/google-search-scraper),
 [Booking](https://apify.com/dtrungtin/booking-scraper),
 [Instagram](https://apify.com/jaroslavhejlek/instagram-scraper),
-[Tripadvisor](https://apify.com/maxcopell/tripadvisor) and many other websites. Feel free to check them out! It's also a great place to practice our Jedi scraping skills since it has categories, lists and details. That's almost like our imaginary `online-store.com` from the previous chapter.
+[Tripadvisor](https://apify.com/maxcopell/tripadvisor) and many other websites. Feel free to check them out! It's also a great place to practice our Jedi scraping skills since it has categories, lists and details. That's almost like our imaginary
+`online-store.com` from the previous chapter.
 
 ### The importance of having a plan
 

--- a/docs/guides/getting_started.mdx
+++ b/docs/guides/getting_started.mdx
@@ -130,7 +130,8 @@ introduce all Crawlee classes necessary to make it happen.
 
 ### The general idea
 
-There are 4 crawler classes available for use in Crawlee. <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>, <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. We'll talk about their differences later. Now, let's talk about what they have in common.
+There are 4 crawler classes available for use in Crawlee. <ApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</ApiLink>, <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink>, <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> and <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
+We'll talk about their differences later. Now, let's talk about what they have in common.
 
 The general idea of each crawler is to go to a web page, open it, do some stuff there, save some results and continue to the next page, until it's done
 its job. So the crawler always needs to find answers to two questions: **Where should I go?** and **What should I do there?** Answering those two
@@ -138,19 +139,32 @@ questions is the only setup mandatory for running the crawlers.
 
 ### The Where - `Request`, `RequestList` and `RequestQueue`
 
-All crawlers use instances of the <ApiLink to="core/class/Request">`Request`</ApiLink> class to determine where they need to go. Each request may hold a lot of information, but at the very least, it must hold a URL - a web page to open. But having only one URL would not make sense for crawling. We need to either have a pre-existing list of our own URLs that we wish to visit, perhaps a thousand, or a million, or we need to build this list dynamically as we crawl, adding more and more URLs to the list as we progress.
+All crawlers use instances of the <ApiLink to="core/class/Request">`Request`</ApiLink> class to determine where they need to go. Each request may hold a lot
+of information, but at the very least, it must hold a URL - a web page to open. But having only one URL would not make sense for crawling. We need to either
+have a pre-existing list of our own URLs that we wish to visit, perhaps a thousand, or a million, or we need to build this list dynamically as we crawl,
+adding more and more URLs to the list as we progress.
 
-A representation of the pre-existing list is an instance of the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class. It is a static, immutable list of URLs and other metadata (see the <ApiLink to="core/class/Request">`Request`</ApiLink> object) that the crawler will visit, one by one, retrying whenever an error occurs, until there are no more `Requests` to process.
+A representation of the pre-existing list is an instance of the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class. It is a static, immutable
+list of URLs and other metadata (see the <ApiLink to="core/class/Request">`Request`</ApiLink> object) that the crawler will visit, one by one, retrying whenever
+an error occurs, until there are no more `Requests` to process.
 
-&#8203;<ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> on the other hand, represents a dynamic queue of `Requests`. One that can be updated at runtime by adding more pages - `Requests` to process. This allows the crawler to open one page, extract interesting URLs, such as links to other pages on the same domain, add them to the queue (called _enqueuing_) and repeat this process to build a queue of tens of thousands or more URLs while knowing only a single one at the beginning.
+&#8203;<ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> on the other hand, represents a dynamic queue of `Requests`. One that can be updated
+at runtime by adding more pages - `Requests` to process. This allows the crawler to open one page, extract interesting URLs, such as links to other pages on
+the same domain, add them to the queue (called _enqueuing_) and repeat this process to build a queue of tens of thousands or more URLs while knowing only a
+single one at the beginning.
 
-`RequestList` and `RequestQueue` are essential for the crawler's operation. There is no other way to supply `Requests` = "pages to crawl" to the crawlers. At least one of them always needs to be provided while setting up. You can also use both at the same time, if you wish.
+`RequestList` and `RequestQueue` are essential for the crawler's operation. There is no other way to supply `Requests` = "pages to crawl" to the crawlers.
+At least one of them always needs to be provided while setting up. You can also use both at the same time, if you wish.
 
 ### The What - `requestHandler`
 
-The `requestHandler` is the brain of the crawler. It tells it what to do at each and every page it visits. Generally it handles extraction of data from the page, processing the data, saving it, calling APIs, doing calculations and whatever else you need it to do.
+The `requestHandler` is the brain of the crawler. It tells it what to do at each and every page it visits. Generally it handles extraction of data from
+the page, processing the data, saving it, calling APIs, doing calculations and whatever else you need it to do.
 
-The `requestHandler` is provided by you, the user, and invoked automatically by the crawler for each `Request` from either the `RequestList` or `RequestQueue`. It always receives a single argument and that is a plain `Object`. Its properties change depending on the crawler class used, but it always includes at least the `request` property, which represents the currently crawled `Request` instance (i.e. the URL the crawler is visiting and related metadata) and the `autoscaledPool` property, which is an instance of the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink> class and we'll talk about it in detail later.
+The `requestHandler` is provided by you, the user, and invoked automatically by the crawler for each `Request` from either the `RequestList` or `RequestQueue`.
+It always receives a single argument and that is a plain `Object`. Its properties change depending on the crawler class used, but it always includes at least the
+`request` property, which represents the currently crawled `Request` instance (i.e. the URL the crawler is visiting and related metadata) and the `autoscaledPool`
+property, which is an instance of the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink> class and we'll talk about it in detail later.
 
 ```ts
 // The object received as a single argument by the requestHandler
@@ -162,7 +176,9 @@ The `requestHandler` is provided by you, the user, and invoked automatically by 
 
 ### Putting it all together
 
-Enough theory! Let's put some of those hard-learned facts into practice. We learned above that we need `Requests` and a `requestHandler` to setup a crawler. We will also use the <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> function. It's not mandatory, but it makes our life easier. We'll learn about it in detail later on.
+Enough theory! Let's put some of those hard-learned facts into practice. We learned above that we need `Requests` and a `requestHandler` to setup a crawler.
+We will also use the <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> function. It's not mandatory, but it makes our life easier. We'll learn about
+it in detail later on.
 
 Let's start with something super easy. Visit a page, get its title and close. First of all we need to require Apify, to make all of its features available to us:
 
@@ -170,7 +186,8 @@ Let's start with something super easy. Visit a page, get its title and close. Fi
 import { Actor } from 'apify';
 ```
 
-Easy, right? It really doesn't get much more difficult than that. For the purposes of this tutorial, we'll be scraping our own webpage [https://apify.com](https://apify.com). Now, to get there, we need a `Request` with the page's URL in one of our sources, `RequestList` or `RequestQueue`. Let's go with `RequestQueue` for now.
+Easy, right? It really doesn't get much more difficult than that. For the purposes of this tutorial, we'll be scraping our own webpage [https://apify.com](https://apify.com).
+Now, to get there, we need a `Request` with the page's URL in one of our sources, `RequestList` or `RequestQueue`. Let's go with `RequestQueue` for now.
 
 ```ts
 import { Actor } from 'apify';
@@ -188,7 +205,8 @@ await Actor.main(async () => {
 > If you're not familiar with the `async` and `await` keywords used in the example, you should know that these are native syntax in modern JavaScript. You can
 > [learn more about them here](https://nikgrozev.com/2017/10/01/async-await/).
 
-The <ApiLink to="core/class/RequestQueue#addRequest">`requestQueue.addRequest()`</ApiLink> function automatically converts the plain object we passed to it to a `Request` instance, so now we have a `requestQueue` that holds one `request` which points to `https://apify.com`. Now we need the `requestHandler`.
+The <ApiLink to="core/class/RequestQueue#addRequest">`requestQueue.addRequest()`</ApiLink> function automatically converts the plain object we passed to it
+to a `Request` instance, so now we have a `requestQueue` that holds one `request` which points to `https://apify.com`. Now we need the `requestHandler`.
 
 ```ts
 import { CheerioCrawlingContext } from '@crawlee/cheerio';
@@ -203,7 +221,9 @@ const requestHandler: CheerioCrawlingContext = async ({ request, $ }) => {
 };
 ```
 
-Wait, where did the `$` come from? Remember what we learned about the `requestHandler` earlier. It expects a plain `Object` as an argument that will always have a `request` property, but it will also have other properties, depending on the chosen crawler class. Well, `$` is a property provided by the `CheerioCrawler` class, which we'll set up right now.
+Wait, where did the `$` come from? Remember what we learned about the `requestHandler` earlier. It expects a plain `Object` as an argument that will always
+have a `request` property, but it will also have other properties, depending on the chosen crawler class. Well, `$` is a property provided by the `CheerioCrawler`
+class, which we'll set up right now.
 
 ```ts
 import { Actor } from 'apify';
@@ -228,11 +248,13 @@ await Actor.main(async () => {
 });
 ```
 
-That starts to look almost good. Almost? Yes, we can do even better! Since v3, the crawler has an implicit `RequestQueue` instance, so we can save ourselves from all the `RequestQueue` related code and just use `crawler.addRequests()` method. We can also move the `requestHandler` method definition directly to the crawler options, this way we get type inference for free:
+That starts to look almost good. Almost? Yes, we can do even better! Since v3, the crawler has an implicit `RequestQueue` instance, so we can save ourselves
+from all the `RequestQueue` related code and just use `crawler.addRequests()` method. We can also move the `requestHandler` method definition directly to the
+crawler options, this way we get type inference for free:
 
 ```ts
 import { Actor } from 'apify';
-import { CheerioCrawler, RequestQueue, CheerioCrawlingContext } from '@crawlee/cheerio';
+import { CheerioCrawler } from '@crawlee/cheerio';
 
 await Actor.main(async () => {
     // Set up the crawler, passing a single options object as an argument.
@@ -248,23 +270,34 @@ await Actor.main(async () => {
 });
 ```
 
-And we're done! You just created your first crawler from scratch. It will download the HTML of `https://apify.com`, find the `<title>` element, get its text content and print it to console. Good job!
+And we're done! You just created your first crawler from scratch. It will download the HTML of `https://apify.com`, find the `<title>` element,
+get its text content and print it to console. Good job!
 
-To run the code locally, copy and paste the code, if you haven't already typed it in yourself, to the `main.js` file in the `my-new-project` we created earlier and run `apify run` from that project's directory.
+To run the code locally, copy and paste the code, if you haven't already typed it in yourself, to the `main.mjs` file in the `my-new-project` we created
+earlier and run `apify run` from that project's directory.
 
 To run the code on Apify Platform, just replace the original example with your new code and hit Run.
 
-Whichever environment you choose, you should see the message `The title of "https://apify.com" is: Web Scraping, Data Extraction and Automation - Actor.` printed to the screen. If you do, congratulations and let's move onto some bigger challenges! And if you feel like you don't really know what just happened there, no worries, it will all become clear when you learn more about `CheerioCrawler`.
+Whichever environment you choose, you should see the message `The title of "https://apify.com" is: Web Scraping, Data Extraction and Automation - Actor.`
+printed to the screen. If you do, congratulations and let's move onto some bigger challenges! And if you feel like you don't really know what just happened there,
+no worries, it will all become clear when you learn more about `CheerioCrawler`.
 
 ## CheerioCrawler aka jQuery crawler
 
-This is the crawler that we used in our earlier example. Our simplest and also the fastest crawling solution. If you're familiar with `jQuery`, you'll understand <ApiLink to="cheerio-crawler/class/CheerioCrawler">CheerioCrawler</ApiLink> in minutes. [`Cheerio`](https://www.npmjs.com/package/cheerio) is essentially `jQuery` for Node.js. It offers the same API, including the familiar `$` object. You can use it, as you would `jQuery`, for manipulating the DOM of an HTML page. In crawling, you'll mostly use it to select the right elements and extract their text values - the data you're interested in. But `jQuery` runs in a browser and attaches directly to the browser's DOM. Where does `cheerio` get its HTML? This is where the `Crawler` part of <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> comes in.
+This is the crawler that we used in our earlier example. Our simplest and also the fastest crawling solution. If you're familiar with `jQuery`,
+you'll understand <ApiLink to="cheerio-crawler/class/CheerioCrawler">CheerioCrawler</ApiLink> in minutes. [`Cheerio`](https://www.npmjs.com/package/cheerio) is
+essentially `jQuery` for Node.js. It offers the same API, including the familiar `$` object. You can use it, as you would `jQuery`, for manipulating the DOM
+of an HTML page. In crawling, you'll mostly use it to select the right elements and extract their text values - the data you're interested in. But `jQuery` runs
+in a browser and attaches directly to the browser's DOM. Where does `cheerio` get its HTML? This is where the `Crawler` part of <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> comes in.
 
 ### Overview
 
-&#8203;<ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> crawls by making plain HTTP requests to the provided URLs. As you remember from the previous section, the URLs are fed to the crawler using either the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> or the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>. The HTTP responses it gets back are HTML pages, the same pages you would get in your browser when you first load a URL.
+&#8203;<ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> crawls by making plain HTTP requests to the provided URLs. As you remember
+from the previous section, the URLs are fed to the crawler using either the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> or the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>.
+The HTTP responses it gets back are HTML pages, the same pages you would get in your browser when you first load a URL.
 
-> Note, however, that modern web pages often do not serve all of their content in the first HTML response, but rather the first HTML contains links to other resources such as CSS and JavaScript that get downloaded afterwards and together they create the final page. See our <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to crawl those.
+> Note, however, that modern web pages often do not serve all of their content in the first HTML response, but rather the first HTML contains links to other
+> resources such as CSS and JavaScript that get downloaded afterwards and together they create the final page. See our <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to crawl those.
 
 Once the page's HTML is retrieved, the crawler will pass it to [Cheerio](https://www.npmjs.com/package/cheerio) for
 parsing. The result is the typical `$` function, which should be familiar to `jQuery` users. You can use this `$` to do all sorts of lookups and
@@ -293,9 +326,10 @@ Even though using `CheerioCrawler` is extremely easy, it probably will not be yo
 environments. Since most websites nowadays use modern JavaScript to create rich, responsive and data-driven user experiences, the plain HTTP requests
 the crawler uses may just fall short of your needs.
 
-But <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> is far from useless! It really shines when you need to cope with extremely high workloads. With just 4 GBs of memory and a single CPU
-core, you can scrape 500 or more pages a minute! _(assuming each page contains approximately 400KB of HTML)_ To scrape this fast with a full browser
-scraper, such as the <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>, you'd need significantly more computing power.
+But <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> is far from useless! It really shines when you need to cope with extremely
+high workloads. With just 4 GBs of memory and a single CPU core, you can scrape 500 or more pages a minute! _(assuming each page contains approximately 400KB of HTML)_
+To scrape this fast with a full browser scraper, such as the <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>, you'd
+need significantly more computing power.
 
 **Advantages:**
 
@@ -323,7 +357,7 @@ it to the console. This is the original source code:
 
 ```ts
 import { Actor } from 'apify';
-import { CheerioCrawler, RequestQueue, CheerioCrawlingContext } from '@crawlee/cheerio';
+import { CheerioCrawler } from '@crawlee/cheerio';
 
 await Actor.main(async () => {
     // Set up the crawler, passing a single options object as an argument.
@@ -360,10 +394,12 @@ const links = $('a[href]')
     .get();
 ```
 
-Our new function finds all the `<a>` elements that contain the `href` attribute and extracts the attributes into an array of strings. But there's a problem. There could be relative links in the list and those can't be used on their own. We need to resolve them using our domain as base URL and
+Our new function finds all the `<a>` elements that contain the `href` attribute and extracts the attributes into an array of strings. But there's a problem.
+There could be relative links in the list and those can't be used on their own. We need to resolve them using our domain as base URL and
 we will use one of Node.js' standard libraries to do this.
 
-Apify exposes two URL properties: <ApiLink to="core/class/Request#url">`request.url`</ApiLink> and <ApiLink to="core/class/Request#loadedUrl">`request.loadedUrl`</ApiLink>. What's the difference? Well, `request.url` is the URL of the first request. In case of redirects, the URL changes. The final one is stored as `request.loadedUrl`.
+Apify exposes two URL properties: <ApiLink to="core/class/Request#url">`request.url`</ApiLink> and <ApiLink to="core/class/Request#loadedUrl">`request.loadedUrl`</ApiLink>.
+What's the difference? Well, `request.url` is the URL of the first request. In case of redirects, the URL changes. The final one is stored as `request.loadedUrl`.
 
 ```ts
 // At the top of the file:
@@ -470,7 +506,7 @@ will be allowed to finish too.
 ```ts
 import { URL } from 'url'; // <------ This is new.
 import { Actor } from 'apify';
-import { CheerioCrawler, RequestQueue, CheerioCrawlingContext } from '@crawlee/cheerio';
+import { CheerioCrawler } from '@crawlee/cheerio';
 
 await Actor.main(async () => {
     // Set up the crawler, passing a single options object as an argument.
@@ -525,9 +561,12 @@ some extra functionality.
 
 ### Introduction to `Actor.utils.enqueueLinks()`
 
-Since enqueuing new links to crawl is such an integral part of web crawling, we created a function that attempts to simplify this process as much as possible. With a single function call, it allows you to find all the links on a page that match specified criteria and add them to a `RequestQueue`. It also allows you to modify the resulting `Requests` to match your crawling needs.
+Since enqueuing new links to crawl is such an integral part of web crawling, we created a function that attempts to simplify this process as much as possible.
+With a single function call, it allows you to find all the links on a page that match specified criteria and add them to a `RequestQueue`. It also allows you
+to modify the resulting `Requests` to match your crawling needs.
 
-`enqueueLinks` is quite a powerful function so, like crawlers, it gets its arguments from an options object. This is useful, because you don't have to remember their order! But also because we can easily extend its API and add new features. You can <ApiLink to="utils#enqueuelinks">find the full reference here</ApiLink>.
+`enqueueLinks` is quite a powerful function so, like crawlers, it gets its arguments from an options object. This is useful, because you don't have to
+remember their order! But also because we can easily extend its API and add new features. You can <ApiLink to="utils#enqueuelinks">find the full reference here</ApiLink>.
 
 We suggest using ES6 destructuring to grab the `enqueueLinks()` function off of the `utils` object, so you don't have to type `Actor.utils` all the time.
 
@@ -535,7 +574,7 @@ We suggest using ES6 destructuring to grab the `enqueueLinks()` function off of 
 import { Actor } from 'apify';
 const {
     utils: { enqueueLinks },
-} = Apify;
+} = Actor;
 
 // Now you can use enqueueLinks like this:
 await enqueueLinks({
@@ -545,7 +584,8 @@ await enqueueLinks({
 
 ### Basic use of `enqueueLinks()` with `CheerioCrawler`
 
-We already implemented logic that takes care of enqueueing new links to a `RequestQueue` in the previous chapter on `CheerioCrawler`. Let's look at that logic and implement the same functionality using `enqueueLinks()`.
+We already implemented logic that takes care of enqueueing new links to a `RequestQueue` in the previous chapter on `CheerioCrawler`. Let's look at that
+logic and implement the same functionality using `enqueueLinks()`.
 
 We found that the crawler needed to do these 4 things to crawl `apify.com`:
 
@@ -554,14 +594,17 @@ We found that the crawler needed to do these 4 things to crawl `apify.com`:
 3. Enqueue them to the `RequestQueue`
 4. Scrape the newly enqueued links
 
-Using `enqueueLinks()` we can squash the first 3 into a single function call, if we set the options correctly. For now, let's just stick to the basics. At the very least, we need a source where to find the links and the queue to enqueue them to. The `$` Cheerio object is one of the sources the function accepts, and we already know how to work with it in the `requestHandler`. We also know how to get a `requestQueue` instance.
+Using `enqueueLinks()` we can squash the first 3 into a single function call, if we set the options correctly. For now, let's just stick to the basics.
+At the very least, we need a source where to find the links and the queue to enqueue them to. The `$` Cheerio object is one of the sources the function accepts,
+and we already know how to work with it in the `requestHandler`. We also know how to get a `requestQueue` instance.
 
 ```ts
 // Assuming previous existence of the '$' and 'requestQueue' variables.
 await enqueueLinks({ $, requestQueue });
 ```
 
-That's all we need to do to enqueue all `<a href="...">` links from the given page to the given queue. Easy, right? Scratch number 1 and 3 off the list. Only number 2 remains and to tackle this one, we need to talk about yet another new concept, the pseudo-URL.
+That's all we need to do to enqueue all `<a href="...">` links from the given page to the given queue. Easy, right? Scratch number 1 and 3 off the list.
+Only number 2 remains and to tackle this one, we need to talk about yet another new concept, the pseudo-URL.
 
 #### Introduction to pseudo-URLs
 
@@ -640,9 +683,12 @@ www.online-store.org/items/7003
 
 #### Using `enqueueLinks()` to filter links
 
-That's been quite a lot of theory and examples. We might as well put it to practice. Going back to our `CheerioCrawler` exercise, we still have number 2 left to cross off the list - filter links pointing to `apify.com`. We've already shown that at the very least, the `enqueueLinks()` function needs two arguments. The source, in our case the `$` object, and the destination - the `requestQueue`. To filter links, we need to add a third argument: `pseudoUrls`.
+That's been quite a lot of theory and examples. We might as well put it to practice. Going back to our `CheerioCrawler` exercise, we still have number 2
+left to cross off the list - filter links pointing to `apify.com`. We've already shown that at the very least, the `enqueueLinks()` function needs two arguments.
+The source, in our case the `$` object, and the destination - the `requestQueue`. To filter links, we need to add a third argument: `pseudoUrls`.
 
-The `options.pseudoUrls` argument is always an `Array`, but its contents can take on many forms. <ApiLink to="utils#enqueueLinks">See the reference</ApiLink> for all of them. Since we just need to filter out same domain links, we'll keep it simple and use a pseudo-URL `string`.
+The `options.pseudoUrls` argument is always an `Array`, but its contents can take on many forms. <ApiLink to="utils#enqueueLinks">See the reference</ApiLink> for all of them.
+Since we just need to filter out same domain links, we'll keep it simple and use a pseudo-URL `string`.
 
 ```ts
 // Assuming previous existence of the '$' and 'requestQueue' variables.
@@ -787,8 +833,8 @@ can find ready-made solutions for crawling [Google Places](https://apify.com/dro
 [Google Search](https://apify.com/apify/google-search-scraper),
 [Booking](https://apify.com/dtrungtin/booking-scraper),
 [Instagram](https://apify.com/jaroslavhejlek/instagram-scraper),
-[Tripadvisor](https://apify.com/maxcopell/tripadvisor) and many other websites. Feel free to check them out! It's also a great place to practice our Jedi scraping skills since it has categories, lists and details. That's almost like our imaginary
-`online-store.com` from the previous chapter.
+[Tripadvisor](https://apify.com/maxcopell/tripadvisor) and many other websites. Feel free to check them out! It's also a great place to practice our Jedi
+scraping skills since it has categories, lists and details. That's almost like our imaginary `online-store.com` from the previous chapter.
 
 ### The importance of having a plan
 
@@ -815,7 +861,8 @@ scrape all actors (see the `Show` dropdown) in all categories (which can be foun
 6.  Last modification date
 7.  Number of runs
 
-We can see that some of the information is available directly on the list page, but for details such as "Last modification date" or "Number of runs" we'll also need
+We can see that some of the information is available directly on the list page, but for details such as "Last modification date" or "Number of runs" we'll
+also need
 to open the actor detail pages.
 
 ![data to scrape](/img/getting-started/scraping-practice.jpg 'Overview of data to be scraped.')
@@ -1240,8 +1287,8 @@ return {
 };
 ```
 
-The `ul.ActorHeader-stats > li:nth-of-type(3)` looks complicated, but it only reads that we're looking for a `<ul class="ActorHeader-stats ...">` element and within that
-element we're looking for the third `<li>` element. We grab its text, but we're only interested in the number of runs. So we parse the number out
+The `ul.ActorHeader-stats > li:nth-of-type(3)` looks complicated, but it only reads that we're looking for a `<ul class="ActorHeader-stats ...">` element
+and within that element we're looking for the third `<li>` element. We grab its text, but we're only interested in the number of runs. So we parse the number out
 using a regular expression, but its type is still a `string`, so we finally convert the result to a `number` by wrapping it with a `Number()` call.
 
 > The numbers are formatted with commas as thousands separators (e.g. `'1,234,567'`), so to extract it, we
@@ -1431,7 +1478,7 @@ await Actor.main(async () => {
 
 #### What's `Actor.pushData()`
 
-<ApiLink to="core/class/Dataset#pushData">`Actor.pushData()`</ApiLink> is a helper function that saves data to the default <ApiLink to="core/class/Dataset">`Dataset`</ApiLink>. `Dataset` is a storage designed to hold virtually unlimited amount of data in a format similar to a table. Each time you call `Actor.pushData()` a new row in the table is created, with the property names serving as column titles.
+&#8203;<ApiLink to="core/class/Dataset#pushData">`Actor.pushData()`</ApiLink> is a helper function that saves data to the default <ApiLink to="core/class/Dataset">`Dataset`</ApiLink>. `Dataset` is a storage designed to hold virtually unlimited amount of data in a format similar to a table. Each time you call `Actor.pushData()` a new row in the table is created, with the property names serving as column titles.
 
 > Each actor run has one default `Dataset` so no need to initialize it or create an instance first. It just gets done automatically for you. You can
 > also create named datasets at will.
@@ -1452,7 +1499,7 @@ Unless you changed the environment variables that Crawlee uses locally, which wo
 this tutorial anyway, you'll find your data in your local Apify Storage.
 
 ```
-{PROJECT_FOLDER}/apify_storage/datasets/default/
+{PROJECT_FOLDER}/crawlee_storage/datasets/default/
 ```
 
 The above folder will hold all your saved data in numbered files, as they were pushed into the dataset. Each file represents one invocation of
@@ -1489,7 +1536,7 @@ and by calling <ApiLink to="apify/class/Actor#getvalue">`Actor.getInput()`</ApiL
 Running locally, you need to place an `INPUT.json` file in your default key value store for this to work.
 
 ```
-{PROJECT_FOLDER}/apify_storage/key_value_stores/default/INPUT.json
+{PROJECT_FOLDER}/crawlee_storage/key_value_stores/default/INPUT.json
 ```
 
 #### Use `INPUT` to seed our actor with categories
@@ -1545,10 +1592,10 @@ In the following code we've made several changes.
 
 > To create a multi-file actor on the Apify Platform, select **Multiple source files** in the **Type** dropdown on the **Source** screen.
 
-In our `main.js` file, we place the general structure of the crawler:
+In our `main.mjs` file, we place the general structure of the crawler:
 
 ```ts
-// main.js
+// main.mjs
 import { Actor } from 'apify';
 import { CheerioCrawler, log } from '@crawlee/cheerio';
 import * as tools from './tools';
@@ -1576,10 +1623,10 @@ await Actor.main(async () => {
 });
 ```
 
-Then in a separate `tools.js`, we add our helper functions:
+Then in a separate `tools.mjs`, we add our helper functions:
 
 ```ts
-// tools.js
+// tools.mjs
 import { Actor } from 'apify';
 import { log } from '@crawlee/core';
 import * as routes from './routes';
@@ -1605,10 +1652,10 @@ export async function createRouter(globalContext) {
 };
 ```
 
-And finally our routes in a separate `routes.js` file:
+And finally our routes in a separate `routes.mjs` file:
 
 ```ts
-// routes.js
+// routes.mjs
 import { Actor } from 'apify';
 import { log } from '@crawlee/core';
 
@@ -1661,8 +1708,8 @@ your logic separate. Less code in a single file means less code you need to thin
 
 #### Using `Actor.utils.log` instead of `console.log`
 
-We wont go to great lengths here to talk about `utils.log`, because you can read <ApiLink to="core/class/Log">it all in the documentation</ApiLink>, but there's just
-one thing that we need to stress: **log levels**.
+We wont go to great lengths here to talk about `utils.log`, because you can read <ApiLink to="core/class/Log">it all in the documentation</ApiLink>, but
+there's just one thing that we need to stress: **log levels**.
 
 `utils.log` enables you to use different log levels, such as `log.debug`, `log.info` or `log.warning`. It not only makes your log more readable, but
 it also allows selective turning off of some levels by either calling the `utils.log.setLevel()` function or by setting an `APIFY_LOG_LEVEL` variable.

--- a/docs/guides/getting_started.mdx
+++ b/docs/guides/getting_started.mdx
@@ -293,7 +293,8 @@ Even though using `CheerioCrawler` is extremely easy, it probably will not be yo
 environments. Since most websites nowadays use modern JavaScript to create rich, responsive and data-driven user experiences, the plain HTTP requests
 the crawler uses may just fall short of your needs.
 
-But <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> is far from useless! It really shines when you need to cope with extremely high workloads. With just 4 GBs of memory and a single CPU core, you can scrape 500 or more pages a minute! _(assuming each page contains approximately 400KB of HTML)_ To scrape this fast with a full browser
+But <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> is far from useless! It really shines when you need to cope with extremely high workloads. With just 4 GBs of memory and a single CPU
+core, you can scrape 500 or more pages a minute! _(assuming each page contains approximately 400KB of HTML)_ To scrape this fast with a full browser
 scraper, such as the <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>, you'd need significantly more computing power.
 
 **Advantages:**

--- a/docs/guides/motivation.mdx
+++ b/docs/guides/motivation.mdx
@@ -4,8 +4,6 @@ title: Motivation
 slug: /
 ---
 
-import ApiLink from '@site/src/components/ApiLink';
-
 Thanks to tools like [Playwright](https://github.com/microsoft/playwright), [Puppeteer](https://github.com/puppeteer/puppeteer) or
 [Cheerio](https://www.npmjs.com/package/cheerio), it is easy to write Node.js code to extract data from web pages. But
 eventually things will get complicated. For example, when you try to:

--- a/docs/guides/quick_start.mdx
+++ b/docs/guides/quick_start.mdx
@@ -5,13 +5,19 @@ title: Quick Start
 
 import ApiLink from '@site/src/components/ApiLink';
 
+:::danger
+
+TODO: this should probably adapt to Crawlee instead of platform
+
+:::
+
 This short tutorial will set you up to start using Crawlee in a minute or two.
 If you want to learn more, proceed to the [Getting Started](../guides/getting-started)
 tutorial that will take you step by step through creating your first scraper.
 
 ## Local stand-alone usage
 
-Crawlee requires [Node.js](https://nodejs.org/en/) 15.10 or later.
+Crawlee requires [Node.js](https://nodejs.org/en/) 16 or later.
 Add Crawlee to any Node.js project by running:
 
 ```bash
@@ -28,47 +34,38 @@ flexibility. That's why we install it with NPM. You can choose one, both, or nei
 Run the following example to perform a recursive crawl of a website using Playwright. For more examples showcasing various features of Crawlee,
 [see the Examples section of the documentation](../examples/crawl-multiple-urls).
 
-```javascript title="src/main.js"
+```javascript title="src/main.mjs"
 import { Actor } from 'apify';
 
 // Actor.main is a helper function, you don't need to use it.
 Actor.main(async () => {
-    const requestQueue = await RequestQueue.open();
-    // Choose the first URL to open.
-    await requestQueue.addRequest({ url: 'https://www.iana.org/' });
-
     const crawler = new PlaywrightCrawler({
-        requestQueue,
-        handlePageFunction: async ({ request, page }) => {
+        async requestHandler({ request, page, enqueueLinks }) {
             // Extract HTML title of the page.
             const title = await page.title();
             console.log(`Title of ${request.url}: ${title}`);
 
             // Add URLs that match the provided pattern.
-            await Actor.utils.enqueueLinks({
-                page,
-                requestQueue,
-                pseudoUrls: ['https://www.iana.org/[.*]'],
+            await enqueueLinks({
+                globs: ['https://www.iana.org/*'],
             });
         },
     });
+
+    // Choose the first URL to open.
+    await crawler.addRequests([{ url: 'https://www.iana.org/' }]);
 
     await crawler.run();
 });
 ```
 
-:::tip
-
-To read more about what pseudo-URL is, check the [getting-started](getting-started#introduction-to-pseudo-urls).
-
-:::
-
 When you run the example, you should see Crawlee automating a Chrome browser.
 
 ![Chrome Scrape](/img/chrome_scrape.gif)
 
-By default, Crawlee stores data to `./apify_storage` in the current working directory. You can override this behavior by setting either the
-`APIFY_LOCAL_STORAGE_DIR` or `APIFY_TOKEN` environment variable. For details, see [Environment variables](../guides/environment-variables), [Request storage](../guides/request-storage) and [Result storage](../guides/result-storage).
+By default, Crawlee stores data to `./crawlee_storage` in the current working directory. You can override this behavior by setting either the
+`APIFY_LOCAL_STORAGE_DIR` or `APIFY_TOKEN` environment variable. For details, see [Environment variables](../guides/environment-variables),
+[Request storage](../guides/request-storage) and [Result storage](../guides/result-storage).
 
 ## Local usage with Apify command-line interface (CLI)
 
@@ -95,8 +92,8 @@ cd my-hello-world
 apify run
 ```
 
-By default, the crawling data will be stored in a local directory at `./apify_storage`. For example, the input JSON file for the actor is expected to
-be in the default key-value store in `./apify_storage/key_value_stores/default/INPUT.json`.
+By default, the crawling data will be stored in a local directory at `./crawlee_storage`. For example, the input JSON file for the actor is expected to
+be in the default key-value store in `./crawlee_storage/key_value_stores/default/INPUT.json`.
 
 Now you can easily deploy your code to the Apify platform by running:
 
@@ -114,7 +111,7 @@ Your script will be uploaded to the Apify platform and built there so that it ca
 ## Usage on the Apify platform
 
 You can also develop your web scraping project in an online code editor directly on the [Apify platform](../guides/apify-platform).
-You'll need to have an Apify Account. Go to the [Actors](https://console.apify.com/actors) page in the app, click <i>Create new</i>
-and then go to the <i>Source</i> tab and start writing your code or paste one of the examples from the Examples section.
+You'll need to have an Apify Account. Go to the [Actors](https://console.apify.com/actors) page in the app, click *Create new*
+and then go to the *Source* tab and start writing your code or paste one of the examples from the Examples section.
 
 For more information, view the [Apify actors quick start guide](https://docs.apify.com/actor/quick-start).

--- a/docs/guides/quick_start.mdx
+++ b/docs/guides/quick_start.mdx
@@ -64,8 +64,7 @@ When you run the example, you should see Crawlee automating a Chrome browser.
 ![Chrome Scrape](/img/chrome_scrape.gif)
 
 By default, Crawlee stores data to `./crawlee_storage` in the current working directory. You can override this behavior by setting either the
-`APIFY_LOCAL_STORAGE_DIR` or `APIFY_TOKEN` environment variable. For details, see [Environment variables](../guides/environment-variables),
-[Request storage](../guides/request-storage) and [Result storage](../guides/result-storage).
+`APIFY_LOCAL_STORAGE_DIR` or `APIFY_TOKEN` environment variable. For details, see [Environment variables](../guides/environment-variables), [Request storage](../guides/request-storage) and [Result storage](../guides/result-storage).
 
 ## Local usage with Apify command-line interface (CLI)
 

--- a/website/src/components/Highlights.jsx
+++ b/website/src/components/Highlights.jsx
@@ -8,7 +8,9 @@ const FeatureList = [
         Svg: require('../../static/img/js_file.svg').default,
         description: (
             <>
-                JavaScript is the language of the web. Apify SDK builds on popular tools like <a href="https://www.npmjs.com/package/playwright">Playwright</a>, <a href="https://www.npmjs.com/package/puppeteer">Puppeteer</a> and <a href={'https://www.npmjs.com/package/cheerio'}>cheerio</a>, to deliver large-scale high-performance web scraping and crawling of any website.
+                JavaScript is the language of the web. Crawlee builds on popular tools like <a href="https://www.npmjs.com/package/playwright">Playwright</a>, {' '}
+                <a href="https://www.npmjs.com/package/puppeteer">Puppeteer</a> and <a href='https://www.npmjs.com/package/cheerio'>cheerio</a>,
+                to deliver large-scale high-performance web scraping and crawling of any website.
             </>
         ),
     },
@@ -17,7 +19,8 @@ const FeatureList = [
         Svg: require('../../static/img/workflow.svg').default,
         description: (
             <>
-                Run headless Chrome, Firefox, WebKit or other browsers, manage lists and queues of URLs to crawl, run crawlers in parallel at maximum system capacity. Handle storage and export of results and rotate proxies.
+                Run headless Chrome, Firefox, WebKit or other browsers, manage lists and queues of URLs to crawl, run crawlers in parallel at maximum
+                system capacity. Handle storage and export of results and rotate proxies.
             </>
         ),
     },
@@ -26,7 +29,8 @@ const FeatureList = [
         Svg: require('../../static/img/system.svg').default,
         description: (
             <>
-                Apify SDK can be used stand-alone on your own systems or it can run as a serverless microservice on the <a href="https://console.apify.com/actors">Apify Platform</a>.
+                Crawlee can be used stand-alone on your own systems or it can run as a serverless microservice on the {' '}
+                <a href="https://console.apify.com/actors">Apify Platform</a>.
             </>
         ),
     },

--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -12,6 +12,8 @@ html[data-theme='dark'] {
     --ifm-footer-background-color: #242736;
     --ifm-color-primary: #5d9df1;
     --ifm-link-color: #5d9df1;
+
+    --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.1);
 }
 
 :root {
@@ -45,6 +47,8 @@ html[data-theme='dark'] {
     --ifm-footer-title-color: #f2f3fb;
     --ifm-footer-link-color: #f2f3fb;
     --max-layout-width: 1680px;
+
+    --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 .footer__title {
@@ -138,17 +142,6 @@ aside svg[class*=iconExternalLink] {
 
 header.hero div[class^=heroButtons] {
     justify-content: inherit;
-}
-
-.docusaurus-highlight-code-line {
-	background-color: rgba(0, 0, 0, 0.1);
-	display: block;
-	margin: 0 calc(-1 * var(--ifm-pre-padding));
-	padding: 0 var(--ifm-pre-padding);
-}
-
-html[data-theme='dark'] .docusaurus-highlight-code-line {
-	background-color: rgba(0, 0, 0, 0.3);
 }
 
 article .card h2 {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -45,14 +45,22 @@ function Features() {
                 </div>
                 <div className="col col--4">
                     <h2>Easy crawling</h2>
-                    <p>There are three main classes that you can use to start crawling the web in no time. Need to crawl plain HTML? Use the blazing fast CheerioCrawler. For complex websites that use React, Vue or other front-end javascript libraries and require JavaScript execution, spawn a headless browser with PlaywrightCrawler or PuppeteerCrawler.</p>
+                    <p>
+                        There are three main classes that you can use to start crawling the web in no time. Need to crawl plain HTML?
+                        Use the blazing fast CheerioCrawler. For complex websites that use React, Vue or other front-end javascript libraries and require
+                        JavaScript execution, spawn a headless browser with PlaywrightCrawler or PuppeteerCrawler.
+                    </p>
                 </div>
                 <div className="col col--2"></div>
             </div>
             <div className="row">
                 <div className="col col--4">
                     <h2>Powerful tools</h2>
-                    <p>All the crawlers are automatically scaled based on available system resources using the AutoscaledPool class. When you run your code on the Apify Platform, you can also take advantage of a pool of proxies to avoid detection. For data storage, you can use the Dataset, KeyValueStore and RequestQueue classes.</p>
+                    <p>
+                        All the crawlers are automatically scaled based on available system resources using the AutoscaledPool class.
+                        When you run your code on the Apify Platform, you can also take advantage of a pool of proxies to avoid detection.
+                        For data storage, you can use the Dataset, KeyValueStore and RequestQueue classes.
+                    </p>
                 </div>
                 <div className="col col--2"></div>
                 <div className="col col--6">
@@ -68,7 +76,7 @@ const example = `import { PuppeteerCrawler } from '@crawlee/puppeteer';
 const crawler = new PuppeteerCrawler({
     async requestHandler({ request, page, enqueueLinks }) {
         const title = await page.title();
-        ${'console.log(`Title of ${request.url}`: ${title});'}
+        console.log(\`Title of $\{request.url}: $\{title}\`);
         await enqueueLinks();
     },
 });
@@ -81,7 +89,7 @@ function ActorExample() {
     return (
         <section id="try" className="container">
             <h2>Try it out</h2>
-            <p>Install Apify SDK into a Node.js project. You must have Node.js 16 or higher installed.</p>
+            <p>Install the Crawlee SDK into a Node.js project. You must have Node.js 16 or higher installed.</p>
             <CodeBlock className="language-bash">
                 npm install @crawlee/puppeteer puppeteer
             </CodeBlock>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -89,7 +89,7 @@ function ActorExample() {
     return (
         <section id="try" className="container">
             <h2>Try it out</h2>
-            <p>Install the Crawlee SDK into a Node.js project. You must have Node.js 16 or higher installed.</p>
+            <p>Install Crawlee into a Node.js project. You must have Node.js 16 or higher installed.</p>
             <CodeBlock className="language-bash">
                 npm install @crawlee/puppeteer puppeteer
             </CodeBlock>


### PR DESCRIPTION
This is part one which mostly focuses on enqueueLink as well as cleaning up examples/guides

A future PR will come for Request.skipNavigation