### PR TITLE
feat: add error handler for requests to be retried

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -131,11 +131,11 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     handleRequestTimeoutSecs?: number;
 
     /**
-     * User-provided function to handle requests that failed less than `option.maxRequestRetries` times
-     * and would be retried by the crawler.
+     * User-provided function that allows modifying the request object before it gets retried by the crawler.
+     * It's executed before each retry for the requests that failed less than `option.maxRequestRetries` times.
      *
      * The function receives the {@link BasicCrawlingContext} as the first argument,
-     * where the {@link BasicCrawlingContext.request} corresponds to the request to be reclaimed.
+     * where the {@link BasicCrawlingContext.request} corresponds to the request to be retried.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -68,15 +68,8 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     /**
      * User-provided function that performs the logic of the crawler. It is called for each URL to crawl.
      *
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *     request: Request,
-     *     session: Session,
-     *     crawler: BasicCrawler,
-     * }
-     * ```
-     * where the {@link Request} instance represents the URL to crawl.
+     * The function receives the {@link BasicCrawlingContext} as an argument,
+     * where the {@link BasicCrawlingContext.request} represents the URL to crawl.
      *
      * The function must return a promise, which is then awaited by the crawler.
      *
@@ -94,15 +87,8 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     /**
      * User-provided function that performs the logic of the crawler. It is called for each URL to crawl.
      *
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *     request: Request,
-     *     session: Session,
-     *     crawler: BasicCrawler,
-     * }
-     * ```
-     * where the {@link Request} instance represents the URL to crawl.
+     * The function receives the {@link BasicCrawlingContext} as an argument,
+     * where the {@link BasicCrawlingContext.request} represents the URL to crawl.
      *
      * The function must return a promise, which is then awaited by the crawler.
      *
@@ -145,18 +131,11 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     handleRequestTimeoutSecs?: number;
 
     /**
-     * A function to handle requests that failed less than `option.maxRequestRetries` times
+     * User-provided function to handle requests that failed less than `option.maxRequestRetries` times
      * and would be retried by the crawler.
      *
-     * The function receives the following object as the first argument:
-     * ```
-     * {
-     *     request: Request,
-     *     session: Session,
-     *     crawler: BasicCrawler,
-     * }
-     * ```
-     * where the {@link Request} instance corresponds to the request to be reclaimed.
+     * The function receives the {@link BasicCrawlingContext} as the first argument,
+     * where the {@link BasicCrawlingContext.request} corresponds to the request to be reclaimed.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */
@@ -165,16 +144,9 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
      *
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *     request: Request,
-     *     error: Error,
-     *     session: Session,
-     *     crawler: BasicCrawler,
-     * }
-     * ```
-     * where the {@link Request} instance corresponds to the failed request, and the `Error` instance
+     * The function receives the {@link BasicCrawlingContext} as the first argument,
+     * where the {@link BasicCrawlingContext.request} corresponds to the failed request.
+     * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */
     failedRequestHandler?: FailedRequestHandler<Context>;
@@ -182,16 +154,9 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
      *
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *     request: Request,
-     *     error: Error,
-     *     session: Session,
-     *     crawler: BasicCrawler,
-     * }
-     * ```
-     * where the {@link Request} instance corresponds to the failed request, and the `Error` instance
+     * The function receives the {@link BasicCrawlingContext} as the first argument,
+     * where the {@link BasicCrawlingContext.request} corresponds to the failed request.
+     * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      *
      * @deprecated `handleFailedRequestFunction` has been renamed to `failedRequestHandler` and will be removed in a future version.

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -64,6 +64,8 @@ export type BrowserCrawlerHandleFailedRequest = (inputs: BrowserFailedRequestCon
 
 export type BrowserCrawlerHandleRequest<Context extends BrowserCrawlingContext = BrowserCrawlingContext> = (inputs: Context) => Awaitable<void>;
 
+export type BrowserCrawlerHandleError<Context extends BrowserCrawlingContext = BrowserCrawlingContext> = (inputs: Context, error: Error) => Awaitable<void>;
+
 export type BrowserCrawlerEnqueueLinksOptions = Omit<EnqueueLinksOptions, 'requestQueue' | 'urls'>
 
 export type BrowserHook<
@@ -85,8 +87,11 @@ export interface BrowserCrawlerOptions<
     // Overridden with browser context
     | 'failedRequestHandler'
     | 'handleFailedRequestFunction'
+    // Overridden with browser context
+    | 'errorHandler'
 > {
     launchContext?: BrowserLaunchContext<any, any>;
+
     /**
      * Function that is called to process each request.
      * It is passed an object with the following fields:
@@ -172,6 +177,29 @@ export interface BrowserCrawlerOptions<
     handlePageFunction?: BrowserCrawlerHandleRequest<Context>;
 
     /**
+     * A function to handle requests that failed less than `option.maxRequestRetries` times
+     * and would be retried by the crawler.
+     *
+     * The function receives the following object as the first argument:
+     * ```
+     * {
+     *     request: Request,
+     *     response: Response,
+     *     page: Page,
+     *     browserPool: BrowserPool,
+     *     autoscaledPool: AutoscaledPool,
+     *     session: Session,
+     *     browserController: BrowserController,
+     *     proxyInfo: ProxyInfo,
+     * }
+     * ```
+     * Where the {@link Request} instance corresponds to the failed request.
+     * Second argument is the `Error` instance
+     * represents the last error thrown during processing of the request.
+     */
+    errorHandler?: BrowserCrawlerHandleError<Context>;
+
+    /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
      *
      * The function receives the following object as an argument:
@@ -189,7 +217,6 @@ export interface BrowserCrawlerOptions<
      * ```
      * Where the {@link Request} instance corresponds to the failed request, and the `Error` instance
      * represents the last error thrown during processing of the request.
-     *
      */
     failedRequestHandler?: BrowserCrawlerHandleFailedRequest;
 

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -148,11 +148,11 @@ export interface BrowserCrawlerOptions<
     handlePageFunction?: BrowserCrawlerHandleRequest<Context>;
 
     /**
-     * User-provided function to handle requests that failed less than `option.maxRequestRetries` times
-     * and would be retried by the crawler.
+     * User-provided function that allows modifying the request object before it gets retried by the crawler.
+     * It's executed before each retry for the requests that failed less than `option.maxRequestRetries` times.
      *
      * The function receives the {@link BrowserCrawlingContext} as the first argument,
-     * where the {@link BrowserCrawlingContext.request} corresponds to the request to be reclaimed.
+     * where the {@link BrowserCrawlingContext.request} corresponds to the request to be retried.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -1,7 +1,6 @@
 import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
 import type {
     EnqueueLinksOptions,
-    FailedRequestContext,
     CrawlingContext,
     ProxyConfiguration,
     ProxyInfo,
@@ -58,13 +57,11 @@ export interface BrowserCrawlingContext<
     sendRequest: (overrideOptions?: Partial<GotOptionsInit>) => Promise<GotResponse<string>>;
 }
 
-export interface BrowserFailedRequestContext extends FailedRequestContext<BrowserCrawler> {}
+export type BrowserCrawlerHandleRequest<
+    Context extends BrowserCrawlingContext = BrowserCrawlingContext> = (inputs: Context) => Awaitable<void>;
 
-export type BrowserCrawlerHandleFailedRequest = (inputs: BrowserFailedRequestContext) => Awaitable<void>;
-
-export type BrowserCrawlerHandleRequest<Context extends BrowserCrawlingContext = BrowserCrawlingContext> = (inputs: Context) => Awaitable<void>;
-
-export type BrowserCrawlerHandleError<Context extends BrowserCrawlingContext = BrowserCrawlingContext> = (inputs: Context, error: Error) => Awaitable<void>;
+export type BrowserCrawlerHandleFailedRequest<
+    Context extends BrowserCrawlingContext= BrowserCrawlingContext>= (inputs: Context, error: Error) => Awaitable<void>;
 
 export type BrowserCrawlerEnqueueLinksOptions = Omit<EnqueueLinksOptions, 'requestQueue' | 'urls'>
 
@@ -84,10 +81,10 @@ export interface BrowserCrawlerOptions<
     // Overridden with browser context
     | 'requestHandler'
     | 'handleRequestFunction'
-    // Overridden with browser context
+
     | 'failedRequestHandler'
     | 'handleFailedRequestFunction'
-    // Overridden with browser context
+
     | 'errorHandler'
 > {
     launchContext?: BrowserLaunchContext<any, any>;
@@ -197,7 +194,7 @@ export interface BrowserCrawlerOptions<
      * Second argument is the `Error` instance
      * represents the last error thrown during processing of the request.
      */
-    errorHandler?: BrowserCrawlerHandleError<Context>;
+    errorHandler?: BrowserCrawlerHandleFailedRequest<Context>;
 
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
@@ -218,7 +215,7 @@ export interface BrowserCrawlerOptions<
      * Where the {@link Request} instance corresponds to the failed request, and the `Error` instance
      * represents the last error thrown during processing of the request.
      */
-    failedRequestHandler?: BrowserCrawlerHandleFailedRequest;
+    failedRequestHandler?: BrowserCrawlerHandleFailedRequest<Context>;
 
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
@@ -241,7 +238,7 @@ export interface BrowserCrawlerOptions<
      *
      * @deprecated `handleFailedRequestFunction` has been renamed to `failedRequestHandler` and will be removed in a future version.
      */
-    handleFailedRequestFunction?: BrowserCrawlerHandleFailedRequest;
+    handleFailedRequestFunction?: BrowserCrawlerHandleFailedRequest<Context>;
 
     /**
      * Custom options passed to the underlying [`BrowserPool`](https://github.com/apify/browser-pool#BrowserPool) constructor.

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -91,32 +91,19 @@ export interface BrowserCrawlerOptions<
 
     /**
      * Function that is called to process each request.
-     * It is passed an object with the following fields:
      *
-     * ```
-     * {
-     *   request: Request,
-     *   response: Response,
-     *   page: Page,
-     *   session: Session,
-     *   browserController: BrowserController,
-     *   proxyInfo: ProxyInfo,
-     *   crawler: BrowserCrawler,
-     * }
-     * ```
-     *
-     * `request` is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
-     * `page` is an instance of the `Puppeteer`
+     * The function receives the {@link BrowserCrawlingContext} as an argument, where:
+     * - {@link BrowserCrawlingContext.request} is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
+     * - {@link BrowserCrawlingContext.page} is an instance of the `Puppeteer`
      * [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) or `Playwright`
      * [`Page`](https://playwright.dev/docs/api/class-page)
-     * `browserPool` is an instance of the
-     * [`BrowserPool`](https://github.com/apify/browser-pool#BrowserPool),
-     * `browserController` is an instance of the
+     * - {@link BrowserCrawlingContext.browserController} is an instance of the
      * [`BrowserController`](https://github.com/apify/browser-pool#browsercontroller),
-     * `response` is an instance of the `Puppeteer`
+     * - {@link BrowserCrawlingContext.response} is an instance of the `Puppeteer`
      * [`Response`](https://pptr.dev/#?product=Puppeteer&show=api-class-response) or `Playwright`
      * [`Response`](https://playwright.dev/docs/api/class-response),
      * which is the main resource response as returned by `page.goto(request.url)`.
+     *
      * The function must return a promise, which is then awaited by the crawler.
      *
      * If the function throws an exception, the crawler will try to re-crawl the
@@ -132,32 +119,19 @@ export interface BrowserCrawlerOptions<
 
     /**
      * Function that is called to process each request.
-     * It is passed an object with the following fields:
      *
-     * ```
-     * {
-     *   request: Request,
-     *   response: Response,
-     *   page: Page,
-     *   session: Session,
-     *   browserController: BrowserController,
-     *   proxyInfo: ProxyInfo,
-     *   crawler: BrowserCrawler,
-     * }
-     * ```
-     *
-     * `request` is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
-     * `page` is an instance of the `Puppeteer`
+     * The function receives the {@link BrowserCrawlingContext} as an argument, where:
+     * - {@link BrowserCrawlingContext.request} is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
+     * - {@link BrowserCrawlingContext.page} is an instance of the `Puppeteer`
      * [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) or `Playwright`
      * [`Page`](https://playwright.dev/docs/api/class-page)
-     * `browserPool` is an instance of the
-     * [`BrowserPool`](https://github.com/apify/browser-pool#BrowserPool),
-     * `browserController` is an instance of the
+     * - {@link BrowserCrawlingContext.browserController} is an instance of the
      * [`BrowserController`](https://github.com/apify/browser-pool#browsercontroller),
-     * `response` is an instance of the `Puppeteer`
+     * - {@link BrowserCrawlingContext.response} is an instance of the `Puppeteer`
      * [`Response`](https://pptr.dev/#?product=Puppeteer&show=api-class-response) or `Playwright`
      * [`Response`](https://playwright.dev/docs/api/class-response),
      * which is the main resource response as returned by `page.goto(request.url)`.
+     *
      * The function must return a promise, which is then awaited by the crawler.
      *
      * If the function throws an exception, the crawler will try to re-crawl the
@@ -174,24 +148,12 @@ export interface BrowserCrawlerOptions<
     handlePageFunction?: BrowserCrawlerHandleRequest<Context>;
 
     /**
-     * A function to handle requests that failed less than `option.maxRequestRetries` times
+     * User-provided function to handle requests that failed less than `option.maxRequestRetries` times
      * and would be retried by the crawler.
      *
-     * The function receives the following object as the first argument:
-     * ```
-     * {
-     *     request: Request,
-     *     response: Response,
-     *     page: Page,
-     *     browserPool: BrowserPool,
-     *     autoscaledPool: AutoscaledPool,
-     *     session: Session,
-     *     browserController: BrowserController,
-     *     proxyInfo: ProxyInfo,
-     * }
-     * ```
-     * Where the {@link Request} instance corresponds to the failed request.
-     * Second argument is the `Error` instance
+     * The function receives the {@link BrowserCrawlingContext} as the first argument,
+     * where the {@link BrowserCrawlingContext.request} corresponds to the request to be reclaimed.
+     * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */
     errorHandler?: BrowserCrawlerHandleFailedRequest<Context>;
@@ -199,20 +161,9 @@ export interface BrowserCrawlerOptions<
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
      *
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *     request: Request,
-     *     response: Response,
-     *     page: Page,
-     *     browserPool: BrowserPool,
-     *     autoscaledPool: AutoscaledPool,
-     *     session: Session,
-     *     browserController: BrowserController,
-     *     proxyInfo: ProxyInfo,
-     * }
-     * ```
-     * Where the {@link Request} instance corresponds to the failed request, and the `Error` instance
+     * The function receives the {@link BrowserCrawlingContext} as the first argument,
+     * where the {@link BrowserCrawlingContext.request} corresponds to the failed request.
+     * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */
     failedRequestHandler?: BrowserCrawlerHandleFailedRequest<Context>;
@@ -220,20 +171,9 @@ export interface BrowserCrawlerOptions<
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
      *
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *     request: Request,
-     *     response: Response,
-     *     page: Page,
-     *     browserPool: BrowserPool,
-     *     autoscaledPool: AutoscaledPool,
-     *     session: Session,
-     *     browserController: BrowserController,
-     *     proxyInfo: ProxyInfo,
-     * }
-     * ```
-     * Where the {@link Request} instance corresponds to the failed request, and the `Error` instance
+     * The function receives the {@link BrowserCrawlingContext} as the first argument,
+     * where the {@link BrowserCrawlingContext.request} corresponds to the failed request.
+     * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      *
      * @deprecated `handleFailedRequestFunction` has been renamed to `failedRequestHandler` and will be removed in a future version.

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -92,7 +92,8 @@ export interface BrowserCrawlerOptions<
     /**
      * Function that is called to process each request.
      *
-     * The function receives the {@link BrowserCrawlingContext} as an argument, where:
+     * The function receives the {@link BrowserCrawlingContext}
+     * (actual context will be enhanced with the crawler specific properties) as an argument, where:
      * - {@link BrowserCrawlingContext.request} is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
      * - {@link BrowserCrawlingContext.page} is an instance of the `Puppeteer`
      * [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) or `Playwright`
@@ -120,7 +121,8 @@ export interface BrowserCrawlerOptions<
     /**
      * Function that is called to process each request.
      *
-     * The function receives the {@link BrowserCrawlingContext} as an argument, where:
+     * The function receives the {@link BrowserCrawlingContext}
+     * (actual context will be enhanced with the crawler specific properties) as an argument, where:
      * - {@link BrowserCrawlingContext.request} is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
      * - {@link BrowserCrawlingContext.page} is an instance of the `Puppeteer`
      * [`Page`](https://pptr.dev/#?product=Puppeteer&show=api-class-page) or `Playwright`
@@ -151,7 +153,8 @@ export interface BrowserCrawlerOptions<
      * User-provided function that allows modifying the request object before it gets retried by the crawler.
      * It's executed before each retry for the requests that failed less than `option.maxRequestRetries` times.
      *
-     * The function receives the {@link BrowserCrawlingContext} as the first argument,
+     * The function receives the {@link BrowserCrawlingContext}
+     * (actual context will be enhanced with the crawler specific properties) as the first argument,
      * where the {@link BrowserCrawlingContext.request} corresponds to the request to be retried.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
@@ -161,7 +164,8 @@ export interface BrowserCrawlerOptions<
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
      *
-     * The function receives the {@link BrowserCrawlingContext} as the first argument,
+     * The function receives the {@link BrowserCrawlingContext}
+     * (actual context will be enhanced with the crawler specific properties) as the first argument,
      * where the {@link BrowserCrawlingContext.request} corresponds to the failed request.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
@@ -171,7 +175,8 @@ export interface BrowserCrawlerOptions<
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
      *
-     * The function receives the {@link BrowserCrawlingContext} as the first argument,
+     * The function receives the {@link BrowserCrawlingContext}
+     * (actual context will be enhanced with the crawler specific properties) as the first argument,
      * where the {@link BrowserCrawlingContext.request} corresponds to the failed request.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -146,11 +146,11 @@ export interface CheerioCrawlerOptions<JSONData = Dictionary> extends Omit<Basic
     proxyConfiguration?: ProxyConfiguration;
 
     /**
-     * User-provided function to handle requests that failed less than `option.maxRequestRetries` times
-     * and would be retried by the crawler.
+     * User-provided function that allows modifying the request object before it gets retried by the crawler.
+     * It's executed before each retry for the requests that failed less than `option.maxRequestRetries` times.
      *
      * The function receives the {@link CheerioCrawlingContext} as the first argument,
-     * where the {@link CheerioCrawlingContext.request} corresponds to the request to be reclaimed.
+     * where the {@link CheerioCrawlingContext.request} corresponds to the request to be retried.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -59,61 +59,29 @@ export interface CheerioCrawlerOptions<JSONData = Dictionary> extends Omit<Basic
     // Overridden with cheerio context
     | 'requestHandler'
     | 'handleRequestFunction'
-    // Overridden with cheerio context
+
     | 'failedRequestHandler'
     | 'handleFailedRequestFunction'
     | 'handleRequestTimeoutSecs'
-    // Overridden with cheerio context
+
     | 'errorHandler'
 > {
     /**
      * User-provided function that performs the logic of the crawler. It is called for each page
      * loaded and parsed by the crawler.
      *
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *   // The Cheerio object's function with the parsed HTML.
-     *   $: Cheerio,
+     * The function receives the {@link CheerioCrawlingContext} as an argument,
+     * where the {@link CheerioCrawlingContext.request} instance represents the URL to crawl.
      *
-     *   // The request body of the web page, whose type depends on the content type.
-     *   body: String|Buffer,
-     *
-     *   // The parsed object from JSON for responses with the "application/json" content types.
-     *   // For other content types it's null.
-     *   json: Object,
-     *
-     *   // Request object with details of the requested web page
-     *   request: Request,
-     *
-     *   // Parsed Content-Type HTTP header: { type, encoding }
-     *   contentType: Object,
-     *
-     *   // An instance of Node's http.IncomingMessage object,
-     *   response: Object,
-     *
-     *   // Session object, useful to work around anti-scraping protections
-     *   session: Session
-     *
-     *   // ProxyInfo object with information about currently used proxy
-     *   proxyInfo: ProxyInfo
-     *
-     *   // The running cheerio crawler instance.
-     *   crawler: CheerioCrawler
-     * }
-     * ```
-     *
-     * Type of `body` depends on the `Content-Type` header of the web page:
+     * Type of {@link CheerioCrawlingContext.body} depends on the `Content-Type` header of the web page:
      * - String for `text/html`, `application/xhtml+xml`, `application/xml` MIME content types
      * - Buffer for others MIME content types
      *
      * Parsed `Content-Type` header using
      * [content-type package](https://www.npmjs.com/package/content-type)
-     * is stored in `contentType`.
+     * is stored in {@link CheerioCrawlingContext.contentType}`.
      *
      * Cheerio is available only for HTML and XML content types.
-     *
-     * With the {@link Request} object representing the URL to crawl.
      *
      * If the function returns, the returned promise is awaited by the crawler.
      *
@@ -132,50 +100,18 @@ export interface CheerioCrawlerOptions<JSONData = Dictionary> extends Omit<Basic
      * User-provided function that performs the logic of the crawler. It is called for each page
      * loaded and parsed by the crawler.
      *
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *   // The Cheerio object's function with the parsed HTML.
-     *   $: Cheerio,
+     * The function receives the {@link CheerioCrawlingContext} as an argument,
+     * where the {@link CheerioCrawlingContext.request} instance represents the URL to crawl.
      *
-     *   // The request body of the web page, whose type depends on the content type.
-     *   body: String|Buffer,
-     *
-     *   // The parsed object from JSON for responses with the "application/json" content types.
-     *   // For other content types it's null.
-     *   json: Object,
-     *
-     *   // Request object with details of the requested web page
-     *   request: Request,
-     *
-     *   // Parsed Content-Type HTTP header: { type, encoding }
-     *   contentType: Object,
-     *
-     *   // An instance of Node's http.IncomingMessage object,
-     *   response: Object,
-     *
-     *   // Session object, useful to work around anti-scraping protections
-     *   session: Session
-     *
-     *   // ProxyInfo object with information about currently used proxy
-     *   proxyInfo: ProxyInfo
-     *
-     *   // The running cheerio crawler instance.
-     *   crawler: CheerioCrawler
-     * }
-     * ```
-     *
-     * Type of `body` depends on the `Content-Type` header of the web page:
+     * Type of {@link CheerioCrawlingContext.body} depends on the `Content-Type` header of the web page:
      * - String for `text/html`, `application/xhtml+xml`, `application/xml` MIME content types
      * - Buffer for others MIME content types
      *
      * Parsed `Content-Type` header using
      * [content-type package](https://www.npmjs.com/package/content-type)
-     * is stored in `contentType`.
+     * is stored in {@link CheerioCrawlingContext.contentType}`.
      *
      * Cheerio is available only for HTML and XML content types.
-     *
-     * With the {@link Request} object representing the URL to crawl.
      *
      * If the function returns, the returned promise is awaited by the crawler.
      *
@@ -209,26 +145,23 @@ export interface CheerioCrawlerOptions<JSONData = Dictionary> extends Omit<Basic
      */
     proxyConfiguration?: ProxyConfiguration;
 
+    /**
+     * User-provided function to handle requests that failed less than `option.maxRequestRetries` times
+     * and would be retried by the crawler.
+     *
+     * The function receives the {@link CheerioCrawlingContext} as the first argument,
+     * where the {@link CheerioCrawlingContext.request} corresponds to the request to be reclaimed.
+     * Second argument is the `Error` instance that
+     * represents the last error thrown during processing of the request.
+     */
     errorHandler?: CheerioFailedRequestHandler<JSONData>;
 
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *     error: Error,
-     *     request: Request,
-     *     session: Session,
-     *     $: Cheerio,
-     *     body: String|Buffer,
-     *     json: Object,
-     *     contentType: Object,
-     *     response: Object,
-     *     proxyInfo: ProxyInfo,
-     *     crawler: CheerioCrawler,
-     * }
-     * ```
-     * where the {@link Request} instance corresponds to the failed request, and the `Error` instance
+     *
+     * The function receives the {@link CheerioCrawlingContext} as the first argument,
+     * where the {@link CheerioCrawlingContext.request} corresponds to the failed request.
+     * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      *
      * See [source code](https://github.com/apify/apify-ts/blob/master/src/crawlers/cheerio_crawler.js#L13)
@@ -238,22 +171,10 @@ export interface CheerioCrawlerOptions<JSONData = Dictionary> extends Omit<Basic
 
     /**
      * A function to handle requests that failed more than `option.maxRequestRetries` times.
-     * The function receives the following object as an argument:
-     * ```
-     * {
-     *     error: Error,
-     *     request: Request,
-     *     session: Session,
-     *     $: Cheerio,
-     *     body: String|Buffer,
-     *     json: Object,
-     *     contentType: Object,
-     *     response: Object,
-     *     proxyInfo: ProxyInfo,
-     *     crawler: CheerioCrawler,
-     * }
-     * ```
-     * where the {@link Request} instance corresponds to the failed request, and the `Error` instance
+     *
+     * The function receives the {@link CheerioCrawlingContext} as the first argument,
+     * where the {@link CheerioCrawlingContext.request} corresponds to the failed request.
+     * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      *
      * See [source code](https://github.com/apify/apify-ts/blob/master/src/crawlers/cheerio_crawler.js#L13)

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -19,15 +19,3 @@ export interface CrawlingContext<UserData extends Dictionary = Dictionary> exten
     proxyInfo?: ProxyInfo;
     log: Log;
 }
-
-export interface FailedRequestContext<Crawler = unknown, UserData extends Dictionary = Dictionary> extends CrawlingContext<UserData> {
-    /**
-     * The Error thrown by `requestHandler`.
-     */
-    error: Error;
-
-    /**
-     * Current crawler instance.
-     */
-    crawler: Crawler;
-}

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -39,12 +39,12 @@ export interface PlaywrightCrawlerOptions extends BrowserCrawlerOptions<
      * Function that is called to process each request.
      *
      * The function receives the {@link PlaywrightCrawlingContext} as an argument, where:
-     * - {@link PlaywrightCrawlingContext.request} is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
-     * - {@link PlaywrightCrawlingContext.page} is an instance of the `Playwright`
+     * - `request` is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
+     * - `page` is an instance of the `Playwright`
      * [`Page`](https://playwright.dev/docs/api/class-page)
-     * - {@link PlaywrightCrawlingContext.browserController} is an instance of the
+     * - `browserController` is an instance of the
      * [`BrowserController`](https://github.com/apify/browser-pool#browsercontroller),
-     * - {@link PlaywrightCrawlingContext.response} is an instance of the `Playwright`
+     * - `response` is an instance of the `Playwright`
      * [`Response`](https://playwright.dev/docs/api/class-response),
      * which is the main resource response as returned by `page.goto(request.url)`.
      *
@@ -65,12 +65,12 @@ export interface PlaywrightCrawlerOptions extends BrowserCrawlerOptions<
      * Function that is called to process each request.
      *
      * The function receives the {@link PlaywrightCrawlingContext} as an argument, where:
-     * - {@link PlaywrightCrawlingContext.request} is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
-     * - {@link PlaywrightCrawlingContext.page} is an instance of the `Playwright`
+     * - `request` is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
+     * - `page` is an instance of the `Playwright`
      * [`Page`](https://playwright.dev/docs/api/class-page)
-     * - {@link PlaywrightCrawlingContext.browserController} is an instance of the
+     * - `browserController` is an instance of the
      * [`BrowserController`](https://github.com/apify/browser-pool#browsercontroller),
-     * - {@link PlaywrightCrawlingContext.response} is an instance of the `Playwright`
+     * - `response` is an instance of the `Playwright`
      * [`Response`](https://playwright.dev/docs/api/class-response),
      * which is the main resource response as returned by `page.goto(request.url)`.
      *

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -31,29 +31,23 @@ export interface PlaywrightCrawlerOptions extends BrowserCrawlerOptions<
     { browserPlugins: [PlaywrightPlugin] }
 > {
     /**
+     * The same options as used by {@link launchPlaywright}.
+     */
+    launchContext?: PlaywrightLaunchContext;
+
+    /**
      * Function that is called to process each request.
-     * It is passed an object with the following fields:
      *
-     * ```
-     * {
-     *   request: Request,
-     *   response: Response,
-     *   page: Page,
-     *   session: Session,
-     *   browserController: BrowserController,
-     *   proxyInfo: ProxyInfo,
-     *   crawler: PlaywrightCrawler,
-     * }
-     * ```
-     *
-     * `request` is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
-     * `page` is an instance of the `Playwright`
+     * The function receives the {@link PlaywrightCrawlingContext} as an argument, where:
+     * - {@link PlaywrightCrawlingContext.request} is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
+     * - {@link PlaywrightCrawlingContext.page} is an instance of the `Playwright`
      * [`Page`](https://playwright.dev/docs/api/class-page)
-     * `browserController` is an instance of the
+     * - {@link PlaywrightCrawlingContext.browserController} is an instance of the
      * [`BrowserController`](https://github.com/apify/browser-pool#browsercontroller),
-     * `response` is an instance of the `Playwright`
+     * - {@link PlaywrightCrawlingContext.response} is an instance of the `Playwright`
      * [`Response`](https://playwright.dev/docs/api/class-response),
      * which is the main resource response as returned by `page.goto(request.url)`.
+     *
      * The function must return a promise, which is then awaited by the crawler.
      *
      * If the function throws an exception, the crawler will try to re-crawl the
@@ -69,28 +63,17 @@ export interface PlaywrightCrawlerOptions extends BrowserCrawlerOptions<
 
     /**
      * Function that is called to process each request.
-     * It is passed an object with the following fields:
      *
-     * ```
-     * {
-     *   request: Request,
-     *   response: Response,
-     *   page: Page,
-     *   session: Session,
-     *   browserController: BrowserController,
-     *   proxyInfo: ProxyInfo,
-     *   crawler: PlaywrightCrawler,
-     * }
-     * ```
-     *
-     * `request` is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
-     * `page` is an instance of the `Playwright`
+     * The function receives the {@link PlaywrightCrawlingContext} as an argument, where:
+     * - {@link PlaywrightCrawlingContext.request} is an instance of the {@link Request} object with details about the URL to open, HTTP method etc.
+     * - {@link PlaywrightCrawlingContext.page} is an instance of the `Playwright`
      * [`Page`](https://playwright.dev/docs/api/class-page)
-     * `browserController` is an instance of the
+     * - {@link PlaywrightCrawlingContext.browserController} is an instance of the
      * [`BrowserController`](https://github.com/apify/browser-pool#browsercontroller),
-     * `response` is an instance of the `Playwright`
+     * - {@link PlaywrightCrawlingContext.response} is an instance of the `Playwright`
      * [`Response`](https://playwright.dev/docs/api/class-response),
      * which is the main resource response as returned by `page.goto(request.url)`.
+     *
      * The function must return a promise, which is then awaited by the crawler.
      *
      * If the function throws an exception, the crawler will try to re-crawl the
@@ -137,11 +120,6 @@ export interface PlaywrightCrawlerOptions extends BrowserCrawlerOptions<
      * ```
      */
     postNavigationHooks?: PlaywrightHook[];
-
-    /**
-     * The same options as used by {@link launchPlaywright}.
-     */
-    launchContext?: PlaywrightLaunchContext;
 }
 
 /**

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -4,7 +4,6 @@ import type { AddressInfo } from 'net';
 import log from '@apify/log';
 import type {
     CrawlingContext,
-    ErrorHandler,
     FailedRequestHandler,
     RequestHandler } from '@crawlee/basic';
 import {
@@ -282,14 +281,14 @@ describe.each(SingleStorageCase)('BasicCrawler - %s', (Emulator) => {
             throw new Error(`This is an error ${errorHandlerCalls}`);
         };
 
-        const errorHandler: ErrorHandler = async ({ request }, error) => {
+        const errorHandler: FailedRequestHandler = async ({ request }, error) => {
             expect(error.message).toBe(`This is an error ${errorHandlerCalls}`);
             errorHandlerCalls++;
             request.label = `error_${errorHandlerCalls}`;
         };
 
         const failedRequestHandler: FailedRequestHandler = async ({ request, error }) => {
-            failed[request.url] = { request, error };
+            failed[request.url] = { request, error: error as Error };
             failedRequestHandlerCalls++;
         };
 
@@ -327,7 +326,7 @@ describe.each(SingleStorageCase)('BasicCrawler - %s', (Emulator) => {
             processed[request.url] = request;
         };
 
-        const failedRequestHandler: FailedRequestHandler = async ({ request, error }) => {
+        const failedRequestHandler: FailedRequestHandler = async ({ request }, error) => {
             failed[request.url] = request;
             errors.push(error);
         };
@@ -368,7 +367,7 @@ describe.each(SingleStorageCase)('BasicCrawler - %s', (Emulator) => {
             throw new NonRetryableError('some-error');
         };
 
-        const failedRequestHandler: FailedRequestHandler = async ({ request, error }) => {
+        const failedRequestHandler: FailedRequestHandler = async ({ request }, error) => {
             failed[request.url] = request;
             errors.push(error);
         };

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -284,7 +284,7 @@ describe.each(SingleStorageCase)('BasicCrawler - %s', (Emulator) => {
             request.label = `error_${errorHandlerCalls}`;
         };
 
-        const failedRequestHandler: FailedRequestHandler = async ({ request, error }) => {
+        const failedRequestHandler: FailedRequestHandler = async ({ request }, error) => {
             failed[request.url] = { request, error: error as Error };
             failedRequestHandlerCalls++;
         };

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -285,7 +285,7 @@ describe.each(SingleStorageCase)('BasicCrawler - %s', (Emulator) => {
         };
 
         const failedRequestHandler: FailedRequestHandler = async ({ request }, error) => {
-            failed[request.url] = { request, error: error as Error };
+            failed[request.url] = { request, error };
             failedRequestHandlerCalls++;
         };
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from 'net';
 import log from '@apify/log';
 import type {
     CrawlingContext,
+    ErrorHandler,
     FailedRequestHandler,
     RequestHandler } from '@crawlee/basic';
 import {
@@ -265,6 +266,49 @@ describe.each(SingleStorageCase)('BasicCrawler - %s', (Emulator) => {
 
         expect(await requestList.isFinished()).toBe(true);
         expect(await requestList.isEmpty()).toBe(true);
+    });
+
+    test('should use errorHandler', async () => {
+        const sources = [{ url: 'http://example.com/', label: 'start' }];
+
+        let errorHandlerCalls = 0;
+        let failedRequestHandlerCalls = 0;
+
+        const failed: Dictionary<{ request: Request; error: Error }> = {};
+        const requestList = new RequestList({ sources });
+
+        const requestHandler: RequestHandler = async ({ request }) => {
+            expect(request.label).toBe(errorHandlerCalls === 0 ? 'start' : `error_${errorHandlerCalls}`);
+            throw new Error(`This is an error ${errorHandlerCalls}`);
+        };
+
+        const errorHandler: ErrorHandler = async ({ request }, error) => {
+            expect(error.message).toBe(`This is an error ${errorHandlerCalls}`);
+            errorHandlerCalls++;
+            request.label = `error_${errorHandlerCalls}`;
+        };
+
+        const failedRequestHandler: FailedRequestHandler = async ({ request, error }) => {
+            failed[request.url] = { request, error };
+            failedRequestHandlerCalls++;
+        };
+
+        const basicCrawler = new BasicCrawler({
+            requestList,
+            requestHandler,
+            errorHandler,
+            failedRequestHandler,
+        });
+
+        await requestList.initialize();
+        await basicCrawler.run();
+
+        expect(errorHandlerCalls).toBe(3);
+        expect(failedRequestHandlerCalls).toBe(1);
+        expect(Object.values(failed)).toHaveLength(1);
+        expect(failed['http://example.com/'].request.label).not.toBe('start');
+        expect(failed['http://example.com/'].request.label).toBe('error_3');
+        expect(failed['http://example.com/'].error.message).toEqual('This is an error 3');
     });
 
     test('should allow to handle failed requests', async () => {

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -271,7 +271,7 @@ describe.each(SingleStorageCase)('BasicCrawler - %s', (Emulator) => {
         let failedRequestHandlerCalls = 0;
 
         const failed: Dictionary<{ request: Request; error: Error }> = {};
-        const requestList = new RequestList({ sources });
+        const requestList = await RequestList.open({ sources });
 
         const requestHandler: RequestHandler = async ({ request }) => {
             expect(request.label).toBe(errorHandlerCalls === 0 ? 'start' : `error_${errorHandlerCalls}`);
@@ -296,7 +296,6 @@ describe.each(SingleStorageCase)('BasicCrawler - %s', (Emulator) => {
             failedRequestHandler,
         });
 
-        await requestList.initialize();
         await basicCrawler.run();
 
         expect(errorHandlerCalls).toBe(3);

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -723,7 +723,7 @@ describe.each(StorageTestCases)('BrowserCrawler - %s', (Emulator) => {
                 expect(crawlingContext.hasOwnProperty('response')).toBe(true);
 
                 expect(crawlingContext.error).toBeUndefined();
-                expect(crawlingContext.error).toBeInstanceOf(Error);
+                expect(error).toBeInstanceOf(Error);
                 expect(error.message).toEqual('some error');
             };
 

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -5,7 +5,6 @@ import puppeteer from 'puppeteer';
 import log from '@apify/log';
 import type {
     BrowserCrawler,
-    BrowserFailedRequestContext,
     BrowserCrawlingContext,
     ProxyInfo,
     PuppeteerCrawlingContext,
@@ -724,7 +723,7 @@ describe.each(StorageTestCases)('BrowserCrawler - %s', (Emulator) => {
                 throw new Error('some error');
             };
 
-            const failedRequestHandler = async (crawlingContext: BrowserFailedRequestContext) => {
+            const failedRequestHandler = async (crawlingContext: BrowserCrawlingContext, error: Error) => {
                 expect(crawlingContext).toBe(prepareCrawlingContext);
                 expect(crawlingContext.request).toBeInstanceOf(Request);
                 expect(crawlingContext.crawler.autoscaledPool).toBeInstanceOf(AutoscaledPool);
@@ -734,8 +733,9 @@ describe.each(StorageTestCases)('BrowserCrawler - %s', (Emulator) => {
                 expect((crawlingContext.crawler as BrowserCrawler).browserPool).toBeInstanceOf(BrowserPool);
                 expect(crawlingContext.hasOwnProperty('response')).toBe(true);
 
+                expect(crawlingContext.error).toBeUndefined();
                 expect(crawlingContext.error).toBeInstanceOf(Error);
-                expect(crawlingContext.error.message).toEqual('some error');
+                expect(error.message).toEqual('some error');
             };
 
             const browserCrawler = new BrowserCrawlerTest({

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -5,7 +5,6 @@ import type { OptionsInit } from 'got-scraping';
 import { gotScraping } from 'got-scraping';
 import bodyParser from 'body-parser';
 import type {
-    CheerioFailedRequestContext,
     CheerioRequestHandler,
     CheerioCrawlingContext,
     PrepareRequestInputs,
@@ -1114,7 +1113,7 @@ describe.each(StorageTestCases)('CheerioCrawler - %s', (Emulator) => {
                 throw new Error('some error');
             };
 
-            const failedRequestHandler = (crawlingContext: CheerioFailedRequestContext) => {
+            const failedRequestHandler = (crawlingContext: CheerioCrawlingContext, error: Error) => {
                 expect(crawlingContext === prepareCrawlingContext).toEqual(true);
                 expect(crawlingContext.request).toBeInstanceOf(Request);
                 expect(crawlingContext.crawler.autoscaledPool).toBeInstanceOf(AutoscaledPool);
@@ -1123,8 +1122,9 @@ describe.each(StorageTestCases)('CheerioCrawler - %s', (Emulator) => {
                 expect(typeof crawlingContext.response).toBe('object');
                 expect(typeof crawlingContext.contentType).toBe('object');
 
-                expect(crawlingContext.error).toBeInstanceOf(Error);
-                expect(crawlingContext.error.message).toEqual('some error');
+                expect(crawlingContext.error).toBeUndefined();
+                expect(error).toBeInstanceOf(Error);
+                expect(error.message).toEqual('some error');
             };
 
             const cheerioCrawler = new CheerioCrawler({


### PR DESCRIPTION
I know that I need to add it to Cheerio and other crawlers, but could you have a quick look before I proceed with the rest?

Also thinking - maybe it's worth adding helper `crawler.reclaimRequest()` since with user-provided function for requests to be retried - they would need to either manually do it or just skip it. Or thinking about it now - maybe there should be something like `context.reclainRequest` (which would be `true` by default) and otherwise user would need to set it to false and thus it would be marked as handled)?