### PR TITLE
feat: prevent hybrid plugins from being used with browser-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * `Session#getPuppeteerCookies` and `Session#setPuppeteerCookies` have been renamed to `Session#getCookies` and `Session#setCookies` respectively.
 * The default `maxConcurrency` for AutoscaledPool has been lowered to 200 from 1000.
   * This means the default `maxConcurrency` for all crawlers is also 200 now.
+* For BrowserPool users, you can no longer mix and match different browser plugin types (for example you can no longer have a pool with puppeteer and playwright plugins in it). Instead, it's expected that all plugins present will match the same class as the first plugin provided.
 
 ## [2.3.2](https://github.com/apify/apify-ts/compare/v2.3.1...v2.3.2) (2022-05-05)
 

--- a/docs/upgrading/upgrading_v3.md
+++ b/docs/upgrading/upgrading_v3.md
@@ -19,7 +19,7 @@ Moreover, the Crawlee library is published as several packages under `@crawlee` 
 - `@crawlee/core`: the base for all the crawler implementations, also contains things like `Request`, `RequestQueue`, `RequestList` or `Dataset` classes
 - `@crawlee/basic`: exports `BasicCrawler`
 - `@crawlee/cheerio`: exports `CheerioCrawler`
-- `@crawlee/browser`: exports `BrowserCrawler`
+- `@crawlee/browser`: exports `BrowserCrawler` (which is used for creating `@crawlee/playwright` and `@crawlee/puppeteer`)
 - `@crawlee/playwright`: exports `PlaywrightCrawler`
 - `@crawlee/puppeteer`: exports `PuppeteerCrawler`
 - `@crawlee/memory-storage`: `@apify/storage-local` alternative
@@ -272,17 +272,27 @@ Last but not least, `retry.limit` is set to `0`. This is because `crawlee` has i
 
 For more info please refer to the Got [documentation](https://github.com/sindresorhus/got#documentation).
 
-### Removed options
+## Removed options
 
 The `useInsecureHttpParser` option has been removed. It's permanently set to `true` in order to better mimic browsers' behavior.
 
 Got Scraping automatically performs protocol negotiation, hence we removed the `useHttp2` option. It's set to `true` - 100% of browsers nowadays are capable of HTTP/2 requests. Oh, more and more of the web is using it too!
 
-### Renamed options
+### Browser pool plugin mixing
+
+Previously, you were able to have a browser pool that would mix Puppeteer and Playwright plugins (or even your own custom plugins if you've built any). As of this version, that is no longer allowed, and creating such a browser pool will cause an error to be thrown (it's expected that all plugins that will be used are of the same type).
+
+:::info Confused?
+
+All this disallows is mixing Puppeteer with Playwright for example. You can still create pools that use multiple Playwright plugins, each with a different launcher.
+
+:::
+
+## Renamed options
 
 In the `requestAsBrowser` approach, some of the options were named differently. Here's a list of renamed options:
 
-#### `payload`
+### `payload`
 
 This options represents the body to send. It could be a `string` or a `Buffer`. However there is no `payload` option anymore. You need to use `body` instead. Or, if you wish to send JSON, `json`. Here's an example:
 
@@ -298,7 +308,7 @@ await gotScraping({ …, body: Buffer.from('c0ffe', 'hex') });
 await gotScraping({ …, json: { hello: 'world' } });
 ```
 
-#### `ignoreSslErrors`
+### `ignoreSslErrors`
 
 It has been renamed to `https.rejectUnauthorized`. By default it's set to `false` for covenience. However, if you want to make sure the connection is secure, you can do the following:
 
@@ -312,7 +322,7 @@ await gotScraping({ …, https: { rejectUnauthorized: true } });
 
 Please note: the meanings are opposite! So we needed to invert the values as well.
 
-#### `header-generator` options
+### `header-generator` options
 
 `useMobileVersion`, `languageCode` and `countryCode` no longer exist. Instead, you need to use `headerGeneratorOptions` directly:
 
@@ -335,7 +345,7 @@ await gotScraping({
 });
 ```
 
-#### `timeoutSecs`
+### `timeoutSecs`
 
 In order to set a timeout, use `timeout.request` (which is **milliseconds** now).
 
@@ -355,15 +365,15 @@ await gotScraping({
 });
 ```
 
-#### `throwOnHttpErrors`
+### `throwOnHttpErrors`
 
 `throwOnHttpErrors` → `throwHttpErrors`. This options throws on unsuccessful HTTP status codes, for example `404`. By default, it's set to `false`.
 
-#### `decodeBody`
+### `decodeBody`
 
 `decodeBody` → `decompress`. This options decompresses the body. Defaults to `true` - please do not change this or websites will break (unless you know what you're doing!).
 
-#### `abortFunction`
+### `abortFunction`
 
 This function used to make the promise throw on specific responses, if it returned `true`. However it wasn't that useful.
 

--- a/docs/upgrading/upgrading_v3.md
+++ b/docs/upgrading/upgrading_v3.md
@@ -272,27 +272,17 @@ Last but not least, `retry.limit` is set to `0`. This is because `crawlee` has i
 
 For more info please refer to the Got [documentation](https://github.com/sindresorhus/got#documentation).
 
-## Removed options
+### Removed options
 
 The `useInsecureHttpParser` option has been removed. It's permanently set to `true` in order to better mimic browsers' behavior.
 
 Got Scraping automatically performs protocol negotiation, hence we removed the `useHttp2` option. It's set to `true` - 100% of browsers nowadays are capable of HTTP/2 requests. Oh, more and more of the web is using it too!
 
-### Browser pool plugin mixing
-
-Previously, you were able to have a browser pool that would mix Puppeteer and Playwright plugins (or even your own custom plugins if you've built any). As of this version, that is no longer allowed, and creating such a browser pool will cause an error to be thrown (it's expected that all plugins that will be used are of the same type).
-
-:::info Confused?
-
-As an example, this change disallows a pool to mix Puppeteer with Playwright. You can still create pools that use multiple Playwright plugins, each with a different launcher if you want!
-
-:::
-
-## Renamed options
+### Renamed options
 
 In the `requestAsBrowser` approach, some of the options were named differently. Here's a list of renamed options:
 
-### `payload`
+#### `payload`
 
 This options represents the body to send. It could be a `string` or a `Buffer`. However there is no `payload` option anymore. You need to use `body` instead. Or, if you wish to send JSON, `json`. Here's an example:
 
@@ -308,7 +298,7 @@ await gotScraping({ …, body: Buffer.from('c0ffe', 'hex') });
 await gotScraping({ …, json: { hello: 'world' } });
 ```
 
-### `ignoreSslErrors`
+#### `ignoreSslErrors`
 
 It has been renamed to `https.rejectUnauthorized`. By default it's set to `false` for covenience. However, if you want to make sure the connection is secure, you can do the following:
 
@@ -322,7 +312,7 @@ await gotScraping({ …, https: { rejectUnauthorized: true } });
 
 Please note: the meanings are opposite! So we needed to invert the values as well.
 
-### `header-generator` options
+#### `header-generator` options
 
 `useMobileVersion`, `languageCode` and `countryCode` no longer exist. Instead, you need to use `headerGeneratorOptions` directly:
 
@@ -345,7 +335,7 @@ await gotScraping({
 });
 ```
 
-### `timeoutSecs`
+#### `timeoutSecs`
 
 In order to set a timeout, use `timeout.request` (which is **milliseconds** now).
 
@@ -365,15 +355,15 @@ await gotScraping({
 });
 ```
 
-### `throwOnHttpErrors`
+#### `throwOnHttpErrors`
 
 `throwOnHttpErrors` → `throwHttpErrors`. This options throws on unsuccessful HTTP status codes, for example `404`. By default, it's set to `false`.
 
-### `decodeBody`
+#### `decodeBody`
 
 `decodeBody` → `decompress`. This options decompresses the body. Defaults to `true` - please do not change this or websites will break (unless you know what you're doing!).
 
-### `abortFunction`
+#### `abortFunction`
 
 This function used to make the promise throw on specific responses, if it returned `true`. However it wasn't that useful.
 
@@ -396,6 +386,16 @@ promise.on('request', request => {
 
 const response = await promise;
 ```
+
+## Removal of browser pool plugin mixing
+
+Previously, you were able to have a browser pool that would mix Puppeteer and Playwright plugins (or even your own custom plugins if you've built any). As of this version, that is no longer allowed, and creating such a browser pool will cause an error to be thrown (it's expected that all plugins that will be used are of the same type).
+
+:::info Confused?
+
+As an example, this change disallows a pool to mix Puppeteer with Playwright. You can still create pools that use multiple Playwright plugins, each with a different launcher if you want!
+
+:::
 
 ## Handling requests outside of browser
 

--- a/docs/upgrading/upgrading_v3.md
+++ b/docs/upgrading/upgrading_v3.md
@@ -284,7 +284,7 @@ Previously, you were able to have a browser pool that would mix Puppeteer and Pl
 
 :::info Confused?
 
-All this disallows is mixing Puppeteer with Playwright for example. You can still create pools that use multiple Playwright plugins, each with a different launcher.
+As an example, this change disallows a pool to mix Puppeteer with Playwright. You can still create pools that use multiple Playwright plugins, each with a different launcher if you want!
 
 :::
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20766,7 +20766,7 @@
                 "@crawlee/core": "^3.0.0",
                 "@crawlee/types": "^3.0.0",
                 "@crawlee/utils": "^3.0.0",
-                "apify-client": "2.6.0-beta.1",
+                "apify-client": "^2.6.0-beta.1",
                 "ow": "^0.28.1",
                 "semver": "^7.3.7",
                 "ws": "^7.5.8"

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -220,7 +220,7 @@ export interface BrowserPoolHooks<
  * import playwright from 'playwright';
  *
  * const browserPool = new BrowserPool({
- *     browserPlugins: [ new PlaywrightPlugin(playwright.chromium)],
+ *     browserPlugins: [new PlaywrightPlugin(playwright.chromium)],
  *     preLaunchHooks: [(pageId, launchContext) => {
  *         // do something before a browser gets launched
  *         launchContext.launchOptions.headless = false;
@@ -429,12 +429,11 @@ export class BrowserPool<
      *         new PlaywrightPlugin(playwright.chromium),
      *         new PlaywrightPlugin(playwright.firefox),
      *         new PlaywrightPlugin(playwright.webkit),
-     *         new PuppeteerPlugin(puppeteer),
      *     ]
      * });
      *
      * const pages = await browserPool.newPageWithEachPlugin();
-     * const [chromiumPage, firefoxPage, webkitPage, puppeteerPage] = pages;
+     * const [chromiumPage, firefoxPage, webkitPage] = pages;
      * ```
      */
     async newPageWithEachPlugin(
@@ -775,6 +774,7 @@ export class BrowserPool<
         ];
         this.postPageCreateHooks = [
             createPostPageCreateHook(this.fingerprintInjector!),
+            ...this.postPageCreateHooks,
         ];
     }
 }

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -336,12 +336,8 @@ export class BrowserPool<
                 const firstPluginName = firstPluginConstructor.name;
                 const providedPluginName = (providedPlugin as BrowserPlugin).constructor.name;
 
-                throw new Error(
-                    [
-                        `Browser plugin at index ${i} (${providedPluginName}) is not an instance of the same plugin`,
-                        `as the first plugin provided (${firstPluginName}).`,
-                    ].join(' '),
-                );
+                // eslint-disable-next-line max-len
+                throw new Error(`Browser plugin at index ${i} (${providedPluginName}) is not an instance of the same plugin as the first plugin provided (${firstPluginName}).`);
             }
         }
 

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -327,6 +327,24 @@ export class BrowserPool<
             fingerprintOptions = {},
         } = options;
 
+        const firstPluginConstructor = browserPlugins[0].constructor as typeof BrowserPlugin;
+
+        for (let i = 1; i < browserPlugins.length; i++) {
+            const providedPlugin = browserPlugins[i];
+
+            if (!(providedPlugin instanceof firstPluginConstructor)) {
+                const firstPluginName = firstPluginConstructor.name;
+                const providedPluginName = (providedPlugin as BrowserPlugin).constructor.name;
+
+                throw new Error(
+                    [
+                        `Browser plugin at index ${i} (${providedPluginName}) is not an instance of the same plugin`,
+                        `as the first plugin provided (${firstPluginName}).`,
+                    ].join(' '),
+                );
+            }
+        }
+
         this.browserPlugins = browserPlugins as unknown as BrowserPlugins;
         this.maxOpenPagesPerBrowser = maxOpenPagesPerBrowser;
         this.retireBrowserAfterPageCount = retireBrowserAfterPageCount;

--- a/packages/browser-pool/src/index.ts
+++ b/packages/browser-pool/src/index.ts
@@ -54,3 +54,9 @@ export type {
     GetFingerprintReturn,
 } from './fingerprinting/types';
 export type { InferBrowserPluginArray } from './utils';
+export type {
+    PuppeteerController,
+} from './puppeteer/puppeteer-controller';
+export type {
+    PlaywrightController,
+} from './playwright/playwright-controller';

--- a/packages/browser-pool/test/changing-page-options.test.ts
+++ b/packages/browser-pool/test/changing-page-options.test.ts
@@ -1,0 +1,94 @@
+import type { PrePageCreateHook, PuppeteerController, PlaywrightController } from '@crawlee/browser-pool';
+import { BrowserPool, PuppeteerPlugin, PlaywrightPlugin } from '@crawlee/browser-pool';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import puppeteer from 'puppeteer';
+import playwright from 'playwright';
+import type { Server as ProxyChainServer } from 'proxy-chain';
+import { promisify } from 'node:util';
+import { createProxyServer } from '../../../test/browser-pool/browser-plugins/create-proxy-server';
+
+describe.each([
+    ['Puppeteer', new PuppeteerPlugin(puppeteer, { useIncognitoPages: true })],
+    ['Playwright', new PlaywrightPlugin(playwright.chromium, {
+        useIncognitoPages: true,
+        launchOptions: {
+            args: [
+                // Exclude loopback interface from proxy bypass list,
+                // so the request to localhost goes through proxy.
+                // This way there's no need for a 3rd party server.
+                '--proxy-bypass-list=<-loopback>',
+            ],
+        },
+    })], // Chromium is faster than firefox and webkit
+])('BrowserPool - %s - prePageCreateHooks > should allow changing pageOptions', (_, plugin) => {
+    let target: http.Server;
+    let protectedProxy: ProxyChainServer;
+
+    beforeAll(async () => {
+        target = http.createServer((request, response) => {
+            response.end(request.socket.remoteAddress);
+        });
+        await promisify(target.listen.bind(target) as any)(0, '127.0.0.1');
+
+        protectedProxy = createProxyServer('127.0.0.2', 'foo', 'bar');
+        await protectedProxy.listen();
+    });
+
+    afterAll(async () => {
+        await promisify(target.close.bind(target))();
+
+        await protectedProxy.close(false);
+    });
+
+    test('should allow changing pageOptions', async () => {
+        const hook: PrePageCreateHook<PlaywrightController | PuppeteerController> = (_pageId, _controller, pageOptions) => {
+            if (!pageOptions) {
+                expect(false).toBe(true);
+                return;
+            }
+
+            const newOptions = {
+                // Puppeteer options
+                proxyServer: `http://127.0.0.2:${protectedProxy.port}`,
+                proxyUsername: 'foo',
+                proxyPassword: 'bar',
+                proxyBypassList: ['<-loopback>'],
+
+                // Playwright options
+                proxy: {
+                    server: `http://127.0.0.2:${protectedProxy.port}`,
+                    username: 'foo',
+                    password: 'bar',
+                    bypass: '<-loopback>',
+                },
+            };
+
+            Object.assign(pageOptions, newOptions);
+        };
+
+        const pool = new BrowserPool({
+            browserPlugins: [plugin],
+            prePageCreateHooks: [hook],
+        });
+
+        try {
+            const page = await pool.newPage();
+
+            try {
+                const response = await page.goto(`http://127.0.0.1:${(target.address() as AddressInfo).port}`);
+                const content = await response!.text();
+
+                // Fails on Windows.
+                // See https://github.com/puppeteer/puppeteer/issues/7698
+                if (process.platform !== 'win32') {
+                    expect(content).toBe('127.0.0.3');
+                }
+            } finally {
+                await page.close();
+            }
+        } finally {
+            await pool.destroy();
+        }
+    });
+});

--- a/packages/browser-pool/test/changing-page-options.test.ts
+++ b/packages/browser-pool/test/changing-page-options.test.ts
@@ -82,7 +82,7 @@ describe.each([
                 // Fails on Windows.
                 // See https://github.com/puppeteer/puppeteer/issues/7698
                 if (process.platform !== 'win32') {
-                    expect(content).toBe('127.0.0.3');
+                    expect(content).toBe('127.0.0.2');
                 }
             } finally {
                 await page.close();

--- a/packages/browser-pool/test/multiple-plugins.test.ts
+++ b/packages/browser-pool/test/multiple-plugins.test.ts
@@ -1,0 +1,79 @@
+import { BrowserPool, PlaywrightPlugin } from '@crawlee/browser-pool';
+import playwright from 'playwright';
+
+describe('BrowserPool - Using multiple plugins', () => {
+    let browserPool: BrowserPool<{ browserPlugins: [PlaywrightPlugin, PlaywrightPlugin]; closeInactiveBrowserAfterSecs: 2 }>;
+    const chromePlugin = new PlaywrightPlugin(playwright.chromium);
+    const firefoxPlugin = new PlaywrightPlugin(playwright.firefox);
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        browserPool = new BrowserPool({
+            browserPlugins: [
+                chromePlugin,
+                firefoxPlugin,
+            ],
+            closeInactiveBrowserAfterSecs: 2,
+        });
+    });
+
+    afterEach(async () => {
+        await browserPool?.destroy();
+    });
+
+    test('should open new page in correct plugin', async () => {
+        const page = await browserPool.newPage({
+            browserPlugin: firefoxPlugin,
+        });
+
+        const controller = browserPool.getBrowserControllerByPage(page)!;
+        expect(controller.launchContext.browserPlugin).toBe(firefoxPlugin);
+    });
+
+    test('should loop through plugins round-robin', async () => {
+        const correctPluginOrder = [
+            chromePlugin,
+            firefoxPlugin,
+        ];
+
+        const pagePromises = correctPluginOrder.map(() => browserPool.newPage());
+
+        const pages = await Promise.all(pagePromises);
+
+        expect(pages).toHaveLength(correctPluginOrder.length);
+        expect(browserPool.activeBrowserControllers.size).toEqual(2);
+
+        for (const [idx, page] of pages.entries()) {
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+            const { browserPlugin } = controller.launchContext;
+            const correctPlugin = correctPluginOrder[idx];
+            expect(browserPlugin).toBe(correctPlugin);
+        }
+    });
+
+    test('newPageWithEachPlugin should open all pages', async () => {
+        const [chromePage, firefoxPage] = await browserPool.newPageWithEachPlugin();
+        const chromeController = browserPool.getBrowserControllerByPage(chromePage)!;
+        const firefoxController = browserPool.getBrowserControllerByPage(firefoxPage)!;
+        expect(chromeController.launchContext.browserPlugin).toBe(chromePlugin);
+        expect(firefoxController.launchContext.browserPlugin).toBe(firefoxPlugin);
+    });
+
+    test('newPageWithEachPlugin should open in existing browsers', async () => {
+        jest.spyOn(chromePlugin, 'launch');
+        jest.spyOn(firefoxPlugin, 'launch');
+
+        // launch 2 browsers
+        await browserPool.newPage();
+        await browserPool.newPage();
+        expect(chromePlugin.launch).toHaveBeenCalledTimes(1);
+        expect(firefoxPlugin.launch).toHaveBeenCalledTimes(1);
+        expect(browserPool.activeBrowserControllers.size).toBe(2);
+
+        // Open more pages
+        await browserPool.newPageWithEachPlugin();
+        expect(chromePlugin.launch).toHaveBeenCalledTimes(1);
+        expect(firefoxPlugin.launch).toHaveBeenCalledTimes(1);
+        expect(browserPool.activeBrowserControllers.size).toBe(2);
+    });
+});

--- a/packages/browser-pool/test/no-hybrid-plugins.test.ts
+++ b/packages/browser-pool/test/no-hybrid-plugins.test.ts
@@ -1,0 +1,18 @@
+import puppeteer from 'puppeteer';
+import playwright from 'playwright';
+import { BrowserPool, PlaywrightPlugin, PuppeteerPlugin } from '@crawlee/browser-pool';
+
+describe('Hybrid BrowserPool plugins should not be allowed', () => {
+    test('mixing Puppeteer with Playwright should throw an error', () => {
+        expect(() => new BrowserPool({
+            browserPlugins: [new PuppeteerPlugin(puppeteer), new PlaywrightPlugin(playwright.chromium)],
+        }),
+        ).toThrowError();
+    });
+
+    test('providing three different Playwright plugins should not throw an error', () => {
+        expect(() => new BrowserPool({
+            browserPlugins: [new PlaywrightPlugin(playwright.chromium), new PlaywrightPlugin(playwright.firefox)],
+        })).not.toThrowError();
+    });
+});

--- a/packages/browser-pool/test/no-hybrid-plugins.test.ts
+++ b/packages/browser-pool/test/no-hybrid-plugins.test.ts
@@ -10,7 +10,7 @@ describe('Hybrid BrowserPool plugins should not be allowed', () => {
         ).toThrowError();
     });
 
-    test('providing three different Playwright plugins should not throw an error', () => {
+    test('providing multiple different Playwright plugins should not throw an error', () => {
         expect(() => new BrowserPool({
             browserPlugins: [new PlaywrightPlugin(playwright.chromium), new PlaywrightPlugin(playwright.firefox)],
         })).not.toThrowError();

--- a/packages/browser-pool/test/proxy-sugar.test.ts
+++ b/packages/browser-pool/test/proxy-sugar.test.ts
@@ -36,7 +36,7 @@ describe.each([
         });
 
         const options = {
-            proxyUrl: `http://foo:bar@127.0.0.1:${protectedProxy.port}`,
+            proxyUrl: `http://foo:bar@127.0.0.2:${protectedProxy.port}`,
             pageOptions: {
                 proxy: {
                     bypass: '<-loopback>',
@@ -47,7 +47,7 @@ describe.each([
 
         const page = await pool.newPage(options);
 
-        const response = await page.goto(`http://127.0.0.2:${(target.address() as AddressInfo).port}`);
+        const response = await page.goto(`http://127.0.0.1:${(target.address() as AddressInfo).port}`);
         const content = await response!.text();
 
         // Fails on Windows.

--- a/packages/browser-pool/test/proxy-sugar.test.ts
+++ b/packages/browser-pool/test/proxy-sugar.test.ts
@@ -1,0 +1,63 @@
+import { BrowserPool, PuppeteerPlugin, PlaywrightPlugin } from '@crawlee/browser-pool';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import puppeteer from 'puppeteer';
+import playwright from 'playwright';
+import type { Server as ProxyChainServer } from 'proxy-chain';
+import { promisify } from 'node:util';
+import { createProxyServer } from '../../../test/browser-pool/browser-plugins/create-proxy-server';
+
+describe.each([
+    ['Puppeteer', new PuppeteerPlugin(puppeteer, { useIncognitoPages: true })],
+    ['Playwright', new PlaywrightPlugin(playwright.chromium, { useIncognitoPages: true })],
+])('BrowserPool - %s - proxy sugar syntax', (_, plugin) => {
+    let target: http.Server;
+    let protectedProxy: ProxyChainServer;
+
+    beforeAll(async () => {
+        target = http.createServer((request, response) => {
+            response.end(request.socket.remoteAddress);
+        });
+        await promisify(target.listen.bind(target) as any)(0, '127.0.0.1');
+
+        protectedProxy = createProxyServer('127.0.0.2', 'foo', 'bar');
+        await protectedProxy.listen();
+    });
+
+    afterAll(async () => {
+        await promisify(target.close.bind(target))();
+
+        await protectedProxy.close(false);
+    });
+
+    test('should work', async () => {
+        const pool = new BrowserPool({
+            browserPlugins: [plugin],
+        });
+
+        const options = {
+            proxyUrl: `http://foo:bar@127.0.0.1:${protectedProxy.port}`,
+            pageOptions: {
+                proxy: {
+                    bypass: '<-loopback>',
+                },
+                proxyBypassList: ['<-loopback>'],
+            },
+        };
+
+        const page = await pool.newPage(options);
+
+        const response = await page.goto(`http://127.0.0.2:${(target.address() as AddressInfo).port}`);
+        const content = await response!.text();
+
+        // Fails on Windows.
+        // See https://github.com/puppeteer/puppeteer/issues/7698
+        if (process.platform !== 'win32') {
+            expect(content).toBe('127.0.0.2');
+        }
+
+        await page.close();
+
+        await pool.destroy();
+    });
+});

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -1,6 +1,6 @@
 import ow from 'ow';
 import type { LaunchOptions, Page, Response } from 'playwright';
-import type { BrowserPoolOptions, PlaywrightPlugin } from '@crawlee/browser-pool';
+import type { BrowserPoolOptions, PlaywrightController, PlaywrightPlugin } from '@crawlee/browser-pool';
 import type { BrowserCrawlerOptions, BrowserCrawlingContext, BrowserCrawlerHandleRequest, BrowserHook } from '@crawlee/browser';
 import { BrowserCrawler, Configuration, Router } from '@crawlee/browser';
 import type { Dictionary } from '@crawlee/types';
@@ -10,7 +10,6 @@ import { PlaywrightLauncher } from './playwright-launcher';
 import type { DirectNavigationOptions, PlaywrightContextUtils } from './utils/playwright-utils';
 import { gotoExtended, registerUtilsToContext } from './utils/playwright-utils';
 
-export type PlaywrightController = ReturnType<PlaywrightPlugin['_createController']>;
 export type PlaywrightCrawlingContext<UserData extends Dictionary = Dictionary> =
     BrowserCrawlingContext<Page, Response, PlaywrightController, UserData> & PlaywrightContextUtils;
 export type PlaywrightHook = BrowserHook<PlaywrightCrawlingContext, PlaywrightGotoOptions>;

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -5,7 +5,7 @@ import type {
     BrowserHook,
 } from '@crawlee/browser';
 import { BrowserCrawler, Configuration, Router } from '@crawlee/browser';
-import type { BrowserPoolOptions, PuppeteerPlugin } from '@crawlee/browser-pool';
+import type { BrowserPoolOptions, PuppeteerController, PuppeteerPlugin } from '@crawlee/browser-pool';
 import type { Dictionary } from '@crawlee/types';
 import ow from 'ow';
 import type { HTTPResponse, LaunchOptions, Page } from 'puppeteer';
@@ -14,7 +14,6 @@ import { PuppeteerLauncher } from './puppeteer-launcher';
 import type { DirectNavigationOptions, PuppeteerContextUtils } from './utils/puppeteer_utils';
 import { gotoExtended, registerUtilsToContext } from './utils/puppeteer_utils';
 
-export type PuppeteerController = ReturnType<PuppeteerPlugin['_createController']>;
 export type PuppeteerCrawlingContext<UserData extends Dictionary = Dictionary> =
     BrowserCrawlingContext<Page, HTTPResponse, PuppeteerController, UserData> & PuppeteerContextUtils;
 export type PuppeteerHook = BrowserHook<PuppeteerCrawlingContext, PuppeteerGoToOptions>;

--- a/test/browser-pool/browser-pool.test.ts
+++ b/test/browser-pool/browser-pool.test.ts
@@ -159,52 +159,9 @@ describe.each([
             browserPool.retireAllBrowsers();
         });
 
-        test('proxy sugar syntax', async () => {
-            const pool = new BrowserPool({
-                browserPlugins: [
-                    new PuppeteerPlugin(puppeteer, {
-                        useIncognitoPages: true,
-                    }),
-                    new PlaywrightPlugin(playwright.chromium, {
-                        useIncognitoPages: true,
-                    }),
-                ],
-            });
-
-            const options = {
-                proxyUrl: `http://foo:bar@127.0.0.3:${protectedProxy.port}`,
-                pageOptions: {
-                    proxy: {
-                        bypass: '<-loopback>',
-                    },
-                    proxyBypassList: ['<-loopback>'],
-                },
-            };
-
-            const pages = await pool.newPageWithEachPlugin([
-                options,
-                options,
-            ]);
-
-            for (const page of pages) {
-                const response = await page.goto(`http://127.0.0.1:${(target.address() as AddressInfo).port}`);
-                const content = await response!.text();
-
-                // Fails on Windows.
-                // See https://github.com/puppeteer/puppeteer/issues/7698
-                if (process.platform !== 'win32') {
-                    expect(content).toBe('127.0.0.3');
-                }
-
-                await page.close();
-            }
-
-            await pool.destroy();
-        });
-
         test('should open new page in incognito context', async () => {
             const browserPoolIncognito = new BrowserPool({
-                browserPlugins: [new PlaywrightPlugin(playwright.chromium, { useIncognitoPages: true })] as const,
+                browserPlugins: [new PlaywrightPlugin(playwright.chromium, { useIncognitoPages: true })],
                 closeInactiveBrowserAfterSecs: 2,
             });
 


### PR DESCRIPTION
Closes #156 

Makes the browser-pool ensure that the constructor of the first plugin is whats used for all provided plugins (making it compatible with user-provided plugins too...should there be any)