### PR TITLE
feat: add `Router`

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -20,6 +20,7 @@ import {
     type CrawlingContext,
     RequestOptions,
     RequestQueueOperationOptions,
+    Router,
     createRequests,
     Configuration,
     EventManager,
@@ -1052,4 +1053,32 @@ interface HandlePropertyNameChangeData<New, Old> {
     newName: string;
     propertyKey: string;
     allowUndefined?: boolean;
+}
+
+/**
+ * Creates new {@link Router} instance that works based on request labels.
+ * This instance can then serve as a `requestHandler` of your {@link BasicCrawler}.
+ * Defaults to the {@link BasicCrawlingContext}.
+ *
+ * > Serves as a shortcut for using `Router.create<BasicCrawlingContext>()`.
+ *
+ * ```ts
+ * import { BasicCrawler, createBasicRouter } from '@crawlee/basic';
+ *
+ * const router = createBasicRouter();
+ * router.addHandler('label-a', async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ * router.addDefaultHandler(async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ *
+ * const crawler = new BasicCrawler({
+ *     requestHandler: router,
+ * });
+ * await crawler.run();
+ * ```
+ */
+export function createBasicRouter<Context extends BasicCrawlingContext = BasicCrawlingContext>() {
+    return Router.create<Context>();
 }

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -385,7 +385,12 @@ export abstract class BrowserCrawler<
             propertyKey: 'userProvidedRequestHandler',
             newProperty: userProvidedRequestHandler,
             oldProperty: handlePageFunction,
+            allowUndefined: true, // fallback to the default router
         });
+
+        if (!this.userProvidedRequestHandler) {
+            this.userProvidedRequestHandler = this.router;
+        }
 
         this._handlePropertyNameChange({
             newName: 'failedRequestHandler',

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -16,6 +16,7 @@ import {
     ProxyInfo,
     Request,
     RequestQueue,
+    Router,
     resolveBaseUrl,
     Session,
     validators,
@@ -1044,4 +1045,32 @@ function addResponsePropertiesToStream(stream: GotRequest) {
     }
 
     return stream as unknown as IncomingMessage;
+}
+
+/**
+ * Creates new {@link Router} instance that works based on request labels.
+ * This instance can then serve as a `requestHandler` of your {@link CheerioCrawler}.
+ * Defaults to the {@link CheerioCrawlingContext}.
+ *
+ * > Serves as a shortcut for using `Router.create<CheerioCrawlingContext>()`.
+ *
+ * ```ts
+ * import { CheerioCrawler, createCheerioRouter } from '@crawlee/cheerio';
+ *
+ * const router = createCheerioRouter();
+ * router.addHandler('label-a', async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ * router.addDefaultHandler(async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ *
+ * const crawler = new CheerioCrawler({
+ *     requestHandler: router,
+ * });
+ * await crawler.run();
+ * ```
+ */
+export function createCheerioRouter<Context extends CheerioCrawlingContext = CheerioCrawlingContext>() {
+    return Router.create<Context>();
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from './events';
 export * from './log';
 export * from './proxy_configuration';
 export * from './request';
+export * from './router';
 export * from './serialization';
 export * from './session_pool';
 export * from './storages';

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,0 +1,127 @@
+import { CrawlingContext } from './crawlers/crawler_commons';
+import { Awaitable } from './typedefs';
+
+const defaultRoute = Symbol('default-route');
+
+type RouterHandler<Context extends CrawlingContext = CrawlingContext> = ((context: Context) => Awaitable<void>) & Router<Context>;
+
+/**
+ * Simple router that works based on request labels. This instance can then serve as a `requestHandler` of your crawler.
+ *
+ * ```ts
+ * import { Router, CheerioCrawler, CheerioCrawlingContext } from '@crawlee/cheerio';
+ *
+ * const router = Router.create<CheerioCrawlingContext>();
+ *
+ * // we can also use factory methods for specific crawling contexts, the above equals to:
+ * // import { createCheerioRouter } from '@crawlee/cheerio';
+ * // const router = createCheerioRouter();
+ *
+ * router.addHandler('label-a', async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ * router.addDefaultHandler(async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ *
+ * const crawler = new CheerioCrawler({
+ *     requestHandler: router,
+ * });
+ * await crawler.run();
+ * ```
+ */
+export class Router<Context extends CrawlingContext> {
+    private readonly routes: Map<string | symbol, (ctx: Context) => Awaitable<void>> = new Map();
+
+    /**
+     * use Router.create() instead!
+     * @ignore
+     */
+    protected constructor() {}
+
+    /**
+     * Registers new route handler for given label.
+     */
+    addHandler(label: string | symbol, handler: (ctx: Context) => Awaitable<void>) {
+        this.validate(label);
+        this.routes.set(label, handler);
+    }
+
+    /**
+     * Registers default route handler.
+     */
+    addDefaultHandler(handler: (ctx: Context) => Awaitable<void>) {
+        this.validate(defaultRoute);
+        this.routes.set(defaultRoute, handler);
+    }
+
+    /**
+     * Returns route handler for given label. If no label is provided, the default request handler will be returned.
+     */
+    getHandler(label?: string | symbol): (ctx: Context) => Awaitable<void> {
+        if (label && this.routes.has(label)) {
+            return this.routes.get(label)!;
+        }
+
+        if (this.routes.has(defaultRoute)) {
+            return this.routes.get(defaultRoute)!;
+        }
+
+        if (!label) {
+            throw new Error(`No default route set up!`);
+        }
+
+        throw new Error(`Route not found for label '${String(label)}' and no default route set up!`);
+    }
+
+    /**
+     * Throws when the label already exists in our registry.
+     */
+    private validate(label: string | symbol) {
+        if (this.routes.has(label)) {
+            const message = label === defaultRoute
+                ? `Default route is already defined!`
+                : `Route for label '${String(label)}' is already defined!`;
+            throw new Error(message);
+        }
+    }
+
+    /**
+     * Creates new router instance. This instance can then serve as a `requestHandler` of your crawler.
+     *
+     * ```ts
+     * import { Router, CheerioCrawler, CheerioCrawlingContext } from '@crawlee/cheerio';
+     *
+     * const router = Router.create<CheerioCrawlingContext>();
+     * router.addHandler('label-a', async (ctx) => {
+     *    ctx.log.info('...');
+     * });
+     * router.addDefaultHandler(async (ctx) => {
+     *    ctx.log.info('...');
+     * });
+     *
+     * const crawler = new CheerioCrawler({
+     *     requestHandler: router,
+     * });
+     * await crawler.run();
+     * ```
+     */
+    static create<Context extends CrawlingContext = CrawlingContext>(): RouterHandler<Context> {
+        const router = new Router<Context>();
+        const obj = Object.create(Function.prototype);
+
+        obj.addHandler = router.addHandler.bind(router);
+        obj.addDefaultHandler = router.addDefaultHandler.bind(router);
+        obj.getHandler = router.getHandler.bind(router);
+
+        const func = function (context: Context) {
+            const { url, label } = context.request;
+            context.log.info('Page opened.', { label, url });
+            return router.getHandler(label)(context);
+        };
+
+        Object.setPrototypeOf(func, obj);
+
+        return func as unknown as RouterHandler<Context>;
+    }
+}

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -3,7 +3,9 @@ import { Awaitable } from './typedefs';
 
 const defaultRoute = Symbol('default-route');
 
-type RouterHandler<Context extends CrawlingContext = CrawlingContext> = ((context: Context) => Awaitable<void>) & Router<Context>;
+export interface RouterHandler<Context extends CrawlingContext = CrawlingContext> extends Router<Context> {
+    (ctx: Context): Awaitable<void>;
+}
 
 /**
  * Simple router that works based on request labels. This instance can then serve as a `requestHandler` of your crawler.
@@ -27,6 +29,23 @@ type RouterHandler<Context extends CrawlingContext = CrawlingContext> = ((contex
  * const crawler = new CheerioCrawler({
  *     requestHandler: router,
  * });
+ * await crawler.run();
+ * ```
+ *
+ * Alternatively we can use the default router instance from crawler object:
+ *
+ * ```ts
+ * import { CheerioCrawler } from '@crawlee/cheerio';
+ *
+ * const crawler = new CheerioCrawler();
+ *
+ * crawler.router.addHandler('label-a', async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ * crawler.router.addDefaultHandler(async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ *
  * await crawler.run();
  * ```
  */

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -7,6 +7,7 @@ import {
     BrowserCrawlingContext,
     BrowserCrawlerHandleRequest,
     BrowserHook,
+    Router,
 } from '@crawlee/browser';
 import { Dictionary } from '@crawlee/types';
 import { Cookie } from 'tough-cookie';
@@ -261,4 +262,32 @@ export class PlaywrightCrawler extends BrowserCrawler<{ browserPlugins: [Playwri
             ].filter((c): c is PlaywrightCookie => c !== undefined),
         );
     }
+}
+
+/**
+ * Creates new {@link Router} instance that works based on request labels.
+ * This instance can then serve as a `requestHandler` of your {@link PlaywrightCrawler}.
+ * Defaults to the {@link PlaywrightCrawlingContext}.
+ *
+ * > Serves as a shortcut for using `Router.create<PlaywrightCrawlingContext>()`.
+ *
+ * ```ts
+ * import { PlaywrightCrawler, createPlaywrightRouter } from '@crawlee/playwright';
+ *
+ * const router = createPlaywrightRouter();
+ * router.addHandler('label-a', async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ * router.addDefaultHandler(async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ *
+ * const crawler = new PlaywrightCrawler({
+ *     requestHandler: router,
+ * });
+ * await crawler.run();
+ * ```
+ */
+export function createPlaywrightRouter<Context extends PlaywrightCrawlingContext = PlaywrightCrawlingContext>() {
+    return Router.create<Context>();
 }

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -4,6 +4,7 @@ import {
     BrowserCrawlerOptions,
     BrowserCrawlingContext,
     BrowserHook,
+    Router,
 } from '@crawlee/browser';
 import { BrowserPoolOptions, PuppeteerPlugin } from '@crawlee/browser-pool';
 import { Dictionary } from '@crawlee/types';
@@ -165,4 +166,32 @@ export class PuppeteerCrawler extends BrowserCrawler<{ browserPlugins: [Puppetee
     protected override async _navigationHandler(crawlingContext: PuppeteerCrawlingContext, gotoOptions: DirectNavigationOptions) {
         return gotoExtended(crawlingContext.page, crawlingContext.request, gotoOptions);
     }
+}
+
+/**
+ * Creates new {@link Router} instance that works based on request labels.
+ * This instance can then serve as a `requestHandler` of your {@link PuppeteerCrawler}.
+ * Defaults to the {@link PuppeteerCrawlingContext}.
+ *
+ * > Serves as a shortcut for using `Router.create<PuppeteerCrawlingContext>()`.
+ *
+ * ```ts
+ * import { PuppeteerCrawler, createPuppeteerRouter } from '@crawlee/puppeteer';
+ *
+ * const router = createPuppeteerRouter();
+ * router.addHandler('label-a', async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ * router.addDefaultHandler(async (ctx) => {
+ *    ctx.log.info('...');
+ * });
+ *
+ * const crawler = new PuppeteerCrawler({
+ *     requestHandler: router,
+ * });
+ * await crawler.run();
+ * ```
+ */
+export function createPuppeteerRouter<Context extends PuppeteerCrawlingContext = PuppeteerCrawlingContext>() {
+    return Router.create<Context>();
 }

--- a/test/core/router.test.ts
+++ b/test/core/router.test.ts
@@ -1,0 +1,68 @@
+import { Router } from '@crawlee/core';
+import { BasicCrawler } from '@crawlee/basic';
+
+describe('Router', () => {
+    test('should be callable and route based on the label', async () => {
+        const router = Router.create();
+
+        const logs: string[] = [];
+        router.addHandler('A', async (ctx) => {
+            logs.push(`label A handled with url ${ctx.request.loadedUrl}`);
+        });
+        router.addHandler('B', async (ctx) => {
+            logs.push(`label B handled with url ${ctx.request.loadedUrl}`);
+        });
+        router.addHandler('C', async (ctx) => {
+            logs.push(`label C handled with url ${ctx.request.loadedUrl}`);
+        });
+        router.addDefaultHandler(async (ctx) => {
+            logs.push(`default handled with url ${ctx.request.loadedUrl}`);
+        });
+
+        const log = { info: jest.fn(), warn: jest.fn() };
+        await router({ request: { loadedUrl: 'https://example.com/A', label: 'A' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/A', label: 'A' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/C', label: 'C' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/A', label: 'A' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/B', label: 'B' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/B', label: 'B' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/A', label: 'A' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/C', label: 'C' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/C', label: 'C' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/D', label: 'D' }, log } as any);
+        await router({ request: { loadedUrl: 'https://example.com/C', label: 'C' }, log } as any);
+
+        expect(logs).toEqual([
+            'label A handled with url https://example.com/A',
+            'label A handled with url https://example.com/A',
+            'label C handled with url https://example.com/C',
+            'label A handled with url https://example.com/A',
+            'label B handled with url https://example.com/B',
+            'label B handled with url https://example.com/B',
+            'default handled with url https://example.com/',
+            'label A handled with url https://example.com/A',
+            'label C handled with url https://example.com/C',
+            'label C handled with url https://example.com/C',
+            'default handled with url https://example.com/D',
+            'label C handled with url https://example.com/C',
+        ]);
+    });
+
+    test('validation', async () => {
+        const router = Router.create();
+        router.addHandler('A', async (ctx) => {});
+        expect(() => router.addHandler('A', async (ctx) => {})).toThrow();
+        const log = { info: jest.fn(), warn: jest.fn() };
+        expect(() => router({ request: { loadedUrl: 'https://example.com/C', label: 'C' }, log } as any)).toThrow();
+        router.addDefaultHandler(async (ctx) => {});
+        expect(() => router.addDefaultHandler(async (ctx) => {})).toThrow();
+    });
+
+    test('assignability to requestHandler', async () => {
+        const router = Router.create();
+        const crawler = new BasicCrawler({
+            requestHandler: router,
+        });
+    });
+});

--- a/test/e2e/cheerio-page-info/actor/main.js
+++ b/test/e2e/cheerio-page-info/actor/main.js
@@ -1,5 +1,5 @@
 import { Actor } from 'apify';
-import { CheerioCrawler } from '@crawlee/cheerio';
+import { CheerioCrawler, createCheerioRouter } from '@crawlee/cheerio';
 import { ApifyStorageLocal } from '@apify/storage-local';
 
 const mainOptions = {
@@ -7,36 +7,39 @@ const mainOptions = {
     storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
 };
 
+const router = createCheerioRouter();
+
+router.addHandler('START', async ({ enqueueLinks }) => {
+    await enqueueLinks({
+        globs: [{
+            glob: 'https://apify.com/apify/web-scraper',
+            userData: { label: 'DETAIL' },
+        }],
+    });
+});
+
+router.addHandler('DETAIL', async ({ request, $ }) => {
+    const { url } = request;
+
+    const uniqueIdentifier = url.split('/').slice(-2).join('/');
+    const title = $('header h1').text();
+    const description = $('header span.actor-description').text();
+    const modifiedDate = $('ul.ActorHeader-stats time').attr('datetime');
+    const runCount = $('ul.ActorHeader-stats > li:nth-of-type(3)').text().match(/[\d,]+/)[0].replace(/,/g, '');
+
+    await Actor.pushData({
+        url,
+        uniqueIdentifier,
+        title,
+        description,
+        modifiedDate: new Date(Number(modifiedDate)),
+        runCount: Number(runCount),
+    });
+});
+
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        async requestHandler({ request, $, enqueueLinks }) {
-            const { userData: { label } } = request;
-
-            if (label === 'START') {
-                await enqueueLinks({
-                    globs: [{ glob: 'https://apify.com/apify/web-scraper', userData: { label: 'DETAIL' } }],
-                });
-            }
-
-            if (label === 'DETAIL') {
-                const { url } = request;
-
-                const uniqueIdentifier = url.split('/').slice(-2).join('/');
-                const title = $('header h1').text();
-                const description = $('header span.actor-description').text();
-                const modifiedDate = $('ul.ActorHeader-stats time').attr('datetime');
-                const runCount = $('ul.ActorHeader-stats > li:nth-of-type(3)').text().match(/[\d,]+/)[0].replace(/,/g, '');
-
-                await Actor.pushData({
-                    url,
-                    uniqueIdentifier,
-                    title,
-                    description,
-                    modifiedDate: new Date(Number(modifiedDate)),
-                    runCount: Number(runCount),
-                });
-            }
-        },
+        requestHandler: router,
     });
 
     await crawler.addRequests([{ url: 'https://apify.com/apify', userData: { label: 'START' } }]);

--- a/test/e2e/puppeteer-store-pagination/actor/main.js
+++ b/test/e2e/puppeteer-store-pagination/actor/main.js
@@ -1,11 +1,56 @@
 import { Actor } from 'apify';
-import { PuppeteerCrawler } from '@crawlee/puppeteer';
+import { createPuppeteerRouter, PuppeteerCrawler } from '@crawlee/puppeteer';
 import { ApifyStorageLocal } from '@apify/storage-local';
 
 const mainOptions = {
     exit: Actor.isAtHome(),
     storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
 };
+
+const router = createPuppeteerRouter();
+
+router.addHandler('START', async ({ log, enqueueLinks, page }) => {
+    log.info('Store opened');
+    const nextButtonSelector = '[data-test="pagination-button-next"]:not([disabled])';
+    // enqueue actor details from the first three pages of the store
+    for (let pageNo = 1; pageNo <= 3; pageNo++) {
+        // Wait for network events to finish
+        await page.waitForNetworkIdle();
+        // Enqueue all loaded links
+        await enqueueLinks({
+            selector: 'a.ActorStoreItem',
+            globs: [{ glob: 'https://apify.com/*/*', userData: { label: 'DETAIL' } }],
+        });
+        log.info(`Enqueued actors for page ${pageNo}`);
+        log.info('Loading the next page');
+        await page.evaluate((el) => document.querySelector(el)?.click(), nextButtonSelector);
+    }
+});
+
+router.addHandler('DETAIL', async ({ log, page, request: { url } }) => {
+    log.info(`Scraping ${url}`);
+
+    const uniqueIdentifier = url.split('/').slice(-2).join('/');
+    const titleP = page.$eval('header h1', ((el) => el.textContent));
+    const descriptionP = page.$eval('header span.actor-description', ((el) => el.textContent));
+    const modifiedTimestampP = page.$eval('ul.ActorHeader-stats time', (el) => el.getAttribute('datetime'));
+    const runCountTextP = page.$eval('ul.ActorHeader-stats li:nth-of-type(3)', ((el) => el.textContent));
+    const [
+        title,
+        description,
+        modifiedTimestamp,
+        runCountText,
+    ] = await Promise.all([
+        titleP,
+        descriptionP,
+        modifiedTimestampP,
+        runCountTextP,
+    ]);
+    const modifiedDate = new Date(Number(modifiedTimestamp));
+    const runCount = Number(runCountText.match(/[\d,]+/)[0].replace(/,/g, ''));
+
+    await Actor.pushData({ url, uniqueIdentifier, title, description, modifiedDate, runCount });
+});
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
@@ -14,50 +59,7 @@ await Actor.main(async () => {
             session?.setPuppeteerCookies([{ name: 'OptanonAlertBoxClosed', value: new Date().toISOString() }], request.url);
             goToOptions.waitUntil = ['networkidle2'];
         }],
-        async requestHandler({ page, enqueueLinks, request, log }) {
-            const { url, userData: { label } } = request;
-
-            if (label === 'START') {
-                log.info('Store opened');
-                const nextButtonSelector = '[data-test="pagination-button-next"]:not([disabled])';
-                // enqueue actor details from the first three pages of the store
-                for (let pageNo = 1; pageNo <= 3; pageNo++) {
-                    // Wait for network events to finish
-                    await page.waitForNetworkIdle();
-                    // Enqueue all loaded links
-                    await enqueueLinks({
-                        selector: 'a.ActorStoreItem',
-                        globs: [{ glob: 'https://apify.com/*/*', userData: { label: 'DETAIL' } }],
-                    });
-                    log.info(`Enqueued actors for page ${pageNo}`);
-                    log.info('Loading the next page');
-                    await page.evaluate((el) => document.querySelector(el)?.click(), nextButtonSelector);
-                }
-            } else if (label === 'DETAIL') {
-                log.info(`Scraping ${url}`);
-
-                const uniqueIdentifier = url.split('/').slice(-2).join('/');
-                const titleP = page.$eval('header h1', ((el) => el.textContent));
-                const descriptionP = page.$eval('header span.actor-description', ((el) => el.textContent));
-                const modifiedTimestampP = page.$eval('ul.ActorHeader-stats time', (el) => el.getAttribute('datetime'));
-                const runCountTextP = page.$eval('ul.ActorHeader-stats li:nth-of-type(3)', ((el) => el.textContent));
-                const [
-                    title,
-                    description,
-                    modifiedTimestamp,
-                    runCountText,
-                ] = await Promise.all([
-                    titleP,
-                    descriptionP,
-                    modifiedTimestampP,
-                    runCountTextP,
-                ]);
-                const modifiedDate = new Date(Number(modifiedTimestamp));
-                const runCount = Number(runCountText.match(/[\d,]+/)[0].replace(/,/g, ''));
-
-                await Actor.pushData({ url, uniqueIdentifier, title, description, modifiedDate, runCount });
-            }
-        },
+        requestHandler: router,
     });
 
     await crawler.addRequests([{ url: 'https://apify.com/store?page=1', userData: { label: 'START' } }]);

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -73,12 +73,12 @@ function Features() {
 
 const example = `import { PuppeteerCrawler } from '@crawlee/puppeteer';
 
-const crawler = new PuppeteerCrawler({
-    async requestHandler({ request, page, enqueueLinks }) {
-        const title = await page.title();
-        console.log(\`Title of $\{request.url}: $\{title}\`);
-        await enqueueLinks();
-    },
+const crawler = new PuppeteerCrawler();
+
+crawler.router.addDefaultHandler(({ request, page, enqueueLinks }) => {
+    const title = await page.title();
+    console.log(\`Title of $\{request.url}: $\{title}\`);
+    await enqueueLinks();
 });
 
 await crawler.addRequests(['https://www.iana.org/']);


### PR DESCRIPTION
Simple router that works based on request labels. This instance can then serve as a `requestHandler` of your crawler.

```ts
import { Router, CheerioCrawler, CheerioCrawlingContext } from '@crawlee/cheerio';

const router = Router.create<CheerioCrawlingContext>();

// we can also use factory methods for specific crawling contexts, the above equals to:
// import { createCheerioRouter } from '@crawlee/cheerio';
// const router = createCheerioRouter();

router.addHandler('label-a', async (ctx) => {
   ctx.log.info('...');
});
router.addDefaultHandler(async (ctx) => {
   ctx.log.info('...');
});

const crawler = new CheerioCrawler({
    requestHandler: router,
});
await crawler.run();
```

Alternatively we can use the default router instance from crawler object:

```ts
import { CheerioCrawler } from '@crawlee/cheerio';

const crawler = new CheerioCrawler();

crawler.router.addHandler('label-a', async (ctx) => {
   ctx.log.info('...');
});
crawler.router.addDefaultHandler(async (ctx) => {
   ctx.log.info('...');
});

await crawler.run();
```