### PR TITLE
feat: add CRAWLEE_ env vars

### DIFF
--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -172,6 +172,9 @@ export class Actor<Data extends Dictionary = Dictionary> {
             this.config.useEventManager(this.eventManager);
             // for browser launcher, adds `--no-sandbox` to args
             process.env.CRAWLEE_DISABLE_BROWSER_SANDBOX = '1';
+            if (!process.env.CRAWLEE_DEFAULT_DATASET_ID) this.config.set('defaultDatasetId', process.env.APIFY_DEFAULT_DATASET_ID);
+            if (!process.env.CRAWLEE_DEFAULT_KEY_VALUE_STORE_ID) this.config.set('defaultKeyValueStoreId', process.env.APIFY_DEFAULT_KEY_VALUE_STORE_ID);
+            if (!process.env.CRAWLEE_DEFAULT_REQUEST_QUEUE_ID) this.config.set('defaultRequestQueueId', process.env.APIFY_DEFAULT_REQUEST_QUEUE_ID);
         } else if (options.storage) {
             this.config.useStorageClient(options.storage);
         }

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -56,10 +56,10 @@ export interface ConfigurationOptions {
  *
  * Key | Environment Variable | Default Value
  * ---|---|---
- * `defaultDatasetId` | `APIFY_DEFAULT_DATASET_ID` | `'default'`
- * `defaultKeyValueStoreId` | `APIFY_DEFAULT_KEY_VALUE_STORE_ID` | `'default'`
- * `defaultRequestQueueId` | `APIFY_DEFAULT_REQUEST_QUEUE_ID` | `'default'`
- * `persistStateIntervalMillis` | `APIFY_PERSIST_STATE_INTERVAL_MILLIS` | `60e3`
+ * `defaultDatasetId` | `CRAWLEE_DEFAULT_DATASET_ID` | `'default'`
+ * `defaultKeyValueStoreId` | `CRAWLEE_DEFAULT_KEY_VALUE_STORE_ID` | `'default'`
+ * `defaultRequestQueueId` | `CRAWLEE_DEFAULT_REQUEST_QUEUE_ID` | `'default'`
+ * `persistStateIntervalMillis` | `CRAWLEE_PERSIST_STATE_INTERVAL_MILLIS` | `60e3`
  *
  * ## Advanced Configuration Options
  *
@@ -91,13 +91,12 @@ export class Configuration {
         // TODO prefix once we have a package name
         CRAWLEE_AVAILABLE_MEMORY_RATIO: 'availableMemoryRatio',
         CRAWLEE_PURGE_ON_START: 'purgeOnStart',
+        CRAWLEE_DEFAULT_DATASET_ID: 'defaultDatasetId',
+        CRAWLEE_DEFAULT_KEY_VALUE_STORE_ID: 'defaultKeyValueStoreId',
+        CRAWLEE_DEFAULT_REQUEST_QUEUE_ID: 'defaultRequestQueueId',
+        CRAWLEE_PERSIST_STATE_INTERVAL_MILLIS: 'persistStateIntervalMillis',
 
-        APIFY_DEFAULT_DATASET_ID: 'defaultDatasetId',
-        APIFY_DEFAULT_KEY_VALUE_STORE_ID: 'defaultKeyValueStoreId',
-        APIFY_DEFAULT_REQUEST_QUEUE_ID: 'defaultRequestQueueId',
         APIFY_METAMORPH_AFTER_SLEEP_MILLIS: 'metamorphAfterSleepMillis',
-        APIFY_PERSIST_STATE_INTERVAL_MILLIS: 'persistStateIntervalMillis',
-        APIFY_TEST_PERSIST_INTERVAL_MILLIS: 'persistStateIntervalMillis', // for BC, seems to be unused
         APIFY_INPUT_KEY: 'inputKey',
         APIFY_ACTOR_ID: 'actorId',
         APIFY_ACTOR_RUN_ID: 'actorRunId',


### PR DESCRIPTION
This is very much a work in progress but wanted to check whether it's even going in the right direction.

So - the current change will make things work locally just fine - you could override the default local storages, etc, and it will also work on the platform. On the platform, you could specify both `APIFY_` and `CRAWLEE_` env vars and both will work (e.g. `APIFY_DEFAULT_DATASET_ID` and `CRAWLEE_DEFAULT_DATASET_ID`).

My main concern is putting it to `Actor.init()`, key-value store to be specific, `INPUT` to be even more specific. While it would work just fine for request queue and dataset, key-value store gets the actor input. And if we assign these vars in `Actor.init()` - actor input would be in default run key-value store, while if we would try to get the input after `Actor.init()` - it would be `null` (as default store is already re-assigned to a different value). So it feels like configuration (I guess) is a more proper place for this mapping.

At the same time - configuration is using `ENV_VARS` and `LOCAL_ENV_VARS` from apify-shared, where (for obvious reasons) all env vars are `APIFY_` prefixed.

Moreover - platform is assigning some env vars (default dataset etc), which will stay as `APIFY_` - so I'm not sure whether it's even possible e.g. to use the input from non-run-default store. On the other hand - SDK 2 works the same - INPUT is always in run default store - so maybe I am overthinking this.

In any case - would appreciate your thoughts. TIA.