### PR TITLE
chore: await all event listener executions before exiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16520,6 +16520,7 @@
             "dependencies": {
                 "@apify/consts": "^2.0.0",
                 "@apify/log": "^2.0.0",
+                "@apify/timeout": "^0.3.0",
                 "@apify/utilities": "^2.0.0",
                 "@crawlee/core": "^3.0.0",
                 "@crawlee/types": "^3.0.0",
@@ -21208,6 +21209,7 @@
             "requires": {
                 "@apify/consts": "^2.0.0",
                 "@apify/log": "^2.0.0",
+                "@apify/timeout": "*",
                 "@apify/utilities": "^2.0.0",
                 "@crawlee/core": "^3.0.0",
                 "@crawlee/types": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4116,6 +4116,11 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
             "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
         },
+        "node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+        },
         "node_modules/@types/ws": {
             "version": "7.4.7",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
@@ -4361,6 +4366,19 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@vladfrangu/async_event_emitter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-1.0.1.tgz",
+            "integrity": "sha512-rkcSxwTBXQN6fyHygfcJBz5Zeq1DOZ1t8h+yxHu8iVo9CJkVGFboWPW6P+ZqsxGx0v92kUltNTSP/hUf1IlBiw==",
+            "dependencies": {
+                "@types/uuid": "^8.3.4",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
             }
         },
         "node_modules/abbrev": {
@@ -15941,7 +15959,6 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -16696,6 +16713,7 @@
                 "@crawlee/types": "^3.0.0",
                 "@crawlee/utils": "^3.0.0",
                 "@types/tough-cookie": "^4.0.2",
+                "@vladfrangu/async_event_emitter": "^1.0.1",
                 "minimatch": "^5.1.0",
                 "ow": "^0.28.1",
                 "stream-chain": "^2.2.5",
@@ -18053,6 +18071,7 @@
                 "@crawlee/types": "^3.0.0",
                 "@crawlee/utils": "^3.0.0",
                 "@types/tough-cookie": "^4.0.2",
+                "@vladfrangu/async_event_emitter": "*",
                 "minimatch": "^5.1.0",
                 "ow": "^0.28.1",
                 "stream-chain": "^2.2.5",
@@ -20899,6 +20918,11 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
             "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
         },
+        "@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+        },
         "@types/ws": {
             "version": "7.4.7",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
@@ -21048,6 +21072,15 @@
             "requires": {
                 "@typescript-eslint/types": "5.27.1",
                 "eslint-visitor-keys": "^3.3.0"
+            }
+        },
+        "@vladfrangu/async_event_emitter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-1.0.1.tgz",
+            "integrity": "sha512-rkcSxwTBXQN6fyHygfcJBz5Zeq1DOZ1t8h+yxHu8iVo9CJkVGFboWPW6P+ZqsxGx0v92kUltNTSP/hUf1IlBiw==",
+            "requires": {
+                "@types/uuid": "^8.3.4",
+                "uuid": "^8.3.2"
             }
         },
         "abbrev": {
@@ -29835,8 +29868,7 @@
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4116,11 +4116,6 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
             "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
         },
-        "node_modules/@types/uuid": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
-        },
         "node_modules/@types/ws": {
             "version": "7.4.7",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
@@ -4369,13 +4364,9 @@
             }
         },
         "node_modules/@vladfrangu/async_event_emitter": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-1.0.1.tgz",
-            "integrity": "sha512-rkcSxwTBXQN6fyHygfcJBz5Zeq1DOZ1t8h+yxHu8iVo9CJkVGFboWPW6P+ZqsxGx0v92kUltNTSP/hUf1IlBiw==",
-            "dependencies": {
-                "@types/uuid": "^8.3.4",
-                "uuid": "^8.3.2"
-            },
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.0.0.tgz",
+            "integrity": "sha512-Gd+mI901BeQMgaZjWeEnJ7v3n/1OD2JZS1vOusT4T3KGb36Jro5hNHTS3ck1drsRxl65QcQwvzxtoKcABNBeWw==",
             "engines": {
                 "node": ">=v14.0.0",
                 "npm": ">=7.0.0"
@@ -15959,6 +15950,7 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -16713,7 +16705,7 @@
                 "@crawlee/types": "^3.0.0",
                 "@crawlee/utils": "^3.0.0",
                 "@types/tough-cookie": "^4.0.2",
-                "@vladfrangu/async_event_emitter": "^1.0.1",
+                "@vladfrangu/async_event_emitter": "^2.0.0",
                 "minimatch": "^5.1.0",
                 "ow": "^0.28.1",
                 "stream-chain": "^2.2.5",
@@ -18071,7 +18063,7 @@
                 "@crawlee/types": "^3.0.0",
                 "@crawlee/utils": "^3.0.0",
                 "@types/tough-cookie": "^4.0.2",
-                "@vladfrangu/async_event_emitter": "*",
+                "@vladfrangu/async_event_emitter": "^2.0.0",
                 "minimatch": "^5.1.0",
                 "ow": "^0.28.1",
                 "stream-chain": "^2.2.5",
@@ -20918,11 +20910,6 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
             "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
         },
-        "@types/uuid": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
-        },
         "@types/ws": {
             "version": "7.4.7",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
@@ -21075,13 +21062,9 @@
             }
         },
         "@vladfrangu/async_event_emitter": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-1.0.1.tgz",
-            "integrity": "sha512-rkcSxwTBXQN6fyHygfcJBz5Zeq1DOZ1t8h+yxHu8iVo9CJkVGFboWPW6P+ZqsxGx0v92kUltNTSP/hUf1IlBiw==",
-            "requires": {
-                "@types/uuid": "^8.3.4",
-                "uuid": "^8.3.2"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.0.0.tgz",
+            "integrity": "sha512-Gd+mI901BeQMgaZjWeEnJ7v3n/1OD2JZS1vOusT4T3KGb36Jro5hNHTS3ck1drsRxl65QcQwvzxtoKcABNBeWw=="
         },
         "abbrev": {
             "version": "1.1.1",
@@ -29868,7 +29851,8 @@
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/packages/apify/package.json
+++ b/packages/apify/package.json
@@ -56,13 +56,14 @@
     "dependencies": {
         "@apify/consts": "^2.0.0",
         "@apify/log": "^2.0.0",
+        "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.0.0",
         "@crawlee/core": "^3.0.0",
         "@crawlee/types": "^3.0.0",
         "@crawlee/utils": "^3.0.0",
-        "semver": "^7.3.7",
         "apify-client": "^2.5.0",
         "ow": "^0.28.1",
+        "semver": "^7.3.7",
         "ws": "^7.5.8"
     }
 }

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -189,6 +189,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         options.timeoutSecs ??= 5;
 
         this.eventManager.emit(EventType.EXIT, options);
+        await this.eventManager.awaitAllListenersToComplete();
         await this.eventManager.close();
 
         if (options.exitCode > 0) {

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -186,7 +186,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         options = typeof messageOrOptions === 'string' ? { ...options, statusMessage: messageOrOptions } : { ...messageOrOptions, ...options };
         options.exit ??= true;
         options.exitCode ??= EXIT_CODES.SUCCESS;
-        options.timeoutSecs ??= 5;
+        options.timeoutSecs ??= 1;
 
         this.eventManager.emit(EventType.EXIT, options);
         await this.eventManager.awaitAllListenersToComplete();

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -189,7 +189,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         options.timeoutSecs ??= 1;
 
         this.eventManager.emit(EventType.EXIT, options);
-        await this.eventManager.awaitAllListenersToComplete();
+        await this.eventManager.waitForAllListenersToComplete();
         await this.eventManager.close();
 
         if (options.exitCode > 0) {

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -195,7 +195,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         this.eventManager.emit(EventType.EXIT, options);
 
         // Wait for all event listeners to be processed
-        log.debug(`Waiting for ${options.timeoutSecs} seconds for all event listeners to complete their execution`);
+        log.debug(`Waiting for all event listeners to complete their execution (with ${options.timeoutSecs} seconds timeout)`);
         await addTimeoutToPromise(
             () => this.eventManager.waitForAllListenersToComplete(),
             options.timeoutSecs * 1000,

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -1465,7 +1465,7 @@ export interface ExitOptions {
     statusMessage?: string;
     /**
      * Amount of time, in seconds, to wait for all event handlers to finish before exiting the process.
-     * @default 5
+     * @default 30
      */
     timeoutSecs?: number;
     /** Exit code, defaults to 0 */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,7 @@
         "@crawlee/types": "^3.0.0",
         "@crawlee/utils": "^3.0.0",
         "@types/tough-cookie": "^4.0.2",
+        "@vladfrangu/async_event_emitter": "^1.0.1",
         "minimatch": "^5.1.0",
         "ow": "^0.28.1",
         "stream-chain": "^2.2.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
         "@crawlee/types": "^3.0.0",
         "@crawlee/utils": "^3.0.0",
         "@types/tough-cookie": "^4.0.2",
-        "@vladfrangu/async_event_emitter": "^1.0.1",
+        "@vladfrangu/async_event_emitter": "^2.0.0",
         "minimatch": "^5.1.0",
         "ow": "^0.28.1",
         "stream-chain": "^2.2.5",

--- a/packages/core/src/events/event_manager.ts
+++ b/packages/core/src/events/event_manager.ts
@@ -1,7 +1,7 @@
 import log from '@apify/log';
-import { EventEmitter } from 'node:events';
 import type { BetterIntervalID } from '@apify/utilities';
 import { betterClearInterval, betterSetInterval } from '@apify/utilities';
+import { AsyncEventEmitter } from '@vladfrangu/async_event_emitter';
 import { Configuration } from '../configuration';
 
 export const enum EventType {
@@ -20,7 +20,7 @@ interface Intervals {
 }
 
 export abstract class EventManager {
-    protected events = new EventEmitter();
+    protected events = new AsyncEventEmitter();
     protected initialized = false;
     protected intervals: Intervals = {};
     protected log = log.child({ prefix: 'Events' });
@@ -89,5 +89,12 @@ export abstract class EventManager {
      */
     listeners(event: EventTypeName): (() => Promise<unknown>)[] {
         return this.events.listeners(event) as (() => Promise<unknown>)[];
+    }
+
+    /**
+     * @internal
+     */
+    awaitAllListenersToComplete() {
+        return this.events.awaitAllListenersToComplete();
     }
 }

--- a/packages/core/src/events/event_manager.ts
+++ b/packages/core/src/events/event_manager.ts
@@ -55,6 +55,9 @@ export abstract class EventManager {
 
         betterClearInterval(this.intervals.persistState!);
         this.initialized = false;
+
+        // Emit final PERSIST_STATE event
+        this.emit(EventType.PERSIST_STATE, { isMigrating: false });
     }
 
     on(event: EventTypeName, listener: (...args: any[]) => any): void {

--- a/packages/core/src/events/event_manager.ts
+++ b/packages/core/src/events/event_manager.ts
@@ -94,7 +94,7 @@ export abstract class EventManager {
     /**
      * @internal
      */
-    awaitAllListenersToComplete() {
-        return this.events.awaitAllListenersToComplete();
+    waitForAllListenersToComplete() {
+        return this.events.waitForAllListenersToComplete();
     }
 }

--- a/test/apify/events.test.ts
+++ b/test/apify/events.test.ts
@@ -118,6 +118,6 @@ describe('events', () => {
         jest.advanceTimersByTime(60001);
         jest.advanceTimersByTime(60001);
         await events.close();
-        expect(eventsReceived.length).toBe(4);
+        expect(eventsReceived.length).toBe(5);
     });
 });


### PR DESCRIPTION
To achieve this in the cleanest way possible (and to also make this usable by anyone who might need this), I took the EventEmitter interface from nodejs, replicated it in more modern code, added support for awaiting the execution of all listeners, and made it its own module.

There's no difference otherwise. The code does (almost) the exact same things the nodejs core code does (bar the catch handling for promises: the rejections will always be handled and emitted as error events). 