### PR TITLE
test: add platform links to e2e tests

### DIFF
--- a/test/e2e/run.mjs
+++ b/test/e2e/run.mjs
@@ -71,7 +71,7 @@ async function run() {
             if (process.env.STORAGE_IMPLEMENTATION === 'PLATFORM' && (str.startsWith('[build]') || str.startsWith('[run]'))) {
                 const platformStatsMessage = str.match(/\[(?:run|build)] (.*)/);
                 if (platformStatsMessage) {
-                    console.log(`${colors.yellow(`[${dir.name}]`)} ${colors.grey(platformStatsMessage[1])}`);
+                    console.log(`${colors.yellow(`[${dir.name}]`)}\x20${colors.grey(platformStatsMessage[1])}`);
                 }
             }
 
@@ -79,7 +79,7 @@ async function run() {
 
             if (match) {
                 const c = match[1] === 'passed' ? colors.green : colors.red;
-                console.log(`${colors.yellow(`[${dir.name}]`)} ${match[2]}: ${c(match[1])}`);
+                console.log(`${colors.yellow(`[${dir.name}]`)}\x20${match[2]}:\x20${c(match[1])}`);
             }
         });
         worker.on('exit', async (code) => {
@@ -91,7 +91,7 @@ async function run() {
             const took = (Date.now() - now) / 1000;
             const status = code === 0 ? 'success' : 'failure';
             const color = code === 0 ? 'green' : 'red';
-            console.log(`${colors.yellow(`[${dir.name}]`)} ${colors[color](`Test finished with status: ${status}`)} ${colors.grey(`[took ${took}s]`)}`);
+            console.log(`${colors.yellow(`[${dir.name}]`)}\x20${colors[color](`Test finished with status: ${status}`)}\x20${colors.grey(`[took ${took}s]`)}`);
 
             if (['MEMORY', 'LOCAL'].includes(process.env.STORAGE_IMPLEMENTATION)) {
                 await clearStorage(`${basePath}/${dir.name}`);

--- a/test/e2e/run.mjs
+++ b/test/e2e/run.mjs
@@ -71,7 +71,7 @@ async function run() {
             if (process.env.STORAGE_IMPLEMENTATION === 'PLATFORM' && (str.startsWith('[build]') || str.startsWith('[run]'))) {
                 const platformStatsMessage = str.match(/\[(?:run|build)] (.*)/);
                 if (platformStatsMessage) {
-                    console.log(`${colors.yellow(`[${dir.name}]`)}\x20${colors.grey(platformStatsMessage[1])}`);
+                    console.log(`${colors.yellow(`[${dir.name}] `)}${colors.grey(platformStatsMessage[1])}`);
                 }
             }
 
@@ -79,7 +79,7 @@ async function run() {
 
             if (match) {
                 const c = match[1] === 'passed' ? colors.green : colors.red;
-                console.log(`${colors.yellow(`[${dir.name}]`)}\x20${match[2]}:\x20${c(match[1])}`);
+                console.log(`${colors.yellow(`[${dir.name}] `)}${match[2]}: ${c(match[1])}`);
             }
         });
         worker.on('exit', async (code) => {
@@ -91,7 +91,7 @@ async function run() {
             const took = (Date.now() - now) / 1000;
             const status = code === 0 ? 'success' : 'failure';
             const color = code === 0 ? 'green' : 'red';
-            console.log(`${colors.yellow(`[${dir.name}]`)}\x20${colors[color](`Test finished with status: ${status}`)}\x20${colors.grey(`[took ${took}s]`)}`);
+            console.log(`${colors.yellow(`[${dir.name}] `)}${colors[color](`Test finished with status: ${status} `)}${colors.grey(`[took ${took}s]`)}`);
 
             if (['MEMORY', 'LOCAL'].includes(process.env.STORAGE_IMPLEMENTATION)) {
                 await clearStorage(`${basePath}/${dir.name}`);

--- a/test/e2e/run.mjs
+++ b/test/e2e/run.mjs
@@ -68,6 +68,13 @@ async function run() {
                 return;
             }
 
+            if (process.env.STORAGE_IMPLEMENTATION === 'PLATFORM' && (str.startsWith('[build]') || str.startsWith('[run]'))) {
+                const platformStatsMessage = str.match(/\[(?:run|build)] (.*)/);
+                if (platformStatsMessage) {
+                    console.log(`${colors.yellow(`[${dir.name}]`)} ${colors.grey(platformStatsMessage[1])}`);
+                }
+            }
+
             const match = str.match(/\[assertion] (passed|failed): (.*)/);
 
             if (match) {

--- a/test/e2e/tools.mjs
+++ b/test/e2e/tools.mjs
@@ -79,7 +79,23 @@ export async function runActor(dirName, memory = 4096) {
         const { items: actors } = await client.actors().list();
         const { id } = actors.find((actor) => actor.name === actorName);
 
-        const { defaultKeyValueStoreId, defaultDatasetId } = await client.actor(id).call(null, { memory });
+        const {
+            defaultKeyValueStoreId,
+            defaultDatasetId,
+            startedAt: runStartedAt,
+            finishedAt: runFinishedAt,
+            id: runId,
+            buildId,
+        } = await client.actor(id).call(null, { memory });
+        const {
+            startedAt: buildStartedAt,
+            finishedAt: buildFinishedAt,
+        } = await client.build(buildId).get();
+        const buildTook = (buildFinishedAt.getTime() - buildStartedAt.getTime()) / 1000;
+        console.log(`[build] View build log: https://api.apify.com/v2/logs/${buildId} [build took ${buildTook}s]`);
+        const runTook = (runFinishedAt.getTime() - runStartedAt.getTime()) / 1000;
+        console.log(`[run] View run: https://console.apify.com/view/runs/${runId} [run took ${runTook}s]`);
+
         const { value } = await client.keyValueStore(defaultKeyValueStoreId).getRecord('SDK_CRAWLER_STATISTICS_0');
         stats = value;
         const { items } = await client.dataset(defaultDatasetId).listItems();


### PR DESCRIPTION
PLATFORM e2e tests take significantly more time than local/memory storage ones mainly due to actor build, now we'll have a link to build log with build time + view run link with actual run time (without build time).

CI run [here](https://github.com/apify/apify-ts/runs/6758395569?check_suite_focus=true).

I was also annoyed by missing spaces in logs - it somehow ignores the space after the `colors[color]` is used it seems, so moved the space inside `colors[color]` calls - kinda shitty solution, but at least I am not triggered every time now =D 