### PR TITLE
docs: few more updates to guides

### DIFF
--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -34,7 +34,7 @@ architectures such as Raspberry PI. We strive to make it work, but there are no 
 ## Logging into Apify platform from Crawlee
 
 To access our [Apify account](https://console.apify.com/sign-up) from Crawlee, we must provide
-credentials - [our API token](https://console.apify.com/account#/integrations). We can do that
+credentials - [our API token](https://console.apify.com/account?tab=integrations). We can do that
 either by utilizing [Apify CLI](https://github.com/apify/apify-cli) or with environment
 variables.
 
@@ -178,7 +178,7 @@ It's important to notice that `CRAWLEE_` environment variables don't need to be 
 
 The API token for our Apify account. It is used to access the Apify API, e.g. to access cloud storage
 or to run an actor on the Apify platform. We can find our API token on the
-[Account - Integrations](https://console.apify.com/account#/integrations) page.
+[Account - Integrations](https://console.apify.com/account?tab=integrations) page.
 
 ### Combinations of `APIFY_TOKEN` and `CRAWLEE_STORAGE_DIR`
 

--- a/docs/guides/avoid_blocking.mdx
+++ b/docs/guides/avoid_blocking.mdx
@@ -4,50 +4,57 @@ title: Avoid getting blocked
 description: How to avoid getting blocked when scraping
 ---
 
-A scraper might get blocked for numerous reasons. Let's narrow it down to two main reasons. The first one is a bad or blocked IP address. This topic is covered in the [proxy management guide](./proxy-management). The second reason we will explore more is [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/) or signatures.
-Browser fingerprint is a collection of browser attributes and significant features that can show if our browser is a bot or a real user. Moreover, even most browsers have these unique features that allow the website to track the browser even within different IP addresses. This is the main reason why scrapers should change browser fingerprints while doing browser-based scraping. In addition, it should reduce blocking significantly.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
 
-Changing browser fingerprints can be a tedious job. Luckily, Crawlee provides this feature out of the box with zero configuration necessary. Let's take a look at how it is done.
+import PlaywrightSource from '!!raw-loader!./avoid_blocking_playwright.ts';
+import PuppeteerSource from '!!raw-loader!./avoid_blocking_puppeteer';
+import PlaywrightFingerprintsOffSource from '!!raw-loader!./avoid_blocking_playwright_fingerprints_off.ts';
+import PuppeteerFingerprintsOffSource from '!!raw-loader!./avoid_blocking_puppeteer_fingerprints_off.ts';
 
-Changing browser fingerprints is available in `PlaywrightCrawler` and `PuppeteerCrawler`. We have to pass the `useFingerprints` option to the `browserPoolOptions`.
+A scraper might get blocked for numerous reasons. Let's narrow it down to two main ones. The first one is a bad or blocked IP address. This topic is covered in the [proxy management guide](./proxy-management). The second reason we will explore more in this guide is [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/) (or signatures).
 
-```javascript
-import { PlaywrightCrawler } from 'crawlee';
+Browser fingerprint is a collection of browser attributes and significant features that can show if our browser is a bot or a real user. Moreover, most browsers have these unique features that allow the website to track the browser even within different IP addresses. This is the main reason why scrapers should change browser fingerprints while doing browser-based scraping. In return, it should significantly reduce the blocking.
 
-const crawler = new PlaywrightCrawler({
-    browserPoolOptions: {
-        useFingerprints: true,
-    },
-    // ...
-});
-```
+## Using browser fingerprints
 
-Now, it is all set. The fingerprints are going to be generated for the default browser and the operating system. The Crawler can have the generation algorithm customized to reflect particular browser version and many more. Let's take a look at the example bellow:
+Changing browser fingerprints can be a tedious job. Luckily, Crawlee provides this feature with zero configuration necessary - the usage of fingerprints is enabled by default and available in `PlaywrightCrawler` and `PuppeteerCrawler`. So whenever we build a scraper that is using one of these crawlers - the fingerprints are going to be generated for the default browser and the operating system out of the box.
 
-```javascript
-import { PlaywrightCrawler } from 'crawlee';
+## Customizing browser fingerprints
 
-const crawler = new PlaywrightCrawler({
-    browserPoolOptions: {
-        useFingerprints: true,
-        fingerprintOptions: {
-            fingerprintGeneratorOptions: {
-                browsers: [
-                    { name: 'firefox', minVersion: 80 },
-                    { name: 'chrome', minVersion: 87 },
-                    'safari',
-                ],
-                devices: [
-                    'desktop',
-                ],
-                operatingSystems: [
-                    'windows',
-                ],
-            },
-        },
-    },
-    // ...
-});
-```
+In certain cases we want to narrow down the fingerprints used - e.g. specify a certain operating system, locale or browser. This is also possible with Crawlee - the crawler can have the generation algorithm customized to reflect the particular browser version and many more. Let's take a look at the examples bellow:
 
-Fingerprint generator has more options available check out the [Fingerprint generator docs](https://github.com/apify/fingerprint-generator#HeaderGeneratorOptions).
+<Tabs groupId="avoid_blocking">
+    <TabItem value="playwright" label="PlaywrightCrawler" default>
+        <CodeBlock language="js">
+            {PlaywrightSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="puppeteer" label="PuppeteerCrawler">
+        <CodeBlock language="js">
+            {PuppeteerSource}
+        </CodeBlock>
+    </TabItem>
+</Tabs>
+
+## Disabling browser fingerprints
+
+On the contrary, sometimes we want to entirely disable the usage of browser fingerprints. This is easy to do with Crawlee too. All we have to do is set the `useFingerprints` option of the `browserPoolOptions` to `false`:
+
+<Tabs groupId="avoid_blocking">
+    <TabItem value="playwright" label="PlaywrightCrawler" default>
+        <CodeBlock language="js">
+            {PlaywrightFingerprintsOffSource}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="puppeteer" label="PuppeteerCrawler">
+        <CodeBlock language="js">
+            {PuppeteerFingerprintsOffSource}
+        </CodeBlock>
+    </TabItem>
+</Tabs>
+
+**Related links**
+
+- [Fingerprint Suite Docs](https://github.com/apify/fingerprint-suite)

--- a/docs/guides/avoid_blocking_playwright.ts
+++ b/docs/guides/avoid_blocking_playwright.ts
@@ -1,0 +1,22 @@
+import { PlaywrightCrawler } from 'crawlee';
+
+const crawler = new PlaywrightCrawler({
+    browserPoolOptions: {
+        useFingerprints: true, // this is the default
+        fingerprintOptions: {
+            fingerprintGeneratorOptions: {
+                browsers: [{
+                    name: 'edge',
+                    minVersion: 96,
+                }],
+                devices: [
+                    'desktop',
+                ],
+                operatingSystems: [
+                    'windows',
+                ],
+            },
+        },
+    },
+    // ...
+});

--- a/docs/guides/avoid_blocking_playwright_fingerprints_off.ts
+++ b/docs/guides/avoid_blocking_playwright_fingerprints_off.ts
@@ -1,0 +1,8 @@
+import { PlaywrightCrawler } from 'crawlee';
+
+const crawler = new PlaywrightCrawler({
+    browserPoolOptions: {
+        useFingerprints: false,
+    },
+    // ...
+});

--- a/docs/guides/avoid_blocking_puppeteer.ts
+++ b/docs/guides/avoid_blocking_puppeteer.ts
@@ -1,0 +1,22 @@
+import { PuppeteerCrawler } from 'crawlee';
+
+const crawler = new PuppeteerCrawler({
+    browserPoolOptions: {
+        useFingerprints: true, // this is the default
+        fingerprintOptions: {
+            fingerprintGeneratorOptions: {
+                browsers: [
+                    'chrome',
+                    'firefox',
+                ],
+                devices: [
+                    'mobile',
+                ],
+                locales: [
+                    'en-US',
+                ],
+            },
+        },
+    },
+    // ...
+});

--- a/docs/guides/avoid_blocking_puppeteer_fingerprints_off.ts
+++ b/docs/guides/avoid_blocking_puppeteer_fingerprints_off.ts
@@ -1,0 +1,8 @@
+import { PuppeteerCrawler } from 'crawlee';
+
+const crawler = new PuppeteerCrawler({
+    browserPoolOptions: {
+        useFingerprints: false,
+    },
+    // ...
+});

--- a/docs/guides/docker_images_js
+++ b/docs/guides/docker_images_js
@@ -1,5 +1,5 @@
 # First, specify the base Docker image. You can read more about
-# the available images at https://sdk.apify.com/docs/guides/docker-images
+# the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
 # The 16 represents the version of Node.js you want to use.
 FROM apify/actor-node:16

--- a/docs/guides/quick_start.mdx
+++ b/docs/guides/quick_start.mdx
@@ -14,6 +14,8 @@ import CheerioSource from '!!raw-loader!./quick_start_cheerio.ts';
 import PlaywrightSource from '!!raw-loader!./quick_start_playwright.ts';
 import PuppeteerSource from '!!raw-loader!./quick_start_puppeteer.ts';
 
+import CheerioLog from '!!raw-loader!./quick_start_cheerio.log';
+
 This short tutorial will set us up to start using Crawlee in a minute or two,
 while [Getting Started](../guides/getting-started) is a comprehensive step-by-step guide for creating the first scraper.
 So let's check out this page first and then proceed to the latter to learn more.
@@ -67,18 +69,17 @@ When we run the example, we should see Crawlee automating the data extraction pr
 
 <Tabs groupId="quick_start">
 <TabItem value="cheerio" label="CheerioCrawler" default>
-
-[//]: # (TODO: Add CheerioCrawler gif here.)
-![Chrome Scrape](/img/chrome_scrape.gif)
-
+We should only see the logs in our terminal as no browser is used:
+<CodeBlock language="log">{CheerioLog}</CodeBlock>
 </TabItem>
 <TabItem value="playwright" label="PlaywrightCrawler">
+Besides the logs, we should also see Crawlee automating the browser:
 
-[//]: # (TODO: Add PlaywrightCrawler gif here.)
 ![Chrome Scrape](/img/chrome_scrape.gif)
 
 </TabItem>
 <TabItem value="puppeteer" label="PuppeteerCrawler">
+Besides the logs, we should also see Crawlee automating the browser:
 
 ![Chrome Scrape](/img/chrome_scrape.gif)
 

--- a/docs/guides/quick_start_cheerio.log
+++ b/docs/guides/quick_start_cheerio.log
@@ -1,0 +1,16 @@
+INFO  CheerioCrawler:AutoscaledPool: state {"currentConcurrency":0,"desiredConcurrency":2,"systemStatus":{"isSystemIdle":true,"memInfo":{"isOverloaded":false,"limitRatio":0.2,"actualRatio":null},"eventLoopInfo":{"isOverloaded":false,"limitRatio":0.7,"actualRatio":null},"cpuInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"clientInfo":{"isOverloaded":false,"limitRatio":0.3,"actualRatio":null}}}
+Title of https://www.iana.org/: Internet Assigned Numbers Authority
+Title of https://www.iana.org/domains: Domain Name Services
+Title of https://www.iana.org/about/: About us
+Title of https://www.iana.org/numbers: Number Resources
+Title of https://www.iana.org/abuse: Abuse Issues
+Title of https://www.iana.org/protocols: Protocol Registries
+Title of https://www.iana.org/time-zones: Time Zone Database
+Title of https://www.iana.org/performance: Performance
+Title of https://www.iana.org/reports: Reports
+Title of https://www.iana.org/contact: Contact Us
+Title of https://www.iana.org/reviews: Reviews
+Title of https://www.iana.org/dnssec: DNSSEC Information
+Title of https://www.iana.org/procedures: Procedures
+Title of https://www.iana.org/glossary: Glossary
+Title of https://www.iana.org/audits: Audit Programs

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -173,7 +173,7 @@ module.exports = {
             defaultLanguage: 'typescript',
             theme: require('prism-react-renderer/themes/github'),
             darkTheme: require('prism-react-renderer/themes/dracula'),
-            additionalLanguages: ['docker'],
+            additionalLanguages: ['docker', 'log'],
         },
         metadata: [],
         image: 'img/apify_og_SDK.png',


### PR DESCRIPTION
- fix apify console links in `apify-platform`
- fix links to docker guide in `docker-images`: instead of sdk.apify.com -> use crawlee.dev
- update `avoid-blocking` guide
- `quick-start` - instead of the gif for cheerio - added static log example + kept the same gif for playwright/puppeteer + added a sentence before gif/log. I think it should be ok but let me know if you think it's not.

Last thing to do on my list here is to update the `apify-platform` guide with links to new repo, so will do in another PR once `apify-sdk-js` is live.

