### PR TITLE
docs: last major portion of guide updates

### DIFF
--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -130,12 +130,12 @@ Now (assuming we are already logged in to our Apify account) we can easily deplo
 apify push
 ```
 
-Our script will be uploaded to the Apify platform and built there so that it can be run. For more information, view the
+Our script will be uploaded to and built on the Apify platform so that it can be run there. For more information, view the
 [Apify Actor](https://docs.apify.com/cli) documentation.
 
 ## Usage on Apify platform
 
-We can also develop our actor in an online code editor directly on the platform (we'll need an Apify Account). Let's go to the [Actors](https://console.apify.com/actors) page in the app, click *Create new* and then go to the *Source* tab and start writing our code or paste one of the examples from the Examples section.
+We can also develop our actor in an online code editor directly on the platform (we'll need an Apify Account). Let's go to the [Actors](https://console.apify.com/actors) page in the app, click *Create new* and then go to the *Source* tab and start writing our code or paste one of the examples from the [Examples](../examples) section.
 
 ## Storages
 
@@ -145,10 +145,18 @@ There are several things worth mentioning here.
 2. In order to open the storage, we shouldn't use the storage classes, but instead use the Actor class. Thus, instead of <ApiLink to="core/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="core/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="core/class/RequestQueue#open">`RequestQueue.open()`</ApiLink>, we could use <ApiLink to="apify/class/Actor#openKeyValueStore">`Actor.openKeyValueStore()`</ApiLink>, <ApiLink to="apify/class/Actor#openDataset">`Actor.openDataset()`</ApiLink> and <ApiLink to="apify/class/Actor#openRequestQueue">`Actor.openRequestQueue()`</ApiLink> respectively. Using each of these methods allows us to pass the <ApiLink to="apify/interface/OpenStorageOptions">`OpenStorageOptions`</ApiLink> as a second argument, which has only one optional property: <ApiLink to="apify/interface/OpenStorageOptions#forceCloud">`forceCloud`</ApiLink>. If set to `true` - cloud storage will be used instead of the folder on the local disk.
 3. When the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> is stored on the `Apify platform`, we can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way you can easily share the crawling results.
 
+**Related links**
+
+- [Apify platform storage documentation](https://docs.apify.com/storage)
+- [View storage in Apify Console](https://console.apify.com/storage)
+- [Key-value stores API reference](https://apify.com/docs/api/v2#/reference/key-value-stores)
+- [Datasets API reference](https://docs.apify.com/api/v2#/reference/datasets)
+- [Request queues API reference](https://docs.apify.com/api/v2#/reference/request-queues)
+
 ## Important environment variables
 
-The following environment variables have large impact on the way Apify works and its behavior
-can be changed significantly by setting or unsetting them.
+The following environment variables have large impact on the way Actors work, and their behavior
+can be changed significantly by setting or unsetting these vars.
 
 ### `APIFY_TOKEN`
 
@@ -219,7 +227,7 @@ const proxyConfiguration = await Actor.createProxyConfiguration();
 const proxyUrl = await proxyConfiguration.newUrl();
 ```
 
-Note that unlike with Crawlee, we shouldn't use the constructor to create <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy we should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function instead.
+Note that unlike using proxy in Crawlee, we shouldn't use the constructor to create <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy we should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function instead.
 
 ### Apify Proxy vs. Own proxies
 
@@ -255,9 +263,4 @@ in the [proxy dashboard](https://console.apify.com/proxy).
 
 **Related links**
 
-- [Apify platform storage documentation](https://docs.apify.com/storage)
-- [View storage in Apify Console](https://console.apify.com/storage)
-- [Key-value stores API reference](https://apify.com/docs/api/v2#/reference/key-value-stores)
-- [Datasets API reference](https://docs.apify.com/api/v2#/reference/datasets)
-- [Request queues API reference](https://docs.apify.com/api/v2#/reference/request-queues)
 - [Apify Proxy docs](https://docs.apify.com/proxy)

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -73,6 +73,13 @@ Actors can be shared in the [Apify Store](https://apify.com/store) so that other
 But don't worry, if you share your actor in the store and somebody uses it, it runs under their account,
 not yours.
 
+**Related links**
+
+- [Store of existing actors](https://apify.com/store)
+- [Documentation](https://docs.apify.com/actors)
+- [View actors in Apify Console](https://console.apify.com/actors)
+- [API reference](https://apify.com/docs/api/v2#/reference/actors)
+
 ## Running an actor locally
 
 First let's create a boilerplate of the new actor. We could use Apify CLI and just run:
@@ -130,9 +137,18 @@ Our script will be uploaded to the Apify platform and built there so that it can
 
 We can also develop our actor in an online code editor directly on the platform (we'll need an Apify Account). Let's go to the [Actors](https://console.apify.com/actors) page in the app, click *Create new* and then go to the *Source* tab and start writing our code or paste one of the examples from the Examples section.
 
+## Storages
+
+There are several things worth mentioning here.
+
+1. Compared to Crawlee, in order to simplify access to the default <ApiLink to="core/class/KeyValueStore">`Key-Value Store`</ApiLink> and <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> we don't need to use the helper functions of storage classes, but instead, we could use <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink>, <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink> for the default `Key-Value Store` and <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> for the default `Dataset` directly.
+2. In order to open the storage, we shouldn't use the storage classes, but instead use the Actor class. Thus, instead of <ApiLink to="core/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="core/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="core/class/RequestQueue#open">`RequestQueue.open()`</ApiLink>, we could use <ApiLink to="apify/class/Actor#openKeyValueStore">`Actor.openKeyValueStore()`</ApiLink>, <ApiLink to="apify/class/Actor#openDataset">`Actor.openDataset()`</ApiLink> and <ApiLink to="apify/class/Actor#openRequestQueue">`Actor.openRequestQueue()`</ApiLink> respectively. Using each of these methods allows us to pass the <ApiLink to="apify/interface/OpenStorageOptions">`OpenStorageOptions`</ApiLink> as a second argument, which has only one optional property: <ApiLink to="apify/interface/OpenStorageOptions#forceCloud">`forceCloud`</ApiLink>. If set to `true` - cloud storage will be used instead of the folder on the local disk.
+3. When the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> is stored on the `Apify platform`, we can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way you can easily share the crawling results.
+
 **Related links**
 
-- [Store of existing actors](https://apify.com/store)
-- [Documentation](https://docs.apify.com/actors)
-- [View actors in Apify Console](https://console.apify.com/actors)
-- [API reference](https://apify.com/docs/api/v2#/reference/actors)
+- [Apify platform storage documentation](https://docs.apify.com/storage)
+- [View storage in Apify Console](https://console.apify.com/storage)
+- [Key-value stores API reference](https://apify.com/docs/api/v2#/reference/key-value-stores)
+- [Datasets API reference](https://docs.apify.com/api/v2#/reference/datasets)
+- [Request queues API reference](https://docs.apify.com/api/v2#/reference/request-queues)

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -204,6 +204,55 @@ so in most cases, we don't need to touch it. We should use it when, for some rea
 we need access to Apify Proxy, but not access to Apify API, or when we need access to
 proxy from a different account than our token represents.
 
+## Proxy management
+
+In addition to our own proxy servers and proxy servers acquired from
+third-party providers used together with Crawlee, we can also rely on [Apify Proxy](https://apify.com/proxy)
+for our scraping needs.
+
+If we are already subscribed to Apify Proxy, we can start using them immediately in only a few lines of code (for local usage we first we should be [logged in](#logging-into-apify-platform-from-crawlee) to our Apify account.
+
+```javascript
+import { Actor } from 'apify';
+
+const proxyConfiguration = await Actor.createProxyConfiguration();
+const proxyUrl = await proxyConfiguration.newUrl();
+```
+
+Note that unlike with Crawlee, we shouldn't use the constructor to create <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy we should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function instead.
+
+### Apify Proxy vs. Own proxies
+
+The `ProxyConfiguration` class covers both Apify Proxy and custom proxy URLs so that
+we can easily switch between proxy providers, however, some features of the class
+are available only to Apify Proxy users, mainly because Apify Proxy is what
+one would call a super-proxy. It's not a single proxy server, but an API endpoint
+that allows connection through millions of different IP addresses. So the class
+essentially has two modes: Apify Proxy or Own (third party) proxy.
+
+The difference is easy to remember.
+- If we're using our own proxies - we should create an instance with the ProxyConfiguration <ApiLink to="core/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
+- If we are planning to use Apify Proxy - we should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function - <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of our custom proxy URLs, whereas all the other options are there to configure Apify Proxy.
+
+### Apify Proxy Configuration
+
+With Apify Proxy, we can select specific proxy groups to use, or countries to connect from.
+This allows us to get better proxy performance after some initial research.
+
+```javascript
+import { Actor } from 'apify';
+
+const proxyConfiguration = await Actor.createProxyConfiguration({
+    groups: ['RESIDENTIAL'],
+    countryCode: 'US',
+});
+const proxyUrl = await proxyConfiguration.newUrl();
+```
+
+Now our crawlers will use only Residential proxies from the US. Note that we must first get access
+to a proxy group before We are able to use it. We can check proxy groups available to us
+in the [proxy dashboard](https://console.apify.com/proxy).
+
 **Related links**
 
 - [Apify platform storage documentation](https://docs.apify.com/storage)
@@ -211,3 +260,4 @@ proxy from a different account than our token represents.
 - [Key-value stores API reference](https://apify.com/docs/api/v2#/reference/key-value-stores)
 - [Datasets API reference](https://docs.apify.com/api/v2#/reference/datasets)
 - [Request queues API reference](https://docs.apify.com/api/v2#/reference/request-queues)
+- [Apify Proxy docs](https://docs.apify.com/proxy)

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -35,17 +35,14 @@ setting up webhooks and so on.
 Apify CLI allows you to log in to your Apify account on your computer. If you then run your
 scraper using the CLI, your credentials will automatically be added.
 
-```
+```bash
 npm install -g apify-cli
-```
-
-```
 apify login -t YOUR_API_TOKEN
 ```
 
 In your project folder:
 
-```
+```bash
 apify run -p
 ```
 
@@ -74,6 +71,6 @@ not yours.
 **Related links**
 
 - [Store of existing actors](https://apify.com/store)
-- [Documentation](https://docs.apify.com/actor)
+- [Documentation](https://docs.apify.com/actors)
 - [View actors in Apify Console](https://console.apify.com/actors)
 - [API reference](https://apify.com/docs/api/v2#/reference/actors)

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -19,7 +19,7 @@ convenient [request](../guides/request-storage) and [result](../guides/result-st
 and [more](https://docs.apify.com/), accessible through a [web interface](https://console.apify.com)
 or an [API](https://docs.apify.com/api).
 
-While we think that the Apify platform is super cool, and you should definitely sign up for a
+While we think that the Apify platform is super cool, and it's definitely worth signing up for a
 [free account](https://console.apify.com/sign-up), **Crawlee is and will always be open source**,
 runnable locally or on any cloud infrastructure.
 
@@ -32,46 +32,46 @@ architectures such as Raspberry PI. We strive to make it work, but there are no 
 
 ## Logging into Apify platform from Crawlee
 
-To access your [Apify account](https://console.apify.com/sign-up) from Crawlee, you must provide
-credentials - [your API token](https://console.apify.com/account#/integrations). You can do that
+To access our [Apify account](https://console.apify.com/sign-up) from Crawlee, we must provide
+credentials - [our API token](https://console.apify.com/account#/integrations). We can do that
 either by utilizing [Apify CLI](https://github.com/apify/apify-cli) or with environment
 variables.
 
-Once you provide credentials to your scraper, you will be able to use all the Apify platform
+Once we provide credentials to our scraper, we will be able to use all the Apify platform
 features, such as calling actors, saving to cloud storages, using Apify proxies,
 setting up webhooks and so on.
 
 ### Log in with CLI
 
-Apify CLI allows you to log in to your Apify account on your computer. If you then run your
-scraper using the CLI, your credentials will automatically be added.
+Apify CLI allows us to log in to our Apify account on our computer. If we then run our
+scraper using the CLI, our credentials will automatically be added.
 
 ```bash
 npm install -g apify-cli
-apify login -t YOUR_API_TOKEN
+apify login -t OUR_API_TOKEN
 ```
 
 ### Log in with environment variables
 
-If you prefer not to use Apify CLI, you can always provide credentials to your scraper
+Alternatively, we can always provide credentials to our scraper
 by setting the [`APIFY_TOKEN`](../guides/environment-variables#apify_token) environment
-variable to your API token.
+variable to our API token.
 
 > There's also the [`APIFY_PROXY_PASSWORD`](../guides/environment-variables#apify_proxy_password)
-> environment variable. Crawlee automatically infers that from your token, but it can be useful
-> when you need to access proxies from a different account than your token represents.
+> environment variable. Crawlee automatically infers that from our token, but it can be useful
+> when we need to access proxies from a different account than our token represents.
 
 ## What is an actor
 
-When you deploy your script to the Apify platform, it becomes an [actor](https://apify.com/actors).
+When we deploy our script to the Apify platform, it becomes an [actor](https://apify.com/actors).
 An actor is a serverless microservice that accepts an input and produces an output. It can run for
 a few seconds, hours or even infinitely. An actor can perform anything from a simple action such
 as filling out a web form or sending an email, to complex operations such as crawling an entire website
 and removing duplicates from a large dataset.
 
 Actors can be shared in the [Apify Store](https://apify.com/store) so that other people can use them.
-But don't worry, if you share your actor in the store and somebody uses it, it runs under their account,
-not yours.
+But don't worry, if we share our actor in the store and somebody uses it, it runs under their account,
+not ours.
 
 **Related links**
 
@@ -143,7 +143,7 @@ There are several things worth mentioning here.
 
 1. Compared to Crawlee, in order to simplify access to the default <ApiLink to="core/class/KeyValueStore">`Key-Value Store`</ApiLink> and <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> we don't need to use the helper functions of storage classes, but instead, we could use <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink>, <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink> for the default `Key-Value Store` and <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> for the default `Dataset` directly.
 2. In order to open the storage, we shouldn't use the storage classes, but instead use the Actor class. Thus, instead of <ApiLink to="core/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="core/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="core/class/RequestQueue#open">`RequestQueue.open()`</ApiLink>, we could use <ApiLink to="apify/class/Actor#openKeyValueStore">`Actor.openKeyValueStore()`</ApiLink>, <ApiLink to="apify/class/Actor#openDataset">`Actor.openDataset()`</ApiLink> and <ApiLink to="apify/class/Actor#openRequestQueue">`Actor.openRequestQueue()`</ApiLink> respectively. Using each of these methods allows us to pass the <ApiLink to="apify/interface/OpenStorageOptions">`OpenStorageOptions`</ApiLink> as a second argument, which has only one optional property: <ApiLink to="apify/interface/OpenStorageOptions#forceCloud">`forceCloud`</ApiLink>. If set to `true` - cloud storage will be used instead of the folder on the local disk.
-3. When the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> is stored on the `Apify platform`, we can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way you can easily share the crawling results.
+3. When the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> is stored on the `Apify platform`, we can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way we can easily share the crawling results.
 
 **Related links**
 
@@ -168,7 +168,7 @@ or to run an actor on the Apify platform. We can find our API token on the
 
 > `CRAWLEE_STORAGE_DIR` env variable description could be found in [Environment Variables](../guides/environment-variables#crawlee_storage_dir) guide.
 
-By combining the env vars in various ways, we can greatly influence the crawler's behavior.
+By combining the env vars in various ways, we can greatly influence the actor's behavior.
 
 | Env Vars                                | API | Storages         |
 | --------------------------------------- | --- | ---------------- |
@@ -181,6 +181,8 @@ features and our data will be stored locally by default. If we want to access pl
 we can use the `{ forceCloud: true }` option in their respective functions.
 
 ```js
+import { Actor } from 'apify';
+
 const localDataset = await Actor.openDataset('my-local-data');
 const remoteDataset = await Actor.openDataset('my-remote-data', { forceCloud: true });
 ```
@@ -194,7 +196,7 @@ It's important to notice that `CRAWLEE_` environment variables don't need to be 
 ## Convenience environment variables
 
 The next group includes env vars that can help achieve certain goals without having to change
-your code, such as temporarily switching log level to DEBUG.
+our code, such as temporarily switching log level to DEBUG.
 
 ### `APIFY_LOG_LEVEL`
 

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -5,6 +5,13 @@ title: Apify Platform
 
 import ApiLink from '@site/src/components/ApiLink';
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+
+import MainSource from '!!raw-loader!./apify_platform_main.ts';
+import InitExitSource from '!!raw-loader!./apify_platform_init_exit.ts';
+
 Apify is a [platform](https://apify.com) built to serve large-scale and high-performance web scraping
 and automation needs. It provides easy access to [compute instances (Actors)](#what-is-an-actor),
 convenient [request](../guides/request-storage) and [result](../guides/result-storage) storages, [proxies](../guides/proxy-management),
@@ -16,8 +23,12 @@ While we think that the Apify platform is super cool, and you should definitely 
 [free account](https://console.apify.com/sign-up), **Crawlee is and will always be open source**,
 runnable locally or on any cloud infrastructure.
 
-> Note that we do not test Crawlee in other cloud environments such as Lambda or on specific
-> architectures such as Raspberry PI. We strive to make it work, but there are no guarantees.
+:::note
+
+We do not test Crawlee in other cloud environments such as Lambda or on specific
+architectures such as Raspberry PI. We strive to make it work, but there are no guarantees.
+
+:::
 
 ## Logging into Apify platform from Crawlee
 
@@ -27,7 +38,7 @@ either by utilizing [Apify CLI](https://github.com/apify/apify-cli) or with envi
 variables.
 
 Once you provide credentials to your scraper, you will be able to use all the Apify platform
-features of Crawlee, such as calling actors, saving to cloud storages, using Apify proxies,
+features, such as calling actors, saving to cloud storages, using Apify proxies,
 setting up webhooks and so on.
 
 ### Log in with CLI
@@ -38,12 +49,6 @@ scraper using the CLI, your credentials will automatically be added.
 ```bash
 npm install -g apify-cli
 apify login -t YOUR_API_TOKEN
-```
-
-In your project folder:
-
-```bash
-apify run -p
 ```
 
 ### Log in with environment variables
@@ -67,6 +72,63 @@ and removing duplicates from a large dataset.
 Actors can be shared in the [Apify Store](https://apify.com/store) so that other people can use them.
 But don't worry, if you share your actor in the store and somebody uses it, it runs under their account,
 not yours.
+
+## Running an actor locally
+
+First let's create a boilerplate of the new actor. We could use Apify CLI and just run:
+
+```bash
+apify create my-hello-world
+```
+
+The CLI will prompt us to select a project boilerplate template - let's pick "Hello world". The tool will create a directory called `my-hello-world` with a Node.js project files. We can run the actor as follows:
+
+```bash
+cd my-hello-world
+apify run
+```
+
+## Running Crawlee code as an actor
+
+For running the Crawlee code as an actor on the [Apify platform](https://apify.com/actors) we should either:
+- wrap it into <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> function;
+- or use a combination of <ApiLink to="apify/class/Actor#init">`Actor.init()`</ApiLink> and <ApiLink to="apify/class/Actor#exit">`Actor.exit()`</ApiLink> functions.
+
+Let's look at the `CheerioCrawler` example from the [Quick Start](../guides/quick-start) guide:
+
+<Tabs>
+    <TabItem value="main" label="Using Actor.main()" default>
+        <CodeBlock language="js">
+            {MainSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="init_exit" label="Using Actor.init() and Actor.exit()">
+        <CodeBlock language="js">
+            {InitExitSource}
+        </CodeBlock>
+    </TabItem>
+</Tabs>
+
+Note that we could also run our actor (that is using Crawlee) locally with Apify CLI. We could start it via the following command in our project folder:
+
+```bash
+apify run -p
+```
+
+## Deploying an actor to Apify platform
+
+Now (assuming we are already logged in to our Apify account) we can easily deploy our code to the Apify platform by running:
+
+```bash
+apify push
+```
+
+Our script will be uploaded to the Apify platform and built there so that it can be run. For more information, view the
+[Apify Actor](https://docs.apify.com/cli) documentation.
+
+## Usage on Apify platform
+
+We can also develop our actor in an online code editor directly on the platform (we'll need an Apify Account). Let's go to the [Actors](https://console.apify.com/actors) page in the app, click *Create new* and then go to the *Source* tab and start writing our code or paste one of the examples from the Examples section.
 
 **Related links**
 

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -145,6 +145,65 @@ There are several things worth mentioning here.
 2. In order to open the storage, we shouldn't use the storage classes, but instead use the Actor class. Thus, instead of <ApiLink to="core/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="core/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="core/class/RequestQueue#open">`RequestQueue.open()`</ApiLink>, we could use <ApiLink to="apify/class/Actor#openKeyValueStore">`Actor.openKeyValueStore()`</ApiLink>, <ApiLink to="apify/class/Actor#openDataset">`Actor.openDataset()`</ApiLink> and <ApiLink to="apify/class/Actor#openRequestQueue">`Actor.openRequestQueue()`</ApiLink> respectively. Using each of these methods allows us to pass the <ApiLink to="apify/interface/OpenStorageOptions">`OpenStorageOptions`</ApiLink> as a second argument, which has only one optional property: <ApiLink to="apify/interface/OpenStorageOptions#forceCloud">`forceCloud`</ApiLink>. If set to `true` - cloud storage will be used instead of the folder on the local disk.
 3. When the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> is stored on the `Apify platform`, we can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way you can easily share the crawling results.
 
+## Important environment variables
+
+The following environment variables have large impact on the way Apify works and its behavior
+can be changed significantly by setting or unsetting them.
+
+### `APIFY_TOKEN`
+
+The API token for our Apify account. It is used to access the Apify API, e.g. to access cloud storage
+or to run an actor on the Apify platform. We can find our API token on the
+[Account - Integrations](https://console.apify.com/account#/integrations) page.
+
+### Combinations of `APIFY_TOKEN` and `CRAWLEE_STORAGE_DIR`
+
+> `CRAWLEE_STORAGE_DIR` env variable description could be found in [Environment Variables](../guides/environment-variables#crawlee_storage_dir) guide.
+
+By combining the env vars in various ways, we can greatly influence the crawler's behavior.
+
+| Env Vars                                | API | Storages         |
+| --------------------------------------- | --- | ---------------- |
+|  none OR `CRAWLEE_STORAGE_DIR`          | no  | local            |
+| `APIFY_TOKEN`                           | yes | Apify platform   |
+| `APIFY_TOKEN` AND `CRAWLEE_STORAGE_DIR` | yes | local + platform |
+
+When using both `APIFY_TOKEN` and `CRAWLEE_STORAGE_DIR`, we can use all the Apify platform
+features and our data will be stored locally by default. If we want to access platform storages,
+we can use the `{ forceCloud: true }` option in their respective functions.
+
+```js
+const localDataset = await Actor.openDataset('my-local-data');
+const remoteDataset = await Actor.openDataset('my-remote-data', { forceCloud: true });
+```
+
+:::note
+
+It's important to notice that `CRAWLEE_` environment variables don't need to be replaced with `APIFY_` ones while running first locally and then on the platform. E.g. if we have `CRAWLEE_DEFAULT_DATASET_ID` set in our project, and then we push it to the Apify platform as an Actor - this variable would still be respected by the Actor/platform.
+
+:::
+
+## Convenience environment variables
+
+The next group includes env vars that can help achieve certain goals without having to change
+your code, such as temporarily switching log level to DEBUG.
+
+### `APIFY_LOG_LEVEL`
+
+Specifies the minimum log level, which can be one of the following values (in order of severity):
+`DEBUG`, `INFO`, `WARNING` and `ERROR`. By default, the log level is set to `INFO`,
+which means that `DEBUG` messages are not printed to console. See the <ApiLink to="core/class/Log">`utils.log`</ApiLink>
+namespace for logging utilities.
+
+### `APIFY_PROXY_PASSWORD`
+
+Optional password to [Apify Proxy](https://docs.apify.com/proxy) for IP address rotation.
+Assuming Apify Account was already created, we can find the password on the [Proxy page](https://console.apify.com/proxy)
+in the Apify Console. The password is automatically inferred using the `APIFY_TOKEN` env var,
+so in most cases, we don't need to touch it. We should use it when, for some reason,
+we need access to Apify Proxy, but not access to Apify API, or when we need access to
+proxy from a different account than our token represents.
+
 **Related links**
 
 - [Apify platform storage documentation](https://docs.apify.com/storage)

--- a/docs/guides/apify_platform_init_exit.ts
+++ b/docs/guides/apify_platform_init_exit.ts
@@ -1,0 +1,33 @@
+import { Actor } from 'apify'
+import { CheerioCrawler } from "@crawlee/cheerio";
+
+await Actor.init();
+
+const proxyConfiguration = await Actor.createProxyConfiguration();
+
+const crawler = new CheerioCrawler({
+    proxyConfiguration,
+    async requestHandler({ request, $, enqueueLinks }) {
+        const { url } = request;
+
+        // Extract HTML title of the page.
+        const title = $('title').text();
+        console.log(`Title of ${url}: ${title}`);
+
+        // Add URLs that match the provided pattern.
+        await enqueueLinks({
+            globs: ['https://www.iana.org/*'],
+        });
+
+        // Save extracted data to dataset.
+        await Actor.pushData({ url, title });
+    },
+});
+
+// Choose the first URL to open.
+await crawler.addRequests([{ url: 'https://www.iana.org/' }]);
+
+// Start the crawler.
+await crawler.run();
+
+await Actor.exit();

--- a/docs/guides/apify_platform_init_exit.ts
+++ b/docs/guides/apify_platform_init_exit.ts
@@ -3,10 +3,7 @@ import { CheerioCrawler } from "@crawlee/cheerio";
 
 await Actor.init();
 
-const proxyConfiguration = await Actor.createProxyConfiguration();
-
 const crawler = new CheerioCrawler({
-    proxyConfiguration,
     async requestHandler({ request, $, enqueueLinks }) {
         const { url } = request;
 

--- a/docs/guides/apify_platform_main.ts
+++ b/docs/guides/apify_platform_main.ts
@@ -1,0 +1,31 @@
+import { Actor } from 'apify'
+import { CheerioCrawler } from "@crawlee/cheerio";
+
+await Actor.main(async () => {
+    const proxyConfiguration = await Actor.createProxyConfiguration();
+
+    const crawler = new CheerioCrawler({
+        proxyConfiguration,
+        async requestHandler({ request, $, enqueueLinks }) {
+            const { url } = request;
+
+            // Extract HTML title of the page.
+            const title = $('title').text();
+            console.log(`Title of ${url}: ${title}`);
+
+            // Add URLs that match the provided pattern.
+            await enqueueLinks({
+                globs: ['https://www.iana.org/*'],
+            });
+
+            // Save extracted data to dataset.
+            await Actor.pushData({ url, title });
+        },
+    });
+
+    // Choose the first URL to open.
+    await crawler.addRequests([{ url: 'https://www.iana.org/' }]);
+
+    // Start the crawler.
+    await crawler.run();
+});

--- a/docs/guides/apify_platform_main.ts
+++ b/docs/guides/apify_platform_main.ts
@@ -2,10 +2,7 @@ import { Actor } from 'apify'
 import { CheerioCrawler } from "@crawlee/cheerio";
 
 await Actor.main(async () => {
-    const proxyConfiguration = await Actor.createProxyConfiguration();
-
     const crawler = new CheerioCrawler({
-        proxyConfiguration,
         async requestHandler({ request, $, enqueueLinks }) {
             const { url } = request;
 

--- a/docs/guides/environment_variables.mdx
+++ b/docs/guides/environment_variables.mdx
@@ -7,76 +7,51 @@ import ApiLink from '@site/src/components/ApiLink';
 
 The following is a list of the environment variables used by Crawlee that are available to the user.
 Crawlee is capable of running without any env vars present, but certain features will only become available
-after env vars are properly set. You can use [Apify CLI](https://github.com/apify/apify-cli)
-to set the env vars for you. [Apify platform](../guides/apify-platform) also sets the variables automatically.
+after env vars are properly set.
 
 ## Important env vars
 
 The following environment variables have large impact on the way Crawlee works and its behavior
 can be changed significantly by setting or unsetting them.
 
-### `APIFY_LOCAL_STORAGE_DIR`
+### `CRAWLEE_STORAGE_DIR`
 
-Defines the path to a local directory where <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="core/class/Dataset">`Dataset`</ApiLink>, and <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> store their data. Typically, it is set to `./apify_storage`. If omitted, you should define the [`APIFY_TOKEN`](#apify_token) environment variable instead.
+Defines the path to a local directory where <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="core/class/Dataset">`Dataset`</ApiLink>, and <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> store their data. By default, it is set to `./crawlee_storage`.
 
-### `APIFY_TOKEN`
+### `CRAWLEE_DEFAULT_DATASET_ID`
 
-The API token for your Apify account. It is used to access the Apify API, e.g. to access cloud storage
-or to run an actor on the Apify platform. You can find your API token on the
-[Account - Integrations](https://console.apify.com/account#/integrations) page. If omitted,
-you should define the `APIFY_LOCAL_STORAGE_DIR` environment variable instead.
+The default dataset has ID `default`, unless we override it by setting the `CRAWLEE_DEFAULT_DATASET_ID` environment variable.
 
-### Combinations of `APIFY_LOCAL_STORAGE_DIR` and `APIFY_TOKEN`
+### `CRAWLEE_DEFAULT_KEY_VALUE_STORE_ID`
 
-By combining the env vars in various ways, you can greatly influence the Crawlee's behavior.
+The default key-value store has ID `default`, unless we override it by setting the `CRAWLEE_DEFAULT_KEY_VALUE_STORE_ID` environment variable.
 
-| Env Vars                                    | API | Storages       |
-| ------------------------------------------- | --- | -------------- |
-|  none OR `APIFY_LOCAL_STORAGE_DIR`          | no  | local          |
-| `APIFY_TOKEN`                               | yes | Apify platform |
-| `APIFY_TOKEN` AND `APIFY_LOCAL_STORAGE_DIR` | yes | local+platform |
+### `CRAWLEE_DEFAULT_REQUEST_QUEUE_ID`
 
-When using both `APIFY_TOKEN` and `APIFY_LOCAL_STORAGE_DIR`, you can use all the Apify platform
-features and your data will be stored locally by default. If you want to access platform storages,
-you can use the `{ forceCloud: true }` option in their respective functions.
+The default request queue has ID `default`, unless we override it by setting the `CRAWLEE_DEFAULT_REQUEST_QUEUE_ID` environment variable.
 
-```js
-const localDataset = await Actor.openDataset('my-local-data');
-const remoteDataset = await Actor.openDataset('my-remote-data', { forceCloud: true });
-```
+### `CRAWLEE_PURGE_ON_START`
+
+If set to `false` - local storage directories would not be purged automatically at the start of the crawler run or before opening of some storage explicitly (e.g. via `Dataset.open()`). Useful if we're trying e.g. to add more items to dataset with each next run (and keep the previously saved/scraped items). Enabled by default.
 
 ## Convenience env vars
 
 The next group includes env vars that can help achieve certain goals without having to change
-your code, such as temporarily switching log level to DEBUG.
+our code, such as temporarily enabling verbose logging for errors.
 
-### `APIFY_HEADLESS`
+### `CRAWLEE_HEADLESS`
 
-If set to `1`, web browsers launched by Crawlee will run in the headless mode. You can still override
-this setting in the code, e.g. by passing the `headless: true` option to the <ApiLink to="puppeteer-crawler/function/launchPuppeteer">`launchPuppeteer()`</ApiLink> function. But having this setting
-in an environment variable allows you to develop the crawler locally in headful mode to simplify the debugging,
-and only run the crawler in headless mode once you deploy it to the Apify platform. By default, the browsers
+If set to `1`, web browsers launched by Crawlee will run in the headless mode. We can still override
+this setting in the code, e.g. by passing the `headless: true` option to the <ApiLink to="puppeteer-crawler/function/launchPuppeteer">`launchPuppeteer()`</ApiLink> function. By default, the browsers
 are launched in headful mode, i.e. with windows.
 
-### `APIFY_LOG_LEVEL`
+### `CRAWLEE_VERBOSE_LOG`
 
-Specifies the minimum log level, which can be one of the following values (in order of severity):
-`DEBUG`, `INFO`, `WARNING` and `ERROR`. By default, the log level is set to `INFO`,
-which means that `DEBUG` messages are not printed to console. See the <ApiLink to="core/class/Log">`utils.log`</ApiLink>
-namespace for logging utilities.
+Enables verbose logging if set to `true`. If not explicitly set to `true` - for errors thrown from inside request handler a warning with only error message will be logged as long as we know the request will be retried. Same applies to some known errors (such as timeout errors). Disabled by default.
 
-### `APIFY_MEMORY_MBYTES`
+### `CRAWLEE_MEMORY_MBYTES`
 
 Sets the amount of system memory in megabytes to be used by the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink>.
 It is used to limit the number of concurrently running tasks. By default, the max amount of memory
 to be used is set to one quarter of total system memory, i.e. on a system with 8192 MB of memory,
 the autoscaling feature will only use up to 2048 MB of memory.
-
-### `APIFY_PROXY_PASSWORD`
-
-Optional password to [Apify Proxy](https://docs.apify.com/proxy) for IP address rotation.
-If you have an Apify Account, you can find the password on the [Proxy page](https://console.apify.com/proxy)
-in the Apify Console. The password is automatically inferred using the `APIFY_TOKEN` env var,
-so in most cases, you don't need to touch it. You should use it when, for some reason,
-you need access to Apify Proxy, but no access to Apify API, or when you need access to
-proxy from a different account than your token represents.

--- a/docs/guides/request_storage.mdx
+++ b/docs/guides/request_storage.mdx
@@ -34,7 +34,7 @@ The request queue is managed by <ApiLink to="memory-storage/class/MemoryStorage"
 
 :::note
 
-`{QUEUE_ID}` is the name or ID of the request queue. The default queue has ID `default`, unless we override it by setting the `APIFY_DEFAULT_REQUEST_QUEUE_ID` environment variable.
+`{QUEUE_ID}` is the name or ID of the request queue. The default queue has ID `default`, unless we override it by setting the `CRAWLEE_DEFAULT_REQUEST_QUEUE_ID` environment variable.
 
 :::
 

--- a/docs/guides/result_storage.mdx
+++ b/docs/guides/result_storage.mdx
@@ -25,7 +25,7 @@ The data is stored in the directory specified by the `CRAWLEE_STORAGE_DIR` envir
 
 :::note
 
-`{STORE_ID}` is the name or the ID of the key-value store. The default key-value store has ID `default`, unless we override it by setting the `APIFY_DEFAULT_KEY_VALUE_STORE_ID` environment variable. The `{KEY}` is the key of the record and `{EXT}` corresponds to the MIME content type of the data value.
+`{STORE_ID}` is the name or the ID of the key-value store. The default key-value store has ID `default`, unless we override it by setting the `CRAWLEE_DEFAULT_KEY_VALUE_STORE_ID` environment variable. The `{KEY}` is the key of the record and `{EXT}` corresponds to the MIME content type of the data value.
 
 :::
 
@@ -75,7 +75,7 @@ The data is stored in the directory specified by the `CRAWLEE_STORAGE_DIR` envir
 
 :::note
 
-`{DATASET_ID}` is the name or the ID of the dataset. The default dataset has ID `default`, unless we override it by setting the `APIFY_DEFAULT_DATASET_ID` environment variable. Each dataset item is stored as a separate JSON file, where `{INDEX}` is a zero-based index of the item in the dataset.
+`{DATASET_ID}` is the name or the ID of the dataset. The default dataset has ID `default`, unless we override it by setting the `CRAWLEE_DEFAULT_DATASET_ID` environment variable. Each dataset item is stored as a separate JSON file, where `{INDEX}` is a zero-based index of the item in the dataset.
 
 :::
 

--- a/docs/upgrading/upgrading_v3.md
+++ b/docs/upgrading/upgrading_v3.md
@@ -215,7 +215,7 @@ await result.waitForAllRequestsToBeAdded;
 
 ## Less verbose error logging
 
-Previously an error throw from inside request handler resulted in full error object being logger. With crawlee, we log only the error message as a warning as long as we know the request will be retried. If you want to enable verbose logging as in v2, use `CRAWLEE_VERBOSE_LOG` env var.
+Previously an error thrown from inside request handler resulted in full error object being logged. With crawlee, we log only the error message as a warning as long as we know the request will be retried. If you want to enable verbose logging as in v2, use `CRAWLEE_VERBOSE_LOG` env var.
 
 ## Removal of `requestAsBrowser`
 

--- a/packages/apify/src/configuration.ts
+++ b/packages/apify/src/configuration.ts
@@ -24,20 +24,27 @@ export interface ConfigurationOptions extends CoreConfigurationOptions {
  * `Configuration` is a value object holding the SDK configuration. We can use it in two ways:
  *
  * 1. When using `Actor` class, we can get the instance configuration via `sdk.config`
- *   ```js
- *   import { Actor } from 'apify';
  *
- *   const sdk = new Actor({ token: '123' });
- *   console.log(sdk.config.get('token')); // '123'
- *   const crawler = new BasicCrawler({ ... }, config);
- *   ```
+ *    ```javascript
+ *    import { Actor } from 'apify';
+ *    import { BasicCrawler } from 'crawlee';
+ *
+ *    const sdk = new Actor({ token: '123' });
+ *    console.log(sdk.config.get('token')); // '123'
+ *
+ *    const crawler = new BasicCrawler({
+ *        // ... crawler options
+ *    }, sdk.config);
+ *    ```
+ *
  * 2. To get the global configuration (singleton instance). It will respect the environment variables.
- *   ```js
- *   import { BasicCrawler, Configuration } from 'crawlee';
  *
- *   const config = new Configuration({ persistStateIntervalMillis: 30_000 });
- *   const crawler = new BasicCrawler({ ... }, config);
- *   ```
+ *    ```javascript
+ *    import { BasicCrawler, Configuration } from 'crawlee';
+ *
+ *    const config = new Configuration({ persistStateIntervalMillis: 30_000 });
+ *    const crawler = new BasicCrawler({ ... }, config);
+ *    ```
  *
  * ## Supported Configuration Options
  *


### PR DESCRIPTION
Mainly:
- env vars guide
- apify platform guide.

Would appreciate a feedback on both. For env vars - that I did not mess up anything in CRAWLEE_/APIFY_ part. For platform - I tried to make sure all previous platform related content is there (and not in the other guide). But still - order,  maybe I missed something etc.

There are several smaller things I need to take care for other guides (some examples, update gifs, you -> we), but I would probably do it in next PR and probably after API docs check as it's really non-important stuff I'd say and it's just a very few places.

Few random things I noticed while checking the examples etc:
1. `APIFY_` vs `CRAWLEE_` env vars -> if I set `process.env.CRAWLEE_LOG_LEVEL` locally to `DEBUG` - it would not show debug messages. With `log.setLevel(log.LEVELS.DEBUG);` it works. Is it expected to be this way?
2. If I am logged out of APIFY account locally and create a configuration with `const sdk = new Actor({ token: 'xxx' })` with proper token and then try to `sdk.createProxyConfiguration()` it would fail - am I doing something wrong or is it a bug? I would expect that creating an instance while explicitly providing the token should then work with proxy (and maybe other places where the token is used).