### PR TITLE
docs: add skip-navigation example

### DIFF
--- a/docs/examples/skip-navigation.mdx
+++ b/docs/examples/skip-navigation.mdx
@@ -1,0 +1,23 @@
+---
+id: skip-navigation
+title: Skipping navigations for certain requests
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import ApiLink from '@site/src/components/ApiLink';
+import SkipNavigationSource from '!!raw-loader!./skip-navigation.ts';
+
+While crawling a website, you may encounter certain resources you'd like to save, but don't need the full power of a crawler to do so (like images delivered through a CDN).
+
+By combining the <ApiLink to="core/class/Request#skipNavigation">`Request#skipNavigation`</ApiLink> option with <ApiLink to="basic-crawler/interface/BasicCrawlingContext#sendRequest">`sendRequest`</ApiLink>, we can fetch the image from the CDN, and save it to our key-value store without needing to use the full crawler.
+
+
+:::info
+
+For this example, we are using the <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> to showcase this, but this is available on all the crawlers we provide.
+
+:::
+
+<CodeBlock className="language-js">
+	{SkipNavigationSource}
+</CodeBlock>

--- a/docs/examples/skip-navigation.ts
+++ b/docs/examples/skip-navigation.ts
@@ -1,0 +1,31 @@
+import { PuppeteerCrawler, KeyValueStore } from 'crawlee';
+
+// Create a key value store for all images we find
+const imageStore = await KeyValueStore.open('images');
+
+const crawler = new PuppeteerCrawler({
+    async requestHandler({ request, page, sendRequest }) {
+        // The request should have the navigation skipped
+        if (request.skipNavigation) {
+            // Request the image and get its buffer back
+            const imageBuffer = await sendRequest({ responseType: 'buffer' });
+
+            // Save the image in the key-value store
+            await imageStore.setValue(`${request.userData.key}.png`, imageBuffer);
+
+            // Prevent executing the rest of the code as we do not need it
+            return;
+        }
+
+        // Get all the image sources in the current page
+        const images = await page.$$eval('img', (imgs) => imgs.map((img) => img.src));
+
+        // Add all the urls as requests for the crawler, giving each image a key
+        await crawler.addRequests(images.map((url, i) => ({ url, skipNavigation: true, userData: { key: i } })));
+    },
+});
+
+await crawler.addRequests(['https://apify.com/']);
+
+// Run the crawler
+await crawler.run();

--- a/docs/upgrading/upgrading_v3.md
+++ b/docs/upgrading/upgrading_v3.md
@@ -233,7 +233,7 @@ const crawler = new BasicCrawler({
 
 One small feature worth mentioning is the ability to handle requests with browser crawlers outside the browser. To do that, we can use a combination of `Request.skipNavigation` and `context.sendRequest()`.
 
-> **TODO** add example and link it from here
+Take a look at how to achieve this by checking out the [Skipping navigation for certain requests](../examples/skip-navigation) example!
 
 ## Logging
 


### PR DESCRIPTION
I didn't know if I should have created an even simpler presentation in the upgrading guide or if just linking to the example is enough...so I went with just linking as it felt more appropriate