### PR TITLE
chore: make request queue output a file per request for memory storage

### DIFF
--- a/packages/memory-storage/src/cache-helpers.ts
+++ b/packages/memory-storage/src/cache-helpers.ts
@@ -261,7 +261,7 @@ export async function findRequestQueueByPossibleId(client: MemoryStorage, entryN
     let modifiedAt = new Date();
     let pendingRequestCount = 0;
     let handledRequestCount = 0;
-    let entries: InternalRequest[] = [];
+    const entries: InternalRequest[] = [];
 
     for await (const entry of directoryEntries) {
         if (entry.isFile()) {
@@ -280,11 +280,10 @@ export async function findRequestQueueByPossibleId(client: MemoryStorage, entryN
 
                     break;
                 }
-                case 'entries.json': {
-                    entries = JSON.parse(await readFile(resolve(requestQueueDir, entry.name), 'utf8')) as InternalRequest[];
-                    break;
+                default: {
+                    const request = JSON.parse(await readFile(resolve(requestQueueDir, entry.name), 'utf8')) as InternalRequest;
+                    entries.push(request);
                 }
-                default:
             }
         }
     }

--- a/packages/memory-storage/src/utils.ts
+++ b/packages/memory-storage/src/utils.ts
@@ -67,7 +67,7 @@ export interface WorkerData {
     requestQueuesDirectory: string;
 }
 
-export type WorkerReceivedMessage = WorkerUpdateMetadataMessage | WorkerUpdateEntriesMessage;
+export type WorkerReceivedMessage = WorkerUpdateMetadataMessage | WorkerUpdateEntriesMessage | WorkerDeleteEntryMessage;
 
 export type WorkerUpdateMetadataMessage =
     | MetadataUpdate<'datasets', storage.DatasetInfo>
@@ -77,7 +77,9 @@ export type WorkerUpdateMetadataMessage =
 export type WorkerUpdateEntriesMessage =
     | EntriesUpdate<'datasets', [string, storage.Dictionary][]>
     | EntriesUpdate<'keyValueStores', KeyValueStoreItemData>
-    | EntriesUpdate<'requestQueues', InternalRequest[]>;
+    | EntriesUpdate<'requestQueues', InternalRequest>;
+
+export type WorkerDeleteEntryMessage = EntryDelete<'requestQueues'>;
 
 type EntityType = 'datasets' | 'keyValueStores' | 'requestQueues';
 
@@ -97,6 +99,17 @@ interface EntriesUpdate<Type extends EntityType, DataType> {
     entityDirectory: string;
     data: DataType;
     writeMetadata: boolean;
+}
+
+interface EntryDelete<Type extends EntityType> {
+    entityType: Type;
+    id: string;
+    action: 'delete-entry';
+    entityDirectory: string;
+    writeMetadata: boolean;
+    data: {
+        id: string;
+    };
 }
 
 interface KeyValueStoreItemData {


### PR DESCRIPTION
This should fix at least one of the worker related crashes (if your request queue explodes in size... you'll most likely encounter this)