### PR TITLE
chore: fix flaky memory storage test

### DIFF
--- a/packages/memory-storage/test/write-metadata.test.ts
+++ b/packages/memory-storage/test/write-metadata.test.ts
@@ -42,10 +42,10 @@ describe('writeMetadata option', () => {
             const keyValueStore = storage.keyValueStore(keyValueStoreInfo.id);
             await keyValueStore.setRecord({ key: 'foo', value: 'test' });
 
-            const expectedPath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}/foo.txt`);
-            await waitTillWrittenToDisk(expectedPath);
+            const expectedFilePath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}/foo.txt`);
+            await waitTillWrittenToDisk(expectedFilePath);
 
-            const directoryFiles = await readdir(expectedPath);
+            const directoryFiles = await readdir(resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}`));
 
             expect(directoryFiles).toHaveLength(1);
         });

--- a/packages/memory-storage/test/write-metadata.test.ts
+++ b/packages/memory-storage/test/write-metadata.test.ts
@@ -40,9 +40,9 @@ describe('writeMetadata option', () => {
             const keyValueStoreInfo = await storage.keyValueStores().getOrCreate();
 
             const keyValueStore = storage.keyValueStore(keyValueStoreInfo.id);
-            await keyValueStore.setRecord({ key: 'owo', value: 'test' });
+            await keyValueStore.setRecord({ key: 'foo', value: 'test' });
 
-            const expectedPath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}`);
+            const expectedPath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}/foo.txt`);
             await waitTillWrittenToDisk(expectedPath);
 
             const directoryFiles = await readdir(expectedPath);
@@ -72,12 +72,13 @@ describe('writeMetadata option', () => {
             const keyValueStoreInfo = await storage.keyValueStores().getOrCreate();
 
             const keyValueStore = storage.keyValueStore(keyValueStoreInfo.id);
-            await keyValueStore.setRecord({ key: 'owo', value: 'test' });
+            await keyValueStore.setRecord({ key: 'foo', value: 'test' });
 
-            const expectedPath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}`);
-            await waitTillWrittenToDisk(expectedPath);
+            const expectedFilePath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}/foo.txt`);
+            const expectedMetadataPath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}/foo.__metadata__.json`);
+            await Promise.all([waitTillWrittenToDisk(expectedFilePath), waitTillWrittenToDisk(expectedMetadataPath)]);
 
-            const directoryFiles = await readdir(expectedPath);
+            const directoryFiles = await readdir(resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}`));
 
             expect(directoryFiles).toHaveLength(3);
         });

--- a/packages/memory-storage/test/write-metadata.test.ts
+++ b/packages/memory-storage/test/write-metadata.test.ts
@@ -3,7 +3,7 @@ import { access, readdir, rm } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
-async function waitTillWrittenToDisk(path: string) {
+async function waitTillWrittenToDisk(path: string): Promise<void> {
     try {
         await access(path);
     } catch {


### PR DESCRIPTION
Fixes https://github.com/apify/apify-ts/pull/138#issuecomment-1156672074

Since the worker can take a while to actually write the files, a set timeout might not be sufficient (especially if overloaded). Now the test will keep trying to access the dir (since we know it should be created) before running tests on it