### PR TITLE
docs: update guides + clean-up basic crawler api docs

### DIFF
--- a/docs/guides/got_scraping.mdx
+++ b/docs/guides/got_scraping.mdx
@@ -5,7 +5,7 @@ title: Got Scraping
 
 ## Intro
 
-If we're using Basic Crawler, we have to send requests manually. In order to do this, We need to call `sendRequest()` like this:
+When using `BasicCrawler`, we have to send the requests manually. In order to do this, we can use the context-aware `sendRequest()` function:
 
 ```ts
 import { BasicCrawler } from 'crawlee';

--- a/docs/guides/got_scraping.mdx
+++ b/docs/guides/got_scraping.mdx
@@ -150,7 +150,7 @@ const crawler = new BasicCrawler({
 
 This option specifies the maximum number of `Got` retries.
 
-By default, `retry.limit` is set to `0`. This is because `Crawlee` has its own (complicated enough) retry management.
+By default, `retry.limit` is set to `0`. This is because Crawlee has its own (complicated enough) retry management.
 
 We suggest NOT changing this value for stability reasons.
 

--- a/docs/guides/got_scraping.mdx
+++ b/docs/guides/got_scraping.mdx
@@ -1,13 +1,15 @@
 ---
 id: got-scraping
-title: Got Scraping guide
+title: Got Scraping
 ---
 
 ## Intro
 
-If you're using Basic Crawler, you have to send requests manually. In order to do this, you need to call `sendRequest()` like this:
+If we're using Basic Crawler, we have to send requests manually. In order to do this, We need to call `sendRequest()` like this:
 
 ```ts
+import { BasicCrawler } from 'crawlee';
+
 const crawler = new BasicCrawler({
     async requestHandler({ sendRequest, log }) {
         const res = await sendRequest();
@@ -17,7 +19,7 @@ const crawler = new BasicCrawler({
 ```
 
 It uses [`got-scraping`](https://github.com/apify/got-scraping) under the hood.
-Got Scraping is a [Got](https://github.com/sindresorhus/got) extension developed to mimic browser requests, so there's a high chance we'll open the webpage.
+Got Scraping is a [Got](https://github.com/sindresorhus/got) extension developed to mimic browser requests, so there's a high chance we'll open the webpage without getting blocked.
 
 ## `sendRequest` API
 
@@ -49,35 +51,37 @@ async sendRequest(overrideOptions?: GotOptionsInit) => {
 
 By default, it's the URL of current task. However you can override this with a `string` or a `URL` instance if necessary.
 
-See the [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#url) for more details.
+*More details: [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#url).*
 
 ### `method`
 
 By default, it's the HTTP method of current task. Possible values are `'GET', 'POST', 'HEAD', 'PUT', 'PATCH', 'DELETE'`.
 
-See the [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#method) for more details.
+*More details: [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#method).*
 
 ### `body`
 
 By default, it's the HTTP payload of current task.
 
-See the [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#body) for more details.
+*More details: [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#body).*
 
 ### `headers`
 
 By default, it's the HTTP headers of current task. It's an object with `string` values.
 
-See the [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#headers) for more details.
+*More details: [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#headers).*
 
 ### `proxyUrl`
 
-It's a string represeting the proxy server in the format of `protocol://username:password@hostname:port`.
+It's a string representing the proxy server in the format of `protocol://username:password@hostname:port`.
 
 For example, an Apify proxy server looks like this: `http://auto:password@proxy.apify.com:8000`.
 
-Basic Crawler does not have the concept of a session or proxy, therefore you need to manually pass the `proxyUrl` option:
+Basic Crawler does not have the concept of a session or proxy, therefore we need to manually pass the `proxyUrl` option:
 
 ```ts
+import { BasicCrawler } from 'crawlee';
+
 const crawler = new BasicCrawler({
     async requestHandler({ sendRequest, log }) {
         const res = await sendRequest({
@@ -90,22 +94,24 @@ const crawler = new BasicCrawler({
 
 We use proxies to hide our real IP address.
 
-See the [Got Scraping documentation](https://github.com/apify/got-scraping#proxyurl) for more details.
+*More details: [Got Scraping documentation](https://github.com/apify/got-scraping#proxyurl).*
 
 ### `sessionToken`
 
 It's a non-primitive object used as a key when generating browser fingerprint. Fingerprints with the same token don't change.
 This can be used to retain the `user-agent` header when using the same Apify Session.
 
-See the [Got Scraping documentation](https://github.com/apify/got-scraping#sessiontoken) for more details.
+More details: [Got Scraping documentation](https://github.com/apify/got-scraping#sessiontoken).
 
 ### `responseType`
 
 This option defines how the response should be parsed.
 
-By default we fetch HTML websites - that is plaintext. Hence we set `responseType` to `'text'`. However JSON is possible as well:
+By default, we fetch HTML websites - that is plaintext. Hence, we set `responseType` to `'text'`. However, JSON is possible as well:
 
 ```ts
+import { BasicCrawler } from 'crawlee';
+
 const crawler = new BasicCrawler({
     async requestHandler({ sendRequest, log }) {
         const res = await sendRequest({ responseType: 'json' });
@@ -114,15 +120,16 @@ const crawler = new BasicCrawler({
 });
 ```
 
-See the [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#responsetype) for more details.
+*More details: [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#responsetype).*
 
 ### `cookieJar`
 
-Got, in order to manage cookies, uses a `cookieJar`. It's an object with an interface of a [`tough-cookie` package](https://github.com/salesforce/tough-cookie).
+`Got` uses a `cookieJar` to manage cookies. It's an object with an interface of a [`tough-cookie` package](https://github.com/salesforce/tough-cookie).
 
 Example:
 
 ```ts
+import { BasicCrawler } from 'crawlee';
 import { CookieJar } from 'tough-cookie';
 
 const cookieJar = new CookieJar();
@@ -135,26 +142,29 @@ const crawler = new BasicCrawler({
 });
 ```
 
-See the [Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#cookiejar) for more details.
-See the [Tough Cookie documentation](https://github.com/salesforce/tough-cookie#cookiejarstore-options) for more details.
+*More details:*
+- *[Got documentation](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#cookiejar)*
+- *[Tough Cookie documentation](https://github.com/salesforce/tough-cookie#cookiejarstore-options)*
 
 ### `retry.limit`
 
-This option specifes the maximum number of Got retries.
+This option specifies the maximum number of `Got` retries.
 
-By default, `retry.limit` is set to `0`. This is because `crawlee` has its own (complicated enough) retry management.
+By default, `retry.limit` is set to `0`. This is because `Crawlee` has its own (complicated enough) retry management.
 
-We suggest that you do not change this value for stability reasons.
+We suggest NOT changing this value for stability reasons.
 
 ### `useHeaderGenerator`
 
-It's a boolean for whether to generate browser headers. By default it's set to `true`, and we recommend keeping this for better results.
+It's a boolean for whether to generate browser headers. By default, it's set to `true`, and we recommend keeping this for better results.
 
 ### `headerGeneratorOptions`
 
 This option represents an object how to generate browser fingerprint. Example:
 
 ```ts
+import { BasicCrawler } from 'crawlee';
+
 const crawler = new BasicCrawler({
     async requestHandler({ sendRequest, log }) {
         const res = await sendRequest({
@@ -170,11 +180,9 @@ const crawler = new BasicCrawler({
 });
 ```
 
-See [`HeaderGeneratorOptions` documentation](https://apify.github.io/fingerprint-suite/api/fingerprint-generator/interface/HeaderGeneratorOptions/) for more details.
+*More details: [`HeaderGeneratorOptions` documentation](https://apify.github.io/fingerprint-suite/api/fingerprint-generator/interface/HeaderGeneratorOptions/).*
 
-### More
-
-For more info please refer to:
+**Related links**
 
 - [Got documentation](https://github.com/sindresorhus/got#documentation)
 - [Got Scraping documentation](https://github.com/apify/got-scraping)

--- a/docs/guides/got_scraping.mdx
+++ b/docs/guides/got_scraping.mdx
@@ -101,7 +101,7 @@ We use proxies to hide our real IP address.
 It's a non-primitive object used as a key when generating browser fingerprint. Fingerprints with the same token don't change.
 This can be used to retain the `user-agent` header when using the same Apify Session.
 
-More details: [Got Scraping documentation](https://github.com/apify/got-scraping#sessiontoken).
+*More details: [Got Scraping documentation](https://github.com/apify/got-scraping#sessiontoken).*
 
 ### `responseType`
 

--- a/docs/guides/quick_start_cheerio.log
+++ b/docs/guides/quick_start_cheerio.log
@@ -1,16 +1,18 @@
 INFO  CheerioCrawler:AutoscaledPool: state {"currentConcurrency":0,"desiredConcurrency":2,"systemStatus":{"isSystemIdle":true,"memInfo":{"isOverloaded":false,"limitRatio":0.2,"actualRatio":null},"eventLoopInfo":{"isOverloaded":false,"limitRatio":0.7,"actualRatio":null},"cpuInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"clientInfo":{"isOverloaded":false,"limitRatio":0.3,"actualRatio":null}}}
-Title of https://www.iana.org/: Internet Assigned Numbers Authority
-Title of https://www.iana.org/domains: Domain Name Services
-Title of https://www.iana.org/about/: About us
-Title of https://www.iana.org/numbers: Number Resources
-Title of https://www.iana.org/abuse: Abuse Issues
-Title of https://www.iana.org/protocols: Protocol Registries
-Title of https://www.iana.org/time-zones: Time Zone Database
-Title of https://www.iana.org/performance: Performance
-Title of https://www.iana.org/reports: Reports
-Title of https://www.iana.org/contact: Contact Us
-Title of https://www.iana.org/reviews: Reviews
-Title of https://www.iana.org/dnssec: DNSSEC Information
-Title of https://www.iana.org/procedures: Procedures
-Title of https://www.iana.org/glossary: Glossary
-Title of https://www.iana.org/audits: Audit Programs
+INFO  CheerioCrawler: Title of https://www.iana.org/: Internet Assigned Numbers Authority
+INFO  CheerioCrawler: Title of https://www.iana.org/domains: Domain Name Services
+INFO  CheerioCrawler: Title of https://www.iana.org/numbers: Number Resources
+INFO  CheerioCrawler: Title of https://www.iana.org/about/: About us
+INFO  CheerioCrawler: Title of https://www.iana.org/abuse: Abuse Issues
+INFO  CheerioCrawler: Title of https://www.iana.org/protocols: Protocol Registries
+INFO  CheerioCrawler: Title of https://www.iana.org/time-zones: Time Zone Database
+INFO  CheerioCrawler: Title of https://www.iana.org/performance: Performance
+INFO  CheerioCrawler: Title of https://www.iana.org/reports: Reports
+INFO  CheerioCrawler: Title of https://www.iana.org/reviews: Reviews
+INFO  CheerioCrawler: Title of https://www.iana.org/contact: Contact Us
+INFO  CheerioCrawler: Title of https://www.iana.org/dnssec: DNSSEC Information
+INFO  CheerioCrawler: Title of https://www.iana.org/procedures: Procedures
+INFO  CheerioCrawler: Title of https://www.iana.org/glossary: Glossary
+INFO  CheerioCrawler: Title of https://www.iana.org/audits: Audit Programs
+INFO  CheerioCrawler: All the requests from request list and/or request queue have been processed, the crawler will shut down.
+INFO  CheerioCrawler: Final request statistics: {"requestsFinished":15,"requestsFailed":0,"retryHistogram":[15],"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":482,"requestsFinishedPerMinute":209,"requestsFailedPerMinute":0,"requestTotalDurationMillis":7233,"requestsTotal":15,"crawlerRuntimeMillis":4316}

--- a/docs/guides/quick_start_cheerio.ts
+++ b/docs/guides/quick_start_cheerio.ts
@@ -1,12 +1,12 @@
 import { CheerioCrawler, Dataset } from 'crawlee';
 
 const crawler = new CheerioCrawler({
-    async requestHandler({ request, $, enqueueLinks }) {
+    async requestHandler({ request, $, enqueueLinks, log }) {
         const { url } = request;
 
         // Extract HTML title of the page.
         const title = $('title').text();
-        console.log(`Title of ${url}: ${title}`);
+        log.info(`Title of ${url}: ${title}`);
 
         // Add URLs that match the provided pattern.
         await enqueueLinks({

--- a/docs/guides/quick_start_playwright.ts
+++ b/docs/guides/quick_start_playwright.ts
@@ -1,12 +1,12 @@
 import { PlaywrightCrawler, Dataset } from 'crawlee';
 
 const crawler = new PlaywrightCrawler({
-    async requestHandler({ request, page, enqueueLinks }) {
+    async requestHandler({ request, page, enqueueLinks, log }) {
         const { url } = request;
 
         // Extract HTML title of the page.
         const title = await page.title();
-        console.log(`Title of ${url}: ${title}`);
+        log.info(`Title of ${url}: ${title}`);
 
         // Add URLs that match the provided pattern.
         await enqueueLinks({

--- a/docs/guides/quick_start_puppeteer.ts
+++ b/docs/guides/quick_start_puppeteer.ts
@@ -1,12 +1,12 @@
 import { PuppeteerCrawler, Dataset } from 'crawlee';
 
 const crawler = new PuppeteerCrawler({
-    async requestHandler({ request, page, enqueueLinks }) {
+    async requestHandler({ request, page, enqueueLinks, log }) {
         const { url } = request;
 
         // Extract HTML title of the page.
         const title = await page.title();
-        console.log(`Title of ${url}: ${title}`);
+        log.info(`Title of ${url}: ${title}`);
 
         // Add URLs that match the provided pattern.
         await enqueueLinks({

--- a/docs/guides/request_storage.mdx
+++ b/docs/guides/request_storage.mdx
@@ -145,4 +145,4 @@ import { purgeDefaultStorages } from 'crawlee';
 await purgeDefaultStorages();
 ```
 
-Calling this function will clean up the default request storage directory (and also the request list stored in default key-value store). This is a shortcut for running (optional) `purge` method on the <ApiLink to="types/interface/StorageClient">`StorageClient`</ApiLink> interface, in other words it will call the `purge` method of the underlying storage implementation we are currently using. In addition, this method will make sure the storage is purged only once for a given execution context, so it is safe to call it multiple times.
+Calling this function will clean up the default request storage directory (and also the request list stored in default key-value store). This is a shortcut for running (optional) `purge` method on the <ApiLink to="core/interface/StorageClient">`StorageClient`</ApiLink> interface, in other words it will call the `purge` method of the underlying storage implementation we are currently using. In addition, this method will make sure the storage is purged only once for a given execution context, so it is safe to call it multiple times.

--- a/docs/guides/result_storage.mdx
+++ b/docs/guides/result_storage.mdx
@@ -110,4 +110,4 @@ import { purgeDefaultStorages } from 'crawlee';
 await purgeDefaultStorages();
 ```
 
-Calling this function will clean up the default results storage directories except the `INPUT` key in default key-value store directory. This is a shortcut for running (optional) `purge` method on the <ApiLink to="types/interface/StorageClient">`StorageClient`</ApiLink> interface, in other words it will call the `purge` method of the underlying storage implementation we are currently using. In addition, this method will make sure the storage is purged only once for a given execution context, so it is safe to call it multiple times.
+Calling this function will clean up the default results storage directories except the `INPUT` key in default key-value store directory. This is a shortcut for running (optional) `purge` method on the <ApiLink to="core/interface/StorageClient">`StorageClient`</ApiLink> interface, in other words it will call the `purge` method of the underlying storage implementation we are currently using. In addition, this method will make sure the storage is purged only once for a given execution context, so it is safe to call it multiple times.

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -51,7 +51,7 @@ export type BasicCrawlerEnqueueLinksOptions = Omit<EnqueueLinksOptions, 'request
 /**
  * Since there's no set number of seconds before the container is terminated after
  * a migration event, we need some reasonable number to use for RequestList persistence.
- * Once a migration event is received, the Crawler will be paused and it will wait for
+ * Once a migration event is received, the crawler will be paused, and it will wait for
  * this long before persisting the RequestList state. This should allow most healthy
  * requests to finish and be marked as handled, thus lowering the amount of duplicate
  * results after migration.
@@ -68,18 +68,18 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
      * User-provided function that performs the logic of the crawler. It is called for each URL to crawl.
      *
      * The function receives the {@link BasicCrawlingContext} as an argument,
-     * where the {@link BasicCrawlingContext.request} represents the URL to crawl.
+     * where the {@link BasicCrawlingContext.request|`request`} represents the URL to crawl.
      *
      * The function must return a promise, which is then awaited by the crawler.
      *
      * If the function throws an exception, the crawler will try to re-crawl the
-     * request later, up to `option.maxRequestRetries` times.
+     * request later, up to the {@link BasicCrawlerOptions.maxRequestRetries|`maxRequestRetries`} times.
      * If all the retries fail, the crawler calls the function
-     * provided to the `failedRequestHandler` parameter.
-     * To make this work, you should **always**
-     * let your function throw exceptions rather than catch them.
+     * provided to the {@link BasicCrawlerOptions.failedRequestHandler|`failedRequestHandler`} parameter.
+     * To make this work, we should **always**
+     * let our function throw exceptions rather than catch them.
      * The exceptions are logged to the request using the
-     * {@link Request.pushErrorMessage} function.
+     * {@link Request.pushErrorMessage|`Request.pushErrorMessage()`} function.
      */
     requestHandler?: RequestHandler<Context>;
 
@@ -87,18 +87,18 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
      * User-provided function that performs the logic of the crawler. It is called for each URL to crawl.
      *
      * The function receives the {@link BasicCrawlingContext} as an argument,
-     * where the {@link BasicCrawlingContext.request} represents the URL to crawl.
+     * where the {@link BasicCrawlingContext.request|`request`} represents the URL to crawl.
      *
      * The function must return a promise, which is then awaited by the crawler.
      *
      * If the function throws an exception, the crawler will try to re-crawl the
-     * request later, up to `option.maxRequestRetries` times.
+     * request later, up to the {@link BasicCrawlerOptions.maxRequestRetries|`maxRequestRetries`} times.
      * If all the retries fail, the crawler calls the function
-     * provided to the `failedRequestHandler` parameter.
-     * To make this work, you should **always**
-     * let your function throw exceptions rather than catch them.
+     * provided to the {@link BasicCrawlerOptions.failedRequestHandler|`failedRequestHandler`} parameter.
+     * To make this work, we should **always**
+     * let our function throw exceptions rather than catch them.
      * The exceptions are logged to the request using the
-     * {@link Request.pushErrorMessage} function.
+     * {@link Request.pushErrorMessage|`Request.pushErrorMessage()`} function.
      *
      * @deprecated `handleRequestFunction` has been renamed to `requestHandler` and will be removed in a future version.
      */
@@ -106,24 +106,28 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
 
     /**
      * Static list of URLs to be processed.
-     * Either `requestList` or `requestQueue` option must be provided (or both).
+     * If not provided, the crawler will open the default request queue when the {@link BasicCrawler.addRequests|`crawler.addRequests()`} function is called.
+     * > Alternatively, `requests` parameter of {@link BasicCrawler.run|`crawler.run()`} could be used to enqueue the initial requests -
+     * it is a shortcut for running `crawler.addRequests()` before the `crawler.run()`.
      */
     requestList?: RequestList;
 
     /**
      * Dynamic queue of URLs to be processed. This is useful for recursive crawling of websites.
-     * Either `requestList` or `requestQueue` option must be provided (or both).
+     * If not provided, the crawler will open the default request queue when the {@link BasicCrawler.addRequests|`crawler.addRequests()`} function is called.
+     * > Alternatively, `requests` parameter of {@link BasicCrawler.run|`crawler.run()`} could be used to enqueue the initial requests -
+     * it is a shortcut for running `crawler.addRequests()` before the `crawler.run()`.
      */
     requestQueue?: RequestQueue;
 
     /**
-     * Timeout in which the function passed as `requestHandler` needs to finish, in seconds.
+     * Timeout in which the function passed as {@link BasicCrawlerOptions.requestHandler|`requestHandler`} needs to finish, in seconds.
      * @default 60
      */
     requestHandlerTimeoutSecs?: number;
 
     /**
-     * Timeout in which the function passed as `requestHandler` needs to finish, in seconds.
+     * Timeout in which the function passed as {@link BasicCrawlerOptions.requestHandler|`requestHandler`} needs to finish, in seconds.
      * @default 60
      * @deprecated `handleRequestTimeoutSecs` has been renamed to `requestHandlerTimeoutSecs` and will be removed in a future version.
      */
@@ -131,30 +135,30 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
 
     /**
      * User-provided function that allows modifying the request object before it gets retried by the crawler.
-     * It's executed before each retry for the requests that failed less than `option.maxRequestRetries` times.
+     * It's executed before each retry for the requests that failed less than {@link BasicCrawlerOptions.maxRequestRetries|`maxRequestRetries`} times.
      *
      * The function receives the {@link BasicCrawlingContext} as the first argument,
-     * where the {@link BasicCrawlingContext.request} corresponds to the request to be retried.
+     * where the {@link BasicCrawlingContext.request|`request`} corresponds to the request to be retried.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */
     errorHandler?: FailedRequestHandler<Context>;
 
     /**
-     * A function to handle requests that failed more than `option.maxRequestRetries` times.
+     * A function to handle requests that failed more than {@link BasicCrawlerOptions.maxRequestRetries|`maxRequestRetries`} times.
      *
      * The function receives the {@link BasicCrawlingContext} as the first argument,
-     * where the {@link BasicCrawlingContext.request} corresponds to the failed request.
+     * where the {@link BasicCrawlingContext.request|`request`} corresponds to the failed request.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      */
     failedRequestHandler?: FailedRequestHandler<Context>;
 
     /**
-     * A function to handle requests that failed more than `option.maxRequestRetries` times.
+     * A function to handle requests that failed more than {@link BasicCrawlerOptions.maxRequestRetries|`maxRequestRetries`} times.
      *
      * The function receives the {@link BasicCrawlingContext} as the first argument,
-     * where the {@link BasicCrawlingContext.request} corresponds to the failed request.
+     * where the {@link BasicCrawlingContext.request|`request`} corresponds to the failed request.
      * Second argument is the `Error` instance that
      * represents the last error thrown during processing of the request.
      *
@@ -163,49 +167,51 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     handleFailedRequestFunction?: FailedRequestHandler<Context>;
 
     /**
-     * Indicates how many times the request is retried if {@link requestHandler} fails.
+     * Indicates how many times the request is retried if {@link BasicCrawlerOptions.requestHandler|`requestHandler`} fails.
      * @default 3
      */
     maxRequestRetries?: number;
 
     /**
      * Maximum number of pages that the crawler will open. The crawl will stop when this limit is reached.
-     * Always set this value in order to prevent infinite loops in misconfigured crawlers.
-     * Note that in cases of parallel crawling, the actual number of pages visited might be slightly higher than this value.
+     * This value should always be set in order to prevent infinite loops in misconfigured crawlers.
+     * > *NOTE:* In cases of parallel crawling, the actual number of pages visited might be slightly higher than this value.
      */
     maxRequestsPerCrawl?: number;
 
     /**
      * Custom options passed to the underlying {@link AutoscaledPool} constructor.
-     * Note that the `runTaskFunction` and `isTaskReadyFunction` options
+     * > *NOTE:* The {@link AutoscaledPoolOptions.runTaskFunction|`runTaskFunction`}
+     * and {@link AutoscaledPoolOptions.isTaskReadyFunction|`isTaskReadyFunction`} options
      * are provided by the crawler and cannot be overridden.
-     * However, you can provide a custom implementation of `isFinishedFunction`.
+     * However, we can provide a custom implementation of {@link AutoscaledPoolOptions.isFinishedFunction|`isFinishedFunction`}.
      */
     autoscaledPoolOptions?: AutoscaledPoolOptions;
 
     /**
-     * Sets the minimum concurrency (parallelism) for the crawl. Shortcut to the corresponding {@link AutoscaledPool} option.
-     *
-     * *WARNING:* If you set this value too high with respect to the available system memory and CPU, your crawler will run extremely slow or crash.
-     * If you're not sure, just keep the default value and the concurrency will scale up automatically.
+     * Sets the minimum concurrency (parallelism) for the crawl. Shortcut for the
+     * AutoscaledPool {@link AutoscaledPoolOptions.minConcurrency|`minConcurrency`} option.
+     * > *WARNING:* If we set this value too high with respect to the available system memory and CPU, our crawler will run extremely slow or crash.
+     * If not sure, it's better to keep the default value and the concurrency will scale up automatically.
      */
     minConcurrency?: number;
 
     /**
-     * Sets the maximum concurrency (parallelism) for the crawl. Shortcut to the corresponding {@link AutoscaledPool} option.
+     * Sets the maximum concurrency (parallelism) for the crawl. Shortcut for the
+     * AutoscaledPool {@link AutoscaledPoolOptions.maxConcurrency|`maxConcurrency`} option.
      */
     maxConcurrency?: number;
 
     /**
      * The maximum number of requests per minute the crawler should run.
-     * By default, this is set to `Infinity`, but you can pass any positive, non-zero integer.
-     * Shortcut for the {@link AutoscaledPoolOptions.maxTasksPerMinute} option.
+     * By default, this is set to `Infinity`, but we can pass any positive, non-zero integer.
+     * Shortcut for the AutoscaledPool {@link AutoscaledPoolOptions.maxTasksPerMinute|`maxTasksPerMinute`} option.
      */
     maxRequestsPerMinute?: number;
 
     /**
-     * Basic crawler will initialize the {@link SessionPool} with the corresponding `sessionPoolOptions`.
-     * The session instance will be than available in the `requestHandler`.
+     * Basic crawler will initialize the {@link SessionPool} with the corresponding {@link SessionPoolOptions|`sessionPoolOptions`}.
+     * The session instance will be than available in the {@link BasicCrawlerOptions.requestHandler|`requestHandler`}.
      */
     useSessionPool?: boolean;
 
@@ -225,16 +231,18 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
  *
  * `BasicCrawler` is a low-level tool that requires the user to implement the page
  * download and data extraction functionality themselves.
- * If you want a crawler that already facilitates this functionality,
- * please consider using {@link CheerioCrawler}, {@link PuppeteerCrawler} or {@link PlaywrightCrawler}.
+ * If we want a crawler that already facilitates this functionality,
+ * we should consider using {@link CheerioCrawler}, {@link PuppeteerCrawler} or {@link PlaywrightCrawler}.
  *
- * `BasicCrawler` invokes the user-provided {@link BasicCrawlerOptions.requestHandler}
+ * `BasicCrawler` invokes the user-provided {@link BasicCrawlerOptions.requestHandler|`requestHandler`}
  * for each {@link Request} object, which represents a single URL to crawl.
  * The {@link Request} objects are fed from the {@link RequestList} or the {@link RequestQueue}
- * instances provided by the {@link BasicCrawlerOptions.requestList} or {@link BasicCrawlerOptions.requestQueue}
- * constructor options, respectively.
+ * instances provided by the {@link BasicCrawlerOptions.requestList|`requestList`} or {@link BasicCrawlerOptions.requestQueue|`requestQueue`}
+ * constructor options, respectively. If neither `requestList` nor `requestQueue` options are provided,
+ * the crawler will open the default request queue either when the {@link BasicCrawler.addRequests|`crawler.addRequests()`} function is called,
+ * or if `requests` parameter (representing the initial requests) of the {@link BasicCrawler.run|`crawler.run()`} function is provided.
  *
- * If both {@link BasicCrawlerOptions.requestList} and {@link BasicCrawlerOptions.requestQueue} options are used,
+ * If both {@link BasicCrawlerOptions.requestList|`requestList`} and {@link BasicCrawlerOptions.requestQueue|`requestQueue`} options are used,
  * the instance first processes URLs from the {@link RequestList} and automatically enqueues all of them
  * to {@link RequestQueue} before it starts their processing. This ensures that a single URL is not crawled multiple times.
  *
@@ -242,28 +250,21 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
  *
  * New requests are only dispatched when there is enough free CPU and memory available,
  * using the functionality provided by the {@link AutoscaledPool} class.
- * All {@link AutoscaledPool} configuration options can be passed to the `autoscaledPoolOptions`
+ * All {@link AutoscaledPool} configuration options can be passed to the {@link BasicCrawlerOptions.autoscaledPoolOptions|`autoscaledPoolOptions`}
  * parameter of the `BasicCrawler` constructor. For user convenience, the `minConcurrency` and `maxConcurrency`
  * {@link AutoscaledPool} options are available directly in the `BasicCrawler` constructor.
  *
  * **Example usage:**
  *
  * ```javascript
- * import { gotScraping } from 'got-scraping';
+ * import { BasicCrawler, Dataset } from 'crawlee';
  *
- * // Prepare a list of URLs to crawl
- * const requestList = await RequestList.open(null, [
- *     { url: 'http://www.example.com/page-1' },
- *     { url: 'http://www.example.com/page-2' },
- * ]);
- *
- * // Crawl the URLs
+ * // Create a crawler instance
  * const crawler = new BasicCrawler({
- *     requestList,
- *     async requestHandler({ request }) {
+ *     async requestHandler({ request, sendRequest }) {
  *         // 'request' contains an instance of the Request class
  *         // Here we simply fetch the HTML of the page and store it to a dataset
- *         const { body } = await gotScraping({
+ *         const { body } = await sendRequest({
  *             url: request.url,
  *             method: request.method,
  *             body: request.payload,
@@ -277,7 +278,11 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
  *     },
  * });
  *
- * await crawler.run();
+ * // Enqueue the initial requests and run the crawler
+ * await crawler.run([
+ *     'http://www.example.com/page-1',
+ *     'http://www.example.com/page-2',
+ * ]);
  * ```
  * @category Crawlers
  */
@@ -285,43 +290,41 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     private static readonly CRAWLEE_STATE_KEY = 'CRAWLEE_STATE';
 
     /**
-     * Static list of URLs to be processed.
+     * A reference to the underlying {@link Statistics} class that collects and logs run statistics for requests.
      */
     readonly stats: Statistics;
 
     /**
-     * A reference to the underlying {@link RequestList} class that manages the crawler's {@link Request}s.
-     * Either `requestList` or `requestQueue` option must be provided (or both).
+     * A reference to the underlying {@link RequestList} class that manages the crawler's {@link Request|requests}.
      * Only available if used by the crawler.
      */
     requestList?: RequestList;
 
     /**
      * Dynamic queue of URLs to be processed. This is useful for recursive crawling of websites.
-     * A reference to the underlying {@link RequestQueue} class that manages the crawler's {@link Request}s.
-     * Either `requestList` or `requestQueue` option must be provided (or both).
+     * A reference to the underlying {@link RequestQueue} class that manages the crawler's {@link Request|requests}.
      * Only available if used by the crawler.
      */
     requestQueue?: RequestQueue;
 
     /**
-     * A reference to the underlying {@link SessionPool} class that manages the crawler's {@link Session}s.
+     * A reference to the underlying {@link SessionPool} class that manages the crawler's {@link Session|sessions}.
      * Only available if used by the crawler.
      */
     sessionPool?: SessionPool;
 
     /**
      * A reference to the underlying {@link AutoscaledPool} class that manages the concurrency of the crawler.
-     * Note that this property is only initialized after calling the {@link BasicCrawler.run} function.
-     * You can use it to change the concurrency settings on the fly,
-     * to pause the crawler by calling {@link AutoscaledPool.pause}
-     * or to abort it by calling {@link AutoscaledPool.abort}.
+     * > *NOTE:* This property is only initialized after calling the {@link BasicCrawler.run|`crawler.run()`} function.
+     * We can use it to change the concurrency settings on the fly,
+     * to pause the crawler by calling {@link AutoscaledPool.pause|`autoscaledPool.pause()`}
+     * or to abort it by calling {@link AutoscaledPool.abort|`autoscaledPool.abort()`}.
      */
     autoscaledPool?: AutoscaledPool;
 
     /**
-     * Default router instance that will be used if we don't specify any {@link requestHandler}.
-     * See {@link Router.addHandler} and {@link Router.addDefaultHandler.}
+     * Default router instance that will be used if we don't specify any {@link BasicCrawlerOptions.requestHandler|`requestHandler`}.
+     * See {@link Router.addHandler} and {@link Router.addDefaultHandler}.
      */
     readonly router: RouterHandler<Context> = Router.create<Context>();
 
@@ -538,7 +541,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     /**
      * Runs the crawler. Returns a promise that gets resolved once all the requests are processed.
      * We can use the `requests` parameter to enqueue the initial requests - it is a shortcut for
-     * running `crawler.addRequests()` before the `crawler.run()`.
+     * running {@link BasicCrawler.addRequests|`crawler.addRequests()`} before the {@link BasicCrawler.run|`crawler.run()`}.
      *
      * @param [requests] The requests to add
      * @param [options] Options for the request queue
@@ -1078,13 +1081,15 @@ export interface CrawlerAddRequestsResult {
     /**
      * A promise which will resolve with the rest of the requests that were added to the queue.
      *
+     * Alternatively, we can set {@link CrawlerAddRequestsOptions.waitForAllRequestsToBeAdded|`waitForAllRequestsToBeAdded`} to `true`
+     * in the {@link BasicCrawler.addRequests|`crawler.addRequests()`} options.
+     *
      * @example
      * ```ts
      * // Assuming `requests` is a list of requests.
      * const result = await crawler.addRequests(requests);
      *
-     * // If you want to wait for the rest of the requests to be added with a condition, you can do so:
-     * // Alternatively, consider setting `waitForAllRequestsToBeAdded` to `true` in the options for `addRequests`.
+     * // If we want to wait for the rest of the requests to be added to the queue:
      * await result.waitForAllRequestsToBeAdded;
      * ```
      */
@@ -1102,7 +1107,7 @@ interface HandlePropertyNameChangeData<New, Old> {
 
 /**
  * Creates new {@link Router} instance that works based on request labels.
- * This instance can then serve as a `requestHandler` of your {@link BasicCrawler}.
+ * This instance can then serve as a {@link BasicCrawlerOptions.requestHandler|`requestHandler`} of our {@link BasicCrawler}.
  * Defaults to the {@link BasicCrawlingContext}.
  *
  * > Serves as a shortcut for using `Router.create<BasicCrawlingContext>()`.

--- a/packages/basic-crawler/src/internals/constants.ts
+++ b/packages/basic-crawler/src/internals/constants.ts
@@ -1,5 +1,6 @@
 /**
- * Additional number of seconds used in CheerioCrawler and BrowserCrawler to set a reasonable
- * requestHandlerTimeoutSecs for BasicCrawler that would not impare functionality (not timeout before crawlers).
+ * Additional number of seconds used in {@link CheerioCrawler} and {@link BrowserCrawler} to set a reasonable
+ * {@link BasicCrawlerOptions.requestHandlerTimeoutSecs|`requestHandlerTimeoutSecs`} for {@link BasicCrawler}
+ * that would not impare functionality (not timeout before crawlers).
  */
 export const BASIC_CRAWLER_TIMEOUT_BUFFER_SECS = 10;

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -20,10 +20,10 @@ module.exports = {
                 'guides/session-management',
                 'guides/scaling-crawlers',
                 'guides/avoid-blocking',
+                'guides/got-scraping',
                 'guides/typescript-project',
                 'guides/docker-images',
                 'guides/apify-platform',
-                'guides/got-scraping',
             ],
         },
         {


### PR DESCRIPTION
- Went throught `got-scpraing` guide and fixed some typos, `you -> we`, etc. Also move it after `avoid blocking` in the side menu.
- Went through Basic Crawler API docs, fixed/updated some descriptions, added some links, etc.

Please check it out if you would have the internet (maybe even render the docs) - if it's all good - will do the rest tomorrow (or better to say today :/)