### PR TITLE
feat: session-based fingerprints

### DIFF
--- a/packages/browser-pool/README.md
+++ b/packages/browser-pool/README.md
@@ -484,8 +484,8 @@ const browserPool = new BrowserPool({
 | [options.useFingerprints] | <code>boolean</code> | <code>false</code> | If true the Browser pool will automatically generate and inject fingerprints to browsers. |
 | [options.fingerprintsOptions] | <code>FingerprintOptions </code> |  | Fingerprints options that allows customizing the fingerprinting behavior. |
 | [options.fingerprintsOptions.fingerprintGeneratorOptions] |  |  | See the [Fingerprint generator]("https://github.com/apify/fingerprint-generator#headergeneratoroptions") documentation. |
-| [options.fingerprintsOptions.useFingerprintPerProxyCache] | <code>boolean</code> | <code>true</code> | Fingerprints are autimatically assigned to an IP address so 1 IP equals 1 fingerprint. You can disable this behavior by settings this property to false. |
-| [options.fingerprintsOptions.fingerprintPerProxyCacheSize] | <code>number</code> | <code>10000</code> | Maximum number of IP to fingerprint pairs. |
+| [options.fingerprintsOptions.useFingerprintPerSessionCache] | <code>boolean</code> | <code>true</code> | Fingerprints are automatically assigned to an instance of a Session. You can disable this behavior by setting this property to `false`. |
+| [options.fingerprintsOptions.fingerprintPerSessionCacheSize] | <code>number</code> | <code>10000</code> | Maximum number of cached Session - Fingerprint pairs. |
 * * *
 
 <a name="BrowserPool+newPage"></a>

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -29,11 +29,11 @@ export interface FingerprintsOptions{
     /**
      * @default true
      */
-    useFingerprintPerProxyCache?: boolean;
+    useFingerprintPerSessionCache?: boolean;
     /**
     * @default 10000
     */
-    fingerprintPerProxyCacheSize?: number;
+    fingerprintPerSessionCacheSize?: number;
 }
 
 export interface BrowserPoolOptions<Plugin extends BrowserPlugin = BrowserPlugin> {
@@ -738,12 +738,12 @@ export class BrowserPool<
     }
 
     private _initializeFingerprinting(): void {
-        const { useFingerprintPerProxyCache = true, fingerprintPerProxyCacheSize = 10_000 } = this.fingerprintsOptions;
+        const { useFingerprintPerSessionCache = true, fingerprintPerSessionCacheSize = 10_000 } = this.fingerprintsOptions;
         this.fingerprintGenerator = new FingerprintGenerator(this.fingerprintsOptions.fingerprintGeneratorOptions);
         this.fingerprintInjector = new FingerprintInjector();
 
-        if (useFingerprintPerProxyCache) {
-            this.fingerprintCache = new QuickLRU({ maxSize: fingerprintPerProxyCacheSize });
+        if (useFingerprintPerSessionCache) {
+            this.fingerprintCache = new QuickLRU({ maxSize: fingerprintPerSessionCacheSize });
         }
 
         this._addFingerprintHooks();

--- a/packages/browser-pool/src/fingerprinting/hooks.ts
+++ b/packages/browser-pool/src/fingerprinting/hooks.ts
@@ -18,18 +18,21 @@ export function createFingerprintPreLaunchHook(browserPool: BrowserPool<any, any
     } = browserPool;
 
     return (_pageId: string, launchContext: LaunchContext) => {
-        const { useIncognitoPages, proxyUrl } = launchContext;
+        const { useIncognitoPages } = launchContext;
+
         // @TODO: Fix the typings so they are easier to work with.
+        const session = launchContext.session as { id: string };
         const { launchOptions }: { launchOptions: any } = launchContext;
+
         // If no options are passed we try to pass best default options as possible to match browser and OS.
         const fingerprintGeneratorFinalOptions = fingerprintGeneratorOptions || getGeneratorDefaultOptions(launchContext);
         let fingerprint : BrowserFingerprintWithHeaders;
 
-        if (proxyUrl && fingerprintCache?.has(proxyUrl)) {
-            fingerprint = fingerprintCache.get(proxyUrl)!;
-        } else if (proxyUrl) {
+        if (session && fingerprintCache?.has(session.id)) {
+            fingerprint = fingerprintCache.get(session.id)!;
+        } else if (session) {
             fingerprint = fingerprintGenerator!.getFingerprint(fingerprintGeneratorFinalOptions);
-            fingerprintCache?.set(proxyUrl, fingerprint);
+            fingerprintCache?.set(session.id, fingerprint);
         } else {
             fingerprint = fingerprintGenerator!.getFingerprint(fingerprintGeneratorFinalOptions);
         }

--- a/test/browser-pool/browser-pool.test.ts
+++ b/test/browser-pool/browser-pool.test.ts
@@ -730,7 +730,7 @@ describe('BrowserPool', () => {
                     afterEach(async () => {
                         await browserPoolCache.destroy();
                     });
-                    test('should use fingerprint per proxy by default', async () => {
+                    test('should use fingerprint per session by default', async () => {
                         browserPoolCache = new BrowserPool({
                             ...commonOptions,
                             useFingerprints: true,
@@ -744,7 +744,7 @@ describe('BrowserPool', () => {
                             ...commonOptions,
                             useFingerprints: true,
                             fingerprintsOptions: {
-                                useFingerprintPerProxyCache: false,
+                                useFingerprintPerSessionCache: false,
                             },
                         });
 
@@ -756,7 +756,7 @@ describe('BrowserPool', () => {
                             ...commonOptions,
                             useFingerprints: true,
                             fingerprintsOptions: {
-                                fingerprintPerProxyCacheSize: 1,
+                                fingerprintPerSessionCacheSize: 1,
                             },
                         });
                         // cast to any type in order to acces the maxSize property for testing purposes.
@@ -771,7 +771,7 @@ describe('BrowserPool', () => {
                             preLaunchHooks: [
                                 (_pageId, launchContext) => {
                                     // @ts-expect-error issue caused by generics
-                                    launchContext.extend({ proxyUrl: 'http://localhost:8080' });
+                                    launchContext.extend({ session: { id: '123' } });
                                 },
                             ],
                         });


### PR DESCRIPTION
as mentioned in apify/browser-pool#64

Allows browser fingerprints to be based on Session (instead of current proxy URL).