### PR TITLE
fix: `userAgent` overrides `useFingerprints`

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -424,9 +424,9 @@ export abstract class BrowserCrawler<
             this.persistCookiesPerSession = false;
         }
 
-        if (launchContext?.userAgent && browserPoolOptions.useFingerprints) {
+        if (launchContext?.userAgent) {
+            if (browserPoolOptions.useFingerprints) this.log.info('Custom user agent provided, disabling automatic browser fingerprint injection!');
             browserPoolOptions.useFingerprints = false;
-            this.log.info('Custom user agent provided, disabling automatic browser fingerprint injection!');
         }
 
         const { preLaunchHooks = [], postLaunchHooks = [], ...rest } = browserPoolOptions;

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -424,9 +424,9 @@ export abstract class BrowserCrawler<
             this.persistCookiesPerSession = false;
         }
 
-        if (launchContext?.userAgent) {
+        if (launchContext?.userAgent && browserPoolOptions.useFingerprints) {
             browserPoolOptions.useFingerprints = false;
-            this.log.info('Disabling automatic fingerprint injection because custom user agent has been provided.');
+            this.log.info('Custom user agent provided, disabling automatic browser fingerprint injection!');
         }
 
         const { preLaunchHooks = [], postLaunchHooks = [], ...rest } = browserPoolOptions;

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -226,8 +226,7 @@ export class PlaywrightCrawler extends BrowserCrawler<{ browserPlugins: [Playwri
             playwrightLauncher.createBrowserPlugin(),
         ];
 
-        super({ ...browserCrawlerOptions, browserPoolOptions }, config);
-        this.launchContext = launchContext;
+        super({ ...browserCrawlerOptions, launchContext, browserPoolOptions }, config);
     }
 
     protected override async _runRequestHandler(context: PlaywrightCrawlingContext) {


### PR DESCRIPTION
closes #113 

PlaywrightCrawler and PuppeteerCrawler behavior standardized. Specifying `launchContext.userAgent` overrides the `browserPool.useFingerprints` setting - the warning message only shows when `browserPool.useFingerprints` is set, though.